### PR TITLE
feat!: Migrate to Meta Processors

### DIFF
--- a/config/process.libsonnet
+++ b/config/process.libsonnet
@@ -1,12 +1,11 @@
 {
   base64(input, output, direction, 
-         alphabet='std', 
          condition_operator='', condition_inspectors=[]): {
     type: 'base64',
     settings: {
-      input_key: input, output_key: output,
-      options: { direction: direction, alphabet: alphabet },
+      options: { direction: direction },
       condition: { operator: condition_operator, inspectors: condition_inspectors},
+      input_key: input, output_key: output,
     },
   },
   capture(input, output, expression, 
@@ -14,61 +13,61 @@
           condition_operator='', condition_inspectors=[]): {
     type: 'capture',
     settings: {
-      input_key: input, output_key: output,
       options: { expression: expression, 'function': _function, count: count },
       condition: { operator: condition_operator, inspectors: condition_inspectors},
+      input_key: input, output_key: output,
     },
   },
   case(input, output, case, 
        condition_operator='', condition_inspectors=[]): {
     type: 'case',
     settings: {
-      input_key: input, output_key: output,
       options: { case: case },
       condition: { operator: condition_operator, inspectors: condition_inspectors},
+      input_key: input, output_key: output,
     },
   },
   concat(input, output, separator, 
          condition_operator='', condition_inspectors=[]): {
     type: 'concat',
     settings: {
-      input_key: input, output_key: output,
       options: { separator: separator },
       condition: { operator: condition_operator, inspectors: condition_inspectors},
+      input_key: input, output_key: output,
     },
   },
   convert(input, output, type, 
           condition_operator='', condition_inspectors=[]): {
     type: 'convert',
     settings: {
-      input_key: input, output_key: output,
       options: { type: type },
       condition: { operator: condition_operator, inspectors: condition_inspectors},
+      input_key: input, output_key: output,
     },
   },
   copy(input='', output='', 
        condition_operator='', condition_inspectors=[]): {
     type: 'copy',
     settings: {
-      input_key: input, output_key: output,
       condition: { operator: condition_operator, inspectors: condition_inspectors},
+      input_key: input, output_key: output,
     },
   },
   delete(input, 
          condition_operator='', condition_inspectors=[]): {
     type: 'delete',
     settings: {
-      input: input,
       condition: { operator: condition_operator, inspectors: condition_inspectors},
+      input: input,
     },
   },
   domain(input, output, _function, 
          condition_operator='', condition_inspectors=[]): {
     type: 'domain',
     settings: {
-      input_key: input, output_key: output,
       options: { 'function': _function },
       condition: { operator: condition_operator, inspectors: condition_inspectors},
+      input_key: input, output_key: output,
     },
   },
   drop(condition_operator='', condition_inspectors=[]): {
@@ -82,19 +81,17 @@
            condition_operator='', condition_inspectors=[]): {
     type: 'dynamodb',
     settings: {
-      input_key: input, output_key: output,
       options: { table: table, key_condition_expression: key_condition_expression, limit: limit, scan_index_forward: scan_index_forward },
       condition: { operator: condition_operator, inspectors: condition_inspectors},
+      input_key: input, output_key: output,
     },
   },
   expand(input, 
-         retain=[], 
          condition_operator='', condition_inspectors=[]): {
     type: 'expand',
     settings: {
-      input: input,
-      options: { retain: retain },
       condition: { operator: condition_operator, inspectors: condition_inspectors},
+      input: input,
     },
   },
   flatten(input, output, 
@@ -102,19 +99,19 @@
           condition_operator='', condition_inspectors=[]): {
     type: 'flatten',
     settings: {
-      input_key: input, output_key: output,
       options: { deep: deep },
       condition: { operator: condition_operator, inspectors: condition_inspectors},
+      input_key: input, output_key: output,
     },
   },
   group(input, output, 
-        options_keys=[], 
+        keys=[], 
         condition_operator='', condition_inspectors=[]): {
     type: 'group',
     settings: {
-      input_key: input, output_key: output,
-      options: { keys: options_keys },
+      options: { keys: keys },
       condition: { operator: condition_operator, inspectors: condition_inspectors},
+      input_key: input, output_key: output,
     },
   },
   gzip(direction, 
@@ -130,18 +127,18 @@
        condition_operator='', condition_inspectors=[]): {
     type: 'hash',
     settings: {
-      input_key: input, output_key: output,
       options: { algorithm: algorithm },
       condition: { operator: condition_operator, inspectors: condition_inspectors},
+      input_key: input, output_key: output,
     },
   },
   insert(output, value, 
          condition_operator='', condition_inspectors=[]): {
     type: 'insert',
     settings: {
-      output: output,
       options: { value: value },
       condition: { operator: condition_operator, inspectors: condition_inspectors},
+      output: output,
     },
   },
   lambda(input, output, _function, 
@@ -149,18 +146,18 @@
          condition_operator='', condition_inspectors=[]): {
     type: 'lambda',
     settings: {
-      input_key: input, output_key: output,
       options: { 'function': _function, error_on_failure: error_on_failure },
       condition: { operator: condition_operator, inspectors: condition_inspectors},
+      input_key: input, output_key: output,
     },
   },
   math(input, output, operation, 
        condition_operator='', condition_inspectors=[]): {
     type: 'math',
     settings: {
-      input_key: input, output_key: output,
       options: { operation: operation },
       condition: { operator: condition_operator, inspectors: condition_inspectors},
+      input_key: input, output_key: output,
     },
   },
   replace(input, output, old, new, 
@@ -168,9 +165,9 @@
           condition_operator='', condition_inspectors=[]): {
     type: 'replace',
     settings: {
-      input_key: input, output_key: output,
       options: { old: old, new: new, count: count },
       condition: { operator: condition_operator, inspectors: condition_inspectors},
+      input_key: input, output_key: output,
     },
   },
   time(input, output, input_format, 
@@ -178,9 +175,9 @@
        condition_operator='', condition_inspectors=[]): {
     type: 'time',
     settings: {
-      input_key: input, output_key: output,
       options: { input_format: input_format, input_location: input_location, output_format: output_format, output_location: output_location },
       condition: { operator: condition_operator, inspectors: condition_inspectors},
+      input_key: input, output_key: output,
     },
   },
 }

--- a/internal/base64/base64.go
+++ b/internal/base64/base64.go
@@ -1,0 +1,25 @@
+package base64
+
+import (
+	"encoding/base64"
+	"fmt"
+)
+
+// Decode is a convenience wrapper for base64 decoding bytes.
+func Decode(b []byte) ([]byte, error) {
+	decode := make([]byte, base64.StdEncoding.DecodedLen(len(b)))
+	n, err := base64.StdEncoding.Decode(decode, b)
+	if err != nil {
+		return nil, fmt.Errorf("decode: %v", err)
+	}
+
+	return decode[:n], nil
+}
+
+// Encode is a convenience wrapper for base64 encoding bytes.
+func Encode(b []byte) []byte {
+	encode := make([]byte, base64.StdEncoding.EncodedLen(len(b)))
+	base64.StdEncoding.Encode(encode, b)
+
+	return encode
+}

--- a/internal/base64/base64_test.go
+++ b/internal/base64/base64_test.go
@@ -1,0 +1,99 @@
+package base64
+
+import (
+	"bytes"
+	"testing"
+)
+
+var decodeTests = []struct {
+	name     string
+	test     []byte
+	expected []byte
+}{
+	{
+		name:     "foo",
+		test:     []byte(`Zm9v`),
+		expected: []byte(`foo`),
+	},
+	{
+		name:     "zlib",
+		test:     []byte(`eJwFwCENAAAAgLC22Pd3LAYCggFF`),
+		expected: []byte{120, 156, 5, 192, 33, 13, 0, 0, 0, 128, 176, 182, 216, 247, 119, 44, 6, 2, 130, 1, 69},
+	},
+}
+
+func TestBase64Decode(t *testing.T) {
+	for _, test := range decodeTests {
+		result, err := Decode(test.test)
+		if err != nil {
+			t.Logf("got error %v", err)
+			t.Fail()
+			return
+		}
+
+		if c := bytes.Compare(result, test.expected); c != 0 {
+			t.Logf("expected %s, got %s", test.expected, result)
+			t.Fail()
+		}
+	}
+}
+
+func benchmarkBase64Decode(b *testing.B, test []byte) {
+	for i := 0; i < b.N; i++ {
+		Decode(test)
+	}
+}
+
+func BenchmarkBase64Decode(b *testing.B) {
+	for _, test := range encodeTests {
+		b.Run(string(test.name),
+			func(b *testing.B) {
+				benchmarkBase64Decode(b, test.test)
+			},
+		)
+	}
+}
+
+var encodeTests = []struct {
+	name     string
+	test     []byte
+	expected []byte
+}{
+	{
+		name:     "foo",
+		test:     []byte(`foo`),
+		expected: []byte(`Zm9v`),
+	},
+	{
+		name:     "zlib",
+		test:     []byte{120, 156, 5, 192, 33, 13, 0, 0, 0, 128, 176, 182, 216, 247, 119, 44, 6, 2, 130, 1, 69},
+		expected: []byte(`eJwFwCENAAAAgLC22Pd3LAYCggFF`),
+	},
+}
+
+func TestBase64Encode(t *testing.T) {
+	for _, test := range encodeTests {
+		result := Encode(test.test)
+
+		if c := bytes.Compare(result, test.expected); c != 0 {
+			t.Logf("expected %s, got %s", test.expected, result)
+			t.Fail()
+		}
+	}
+}
+
+func benchmarkBase64Encode(b *testing.B, test []byte) {
+	for i := 0; i < b.N; i++ {
+		Encode(test)
+	}
+}
+
+func BenchmarkBase64Encode(b *testing.B) {
+	for _, test := range encodeTests {
+		b.Run(string(test.name),
+			func(b *testing.B) {
+				benchmarkBase64Encode(b, test.test)
+			},
+		)
+	}
+}

--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -1,9 +1,11 @@
 package json
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
 	"unicode/utf8"
 
 	"github.com/tidwall/gjson"
@@ -110,15 +112,23 @@ func Unmarshal(data []byte, v interface{}) error {
 	return json.Unmarshal(data, v)
 }
 
-// Valid wraps json.Valid and conditionally checks if bytes, strings, or Results are valid.
+// Valid conditionally checks if bytes, strings, or Results are valid JSON objects.
 func Valid(data interface{}) bool {
 	switch v := data.(type) {
 	case []byte:
+		if !bytes.HasPrefix(v, []byte(`{`)) {
+			return false
+		}
+
 		return json.Valid(v)
 	case string:
+		if !strings.HasPrefix(v, `{`) {
+			return false
+		}
+
 		return json.Valid([]byte(v))
 	case Result:
-		return json.Valid([]byte(v.String()))
+		return v.IsObject()
 	default:
 		return false
 	}

--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -4,10 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"unicode/utf8"
 
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 
+	"github.com/brexhq/substation/internal/base64"
 	"github.com/brexhq/substation/internal/errors"
 )
 
@@ -46,9 +48,30 @@ func Get(json []byte, key string) Result {
 	return gjson.GetBytes(json, key)
 }
 
-// Set wraps sjson.SetBytes.
+/*
+Set inserts values into JSON and operates under these conditions (in order):
+
+- If the value is valid JSON (bytes, string, or Result), then it is inserted using SetRaw to properly insert it as nested JSON; this avoids encoding that would otherwise create invalid JSON (e.g. `{\"hello\":\"world\"}`)
+
+-If the value is bytes, then it is converted to a base64 encoded string (this is the behavior of the standard library's encoding/json package)
+
+- If the value is Result, then it is converted to the underlying gjson Value
+
+- All other values are inserted as interfaces and are converted by SJSON to the proper format
+*/
 func Set(json []byte, key string, value interface{}) (tmp []byte, err error) {
+	if Valid(value) {
+		tmp, err = SetRaw(json, key, value)
+		return tmp, err
+	}
+
 	switch v := value.(type) {
+	case []byte:
+		if utf8.Valid(v) {
+			tmp, err = sjson.SetBytes(json, key, v)
+		} else {
+			tmp, err = sjson.SetBytes(json, key, base64.Encode(v))
+		}
 	case Result:
 		tmp, err = sjson.SetBytes(json, key, v.Value())
 	default:
@@ -62,7 +85,7 @@ func Set(json []byte, key string, value interface{}) (tmp []byte, err error) {
 	return tmp, nil
 }
 
-// SetRaw wraps sjson.SetRawBytes.
+// SetRaw wraps sjson.SetRawBytes and conditionally converts values to properly insert them as nested JSON.
 func SetRaw(json []byte, key string, value interface{}) (tmp []byte, err error) {
 	switch v := value.(type) {
 	case []byte:
@@ -87,9 +110,18 @@ func Unmarshal(data []byte, v interface{}) error {
 	return json.Unmarshal(data, v)
 }
 
-// Valid wraps json.Valid.
-func Valid(data []byte) bool {
-	return json.Valid(data)
+// Valid wraps json.Valid and conditionally checks if bytes, strings, or Results are valid.
+func Valid(data interface{}) bool {
+	switch v := data.(type) {
+	case []byte:
+		return json.Valid(v)
+	case string:
+		return json.Valid([]byte(v))
+	case Result:
+		return json.Valid([]byte(v.String()))
+	default:
+		return false
+	}
 }
 
 // DeepEquals performs a deep equals comparison between two byte arrays.

--- a/process/base64.go
+++ b/process/base64.go
@@ -2,22 +2,18 @@ package process
 
 import (
 	"context"
-	"encoding/base64"
+	"unicode/utf8"
+
 	"fmt"
 
 	"github.com/brexhq/substation/condition"
+	"github.com/brexhq/substation/internal/base64"
 	"github.com/brexhq/substation/internal/errors"
 	"github.com/brexhq/substation/internal/json"
 )
 
-// Base64InvalidSettings is returned when the Base64 processor is configured with invalid Input and Output settings.
-const Base64InvalidSettings = errors.Error("Base64InvalidSettings")
-
-// Base64InvalidDirection is returned when the Base64 processor is configured with an invalid direction setting.
-const Base64InvalidDirection = errors.Error("Base64InvalidDirection")
-
-// Base64InvalidAlphabet is returned when the Base64 processor is configured with an invalid alphabet setting.
-const Base64InvalidAlphabet = errors.Error("Base64InvalidAlphabet")
+// Base64JSONDecodedBinary is returned when the Base64 processor is configured to decode output to JSON, but the output contains binary data and cannot be written as valid JSON.
+const Base64JSONDecodedBinary = errors.Error("Base64JSONDecodedBinary")
 
 /*
 Base64Options contains custom options for the Base64 processor:
@@ -26,21 +22,15 @@ Base64Options contains custom options for the Base64 processor:
 		must be one of:
 			to: encode to base64
 			from: decode from base64
-	Alphabet:
-		the base64 alphabet to use, either std (https://www.rfc-editor.org/rfc/rfc4648.html#section-4) or url (https://www.rfc-editor.org/rfc/rfc4648.html#section-5)
-		defaults to std
 */
 type Base64Options struct {
 	Direction string `json:"direction"`
-	Alphabet  string `json:"alphabet"`
 }
 
 /*
 Base64 processes data by converting it to and from base64. The processor supports these patterns:
-	json:
+	JSON:
 	  	{"base64":"Zm9v"} >>> {"base64":"foo"}
-	json array:
-		{"base64":["Zm9v","YmFy"]} >>> {"base64":["foo","bar"]}
 	data:
 		Zm9v >>> foo
 
@@ -57,10 +47,10 @@ The processor uses this Jsonnet configuration:
 	}
 */
 type Base64 struct {
+	Options   Base64Options            `json:"options"`
 	Condition condition.OperatorConfig `json:"condition"`
 	InputKey  string                   `json:"input_key"`
 	OutputKey string                   `json:"output_key"`
-	Options   Base64Options            `json:"options"`
 }
 
 // Slice processes a slice of bytes with the Base64 processor. Conditions are optionally applied on the bytes to enable processing.
@@ -94,117 +84,51 @@ func (p Base64) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
 
 // Byte processes bytes with the Base64 processor.
 func (p Base64) Byte(ctx context.Context, data []byte) ([]byte, error) {
-	if p.Options.Alphabet == "" {
-		p.Options.Alphabet = "std"
+	// error early if required options are missing
+	if p.Options.Direction == "" {
+		return nil, fmt.Errorf("byter settings %+v: %v", p, ProcessorInvalidSettings)
 	}
 
-	// json processing
+	// JSON processing
 	if p.InputKey != "" && p.OutputKey != "" {
 		value := json.Get(data, p.InputKey)
+		tmp := []byte(value.String())
 
-		if !value.IsArray() {
-			tmp := []byte(value.String())
-			if p.Options.Direction == "from" {
-				result, err := p.from(tmp, p.Options.Alphabet)
-				if err != nil {
-					return nil, fmt.Errorf("byter settings %v: %v", p, err)
-				}
-				return json.Set(data, p.OutputKey, result)
-			} else if p.Options.Direction == "to" {
-				result, err := p.to(tmp, p.Options.Alphabet)
-				if err != nil {
-					return nil, fmt.Errorf("byter settings %v: %v", p, err)
-				}
-				return json.Set(data, p.OutputKey, result)
-			} else {
-				return nil, fmt.Errorf("byter settings %v: %v", p, Base64InvalidDirection)
+		switch p.Options.Direction {
+		case "from":
+			result, err := base64.Decode(tmp)
+			if err != nil {
+				return nil, fmt.Errorf("byter settings %v: %v", p, err)
 			}
-		}
 
-		// json array processing
-		var array []string
-		for _, v := range value.Array() {
-			tmp := []byte(v.String())
-			if p.Options.Direction == "from" {
-				result, err := p.from(tmp, p.Options.Alphabet)
-				if err != nil {
-					return nil, fmt.Errorf("byter settings %v: %v", p, err)
-				}
-				array = append(array, string(result))
-			} else if p.Options.Direction == "to" {
-				result, err := p.to(tmp, p.Options.Alphabet)
-				if err != nil {
-					return nil, fmt.Errorf("byter settings %v: %v", p, err)
-				}
-				array = append(array, string(result))
-			} else {
-				return nil, fmt.Errorf("byter settings %v: %v", p, Base64InvalidDirection)
+			if !utf8.Valid(result) {
+				return nil, fmt.Errorf("byter settings %v: %v", p, Base64JSONDecodedBinary)
 			}
-		}
 
-		return json.Set(data, p.OutputKey, array)
+			return json.Set(data, p.OutputKey, result)
+		case "to":
+			result := base64.Encode(tmp)
+			return json.Set(data, p.OutputKey, string(result))
+		default:
+			return nil, fmt.Errorf("byter settings %v: %v", p, ProcessorInvalidDirection)
+		}
 	}
 
 	// data processing
 	if p.InputKey == "" && p.OutputKey == "" {
-		if p.Options.Direction == "from" {
-			result, err := p.from(data, p.Options.Alphabet)
+		switch p.Options.Direction {
+		case "from":
+			result, err := base64.Decode(data)
 			if err != nil {
 				return nil, fmt.Errorf("byter settings %v: %v", p, err)
 			}
 			return result, nil
-		} else if p.Options.Direction == "to" {
-			result, err := p.to(data, p.Options.Alphabet)
-			if err != nil {
-				return nil, fmt.Errorf("byter settings %v: %v", p, err)
-			}
-			return result, nil
-		} else {
-			return nil, fmt.Errorf("byter settings %v: %v", p, Base64InvalidDirection)
+		case "to":
+			return base64.Encode(data), nil
+		default:
+			return nil, fmt.Errorf("byter settings %v: %v", p, ProcessorInvalidDirection)
 		}
 	}
 
-	return nil, fmt.Errorf("byter settings %v: %v", p, Base64InvalidSettings)
-}
-
-func (p Base64) from(data []byte, alphabet string) ([]byte, error) {
-	len := len(string(data))
-
-	switch s := alphabet; s {
-	case "std":
-		res := make([]byte, base64.StdEncoding.DecodedLen(len))
-		n, err := base64.StdEncoding.Decode(res, data)
-		if err != nil {
-			return nil, fmt.Errorf("base64 decode alphabet %s: %v", alphabet, err)
-		}
-
-		return res[:n], nil
-	case "url":
-		res := make([]byte, base64.URLEncoding.DecodedLen(len))
-		n, err := base64.URLEncoding.Decode(res, data)
-		if err != nil {
-			return nil, fmt.Errorf("base64 decode alphabet %s: %v", alphabet, err)
-		}
-
-		return res[:n], nil
-	default:
-		return nil, fmt.Errorf("base64 decode alphabet %s: %v", alphabet, Base64InvalidAlphabet)
-	}
-}
-
-func (p Base64) to(data []byte, alphabet string) ([]byte, error) {
-	len := len(data)
-
-	switch s := alphabet; s {
-	case "std":
-		res := make([]byte, base64.StdEncoding.EncodedLen(len))
-		base64.StdEncoding.Encode(res, data)
-		return res, nil
-	case "url":
-		res := make([]byte, base64.URLEncoding.EncodedLen(len))
-		base64.URLEncoding.Encode(res, data)
-		return res, nil
-	default:
-		return nil, fmt.Errorf("base64 encode alphabet %s: %v", alphabet, Base64InvalidAlphabet)
-	}
+	return nil, fmt.Errorf("byter settings %v: %v", p, ProcessorInvalidSettings)
 }

--- a/process/base64_test.go
+++ b/process/base64_test.go
@@ -21,8 +21,8 @@ var base64Tests = []struct {
 				Direction: "from",
 			},
 		},
-		[]byte(`YWJjMTIzIT8kKiYoKSctPUB+`),
-		[]byte(`abc123!?$*&()'-=@~`),
+		[]byte(`YmFy`),
+		[]byte(`bar`),
 		nil,
 	},
 	{
@@ -32,8 +32,8 @@ var base64Tests = []struct {
 				Direction: "to",
 			},
 		},
-		[]byte(`abc123!?$*&()'-=@~`),
-		[]byte(`YWJjMTIzIT8kKiYoKSctPUB+`),
+		[]byte(`bar`),
+		[]byte(`YmFy`),
 		nil,
 	},
 	{
@@ -42,11 +42,11 @@ var base64Tests = []struct {
 			Options: Base64Options{
 				Direction: "from",
 			},
-			InputKey:  "base64",
-			OutputKey: "base64",
+			InputKey:  "foo",
+			OutputKey: "foo",
 		},
-		[]byte(`{"base64":"YWJjMTIzIT8kKiYoKSctPUB+"}`),
-		[]byte(`{"base64":"abc123!?$*&()'-=@~"}`),
+		[]byte(`{"foo":"YmFy"}`),
+		[]byte(`{"foo":"bar"}`),
 		nil,
 	},
 	{
@@ -62,12 +62,12 @@ var base64Tests = []struct {
 			Options: Base64Options{
 				Direction: "foo",
 			},
-			InputKey:  "base64",
-			OutputKey: "base64",
+			InputKey:  "foo",
+			OutputKey: "foo",
 		},
-		[]byte(`{"base64":"H4sIAMSJy2IA/wXAIQ0AAACAsLbY93csBiFlc4wDAAAA"}`),
+		[]byte(`{"foo":"YmFy"}`),
 		[]byte(``),
-		ProcessorInvalidDirection,
+		ProcessorInvalidSettings,
 	},
 	{
 		"JSON binary",
@@ -75,10 +75,10 @@ var base64Tests = []struct {
 			Options: Base64Options{
 				Direction: "from",
 			},
-			InputKey:  "base64",
-			OutputKey: "base64",
+			InputKey:  "foo",
+			OutputKey: "foo",
 		},
-		[]byte(`{"base64":"H4sIAMSJy2IA/wXAIQ0AAACAsLbY93csBiFlc4wDAAAA"}`),
+		[]byte(`{"foo":"eJwFwDENAAAAwjCtTAL+j6YdAl0BNg=="}`),
 		[]byte(``),
 		Base64JSONDecodedBinary,
 	},
@@ -88,7 +88,7 @@ func TestBase64(t *testing.T) {
 	ctx := context.TODO()
 	for _, test := range base64Tests {
 		res, err := test.proc.Byte(ctx, test.test)
-		if err != nil && errors.As(err, &test.err) {
+		if err != nil && errors.Is(err, test.err) {
 			continue
 		} else if err != nil {
 			t.Log(err)

--- a/process/base64_test.go
+++ b/process/base64_test.go
@@ -3,6 +3,7 @@ package process
 import (
 	"bytes"
 	"context"
+	"errors"
 	"testing"
 )
 
@@ -11,82 +12,75 @@ var base64Tests = []struct {
 	proc     Base64
 	test     []byte
 	expected []byte
+	err      error
 }{
-	// decode std base64
 	{
-		"decode data std",
+		"data decode",
 		Base64{
 			Options: Base64Options{
 				Direction: "from",
-				Alphabet:  "std",
 			},
 		},
 		[]byte(`YWJjMTIzIT8kKiYoKSctPUB+`),
 		[]byte(`abc123!?$*&()'-=@~`),
+		nil,
 	},
-	// decode url base64
 	{
-		"decode data url",
-		Base64{
-			Options: Base64Options{
-				Direction: "from",
-				Alphabet:  "url",
-			},
-		},
-		[]byte(`YWJjMTIzIT8kKiYoKSctPUB-`),
-		[]byte(`abc123!?$*&()'-=@~`),
-	},
-	// encode std base64
-	{
-		"encode data std",
+		"data encode",
 		Base64{
 			Options: Base64Options{
 				Direction: "to",
-				Alphabet:  "std",
 			},
 		},
 		[]byte(`abc123!?$*&()'-=@~`),
 		[]byte(`YWJjMTIzIT8kKiYoKSctPUB+`),
+		nil,
 	},
-	// encode url base64
 	{
-		"encode data url",
+		"JSON decode",
 		Base64{
 			Options: Base64Options{
-				Direction: "to",
-				Alphabet:  "url",
+				Direction: "from",
 			},
-		},
-		[]byte(`abc123!?$*&()'-=@~`),
-		[]byte(`YWJjMTIzIT8kKiYoKSctPUB-`),
-	},
-	// decode std base64 from input to output
-	{
-		"json std",
-		Base64{
 			InputKey:  "base64",
 			OutputKey: "base64",
-			Options: Base64Options{
-				Direction: "from",
-				Alphabet:  "std",
-			},
 		},
 		[]byte(`{"base64":"YWJjMTIzIT8kKiYoKSctPUB+"}`),
 		[]byte(`{"base64":"abc123!?$*&()'-=@~"}`),
+		nil,
 	},
-	// decode array of std base64 from input to output
 	{
-		"json array std",
+		"invalid settings",
+		Base64{},
+		[]byte{},
+		[]byte{},
+		ProcessorInvalidSettings,
+	},
+	{
+		"invalid direction",
 		Base64{
+			Options: Base64Options{
+				Direction: "foo",
+			},
 			InputKey:  "base64",
 			OutputKey: "base64",
+		},
+		[]byte(`{"base64":"H4sIAMSJy2IA/wXAIQ0AAACAsLbY93csBiFlc4wDAAAA"}`),
+		[]byte(``),
+		ProcessorInvalidDirection,
+	},
+	{
+		"JSON binary",
+		Base64{
 			Options: Base64Options{
 				Direction: "from",
-				Alphabet:  "std",
 			},
+			InputKey:  "base64",
+			OutputKey: "base64",
 		},
-		[]byte(`{"base64":["aGVsbG8=","d29ybGQ="]}`),
-		[]byte(`{"base64":["hello","world"]}`),
+		[]byte(`{"base64":"H4sIAMSJy2IA/wXAIQ0AAACAsLbY93csBiFlc4wDAAAA"}`),
+		[]byte(``),
+		Base64JSONDecodedBinary,
 	},
 }
 
@@ -94,8 +88,10 @@ func TestBase64(t *testing.T) {
 	ctx := context.TODO()
 	for _, test := range base64Tests {
 		res, err := test.proc.Byte(ctx, test.test)
-		if err != nil {
-			t.Logf("%v", err)
+		if err != nil && errors.As(err, &test.err) {
+			continue
+		} else if err != nil {
+			t.Log(err)
 			t.Fail()
 		}
 

--- a/process/capture_test.go
+++ b/process/capture_test.go
@@ -15,32 +15,32 @@ var captureTests = []struct {
 	err      error
 }{
 	{
-		"json find",
+		"JSON find",
 		Capture{
-			InputKey:  "capture",
-			OutputKey: "capture",
 			Options: CaptureOptions{
 				Expression: "^([^@]*)@.*$",
 				Function:   "find",
 			},
+			InputKey:  "foo",
+			OutputKey: "foo",
 		},
-		[]byte(`{"capture":"foo@qux.com"}`),
-		[]byte(`{"capture":"foo"}`),
+		[]byte(`{"foo":"bar@qux.corge"}`),
+		[]byte(`{"foo":"bar"}`),
 		nil,
 	},
 	{
-		"json find_all",
+		"JSON find_all",
 		Capture{
-			InputKey:  "capture",
-			OutputKey: "capture",
 			Options: CaptureOptions{
 				Expression: "(.{1})",
 				Function:   "find_all",
 				Count:      3,
 			},
+			InputKey:  "foo",
+			OutputKey: "foo",
 		},
-		[]byte(`{"capture":"foo"}`),
-		[]byte(`{"capture":["f","o","o"]}`),
+		[]byte(`{"foo":"bar"}`),
+		[]byte(`{"foo":["b","a","r"]}`),
 		nil,
 	},
 	{
@@ -51,12 +51,12 @@ var captureTests = []struct {
 				Function:   "find",
 			},
 		},
-		[]byte(`foo@qux.com`),
-		[]byte(`foo`),
+		[]byte(`bar@qux.corge`),
+		[]byte(`bar`),
 		nil,
 	},
 	{
-		"data",
+		"named_group",
 		Capture{
 			Options: CaptureOptions{
 				Function:   "named_group",
@@ -77,10 +77,10 @@ var captureTests = []struct {
 }
 
 func TestCapture(t *testing.T) {
+	ctx := context.TODO()
 	for _, test := range captureTests {
-		ctx := context.TODO()
 		res, err := test.proc.Byte(ctx, test.test)
-		if err != nil && errors.As(err, &test.err) {
+		if err != nil && errors.Is(err, test.err) {
 			continue
 		} else if err != nil {
 			t.Log(err)

--- a/process/case.go
+++ b/process/case.go
@@ -36,34 +36,33 @@ The processor uses this Jsonnet configuration:
 	{
 		type: 'case',
 		settings: {
-			// if the value is "foo", then this returns "FOO"
-			input_key: 'case',
-			output_key: 'case',
 			options: {
 				case: 'upper',
-			}
+			},
+			input_key: 'case',
+			output_key: 'case',
 		},
 	}
 */
 type Case struct {
+	Options   CaseOptions              `json:"options"`
 	Condition condition.OperatorConfig `json:"condition"`
 	InputKey  string                   `json:"input_key"`
 	OutputKey string                   `json:"output_key"`
-	Options   CaseOptions              `json:"options"`
 }
 
 // Slice processes a slice of bytes with the Case processor. Conditions are optionally applied on the bytes to enable processing.
 func (p Case) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
 	op, err := condition.OperatorFactory(p.Condition)
 	if err != nil {
-		return nil, fmt.Errorf("slicer settings %v: %v", p, err)
+		return nil, fmt.Errorf("slicer settings %+v: %w", p, err)
 	}
 
 	slice := NewSlice(&s)
 	for _, data := range s {
 		ok, err := op.Operate(data)
 		if err != nil {
-			return nil, fmt.Errorf("slicer settings %v: %v", p, err)
+			return nil, fmt.Errorf("slicer settings %+v: %w", p, err)
 		}
 
 		if !ok {
@@ -85,44 +84,31 @@ func (p Case) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
 func (p Case) Byte(ctx context.Context, data []byte) ([]byte, error) {
 	// error early if required options are missing
 	if p.Options.Case == "" {
-		return nil, fmt.Errorf("byter settings %+v: %v", p, ProcessorInvalidSettings)
+		return nil, fmt.Errorf("byter settings %+v: %w", p, ProcessorInvalidSettings)
 	}
 
 	// JSON processing
 	if p.InputKey != "" && p.OutputKey != "" {
-		value := json.Get(data, p.InputKey)
-		s := p.stringsCase(value.String())
-		return json.Set(data, p.OutputKey, s)
+		value := json.Get(data, p.InputKey).String()
+		switch p.Options.Case {
+		case "upper":
+			return json.Set(data, p.OutputKey, strings.ToUpper(value))
+		case "lower":
+			return json.Set(data, p.OutputKey, strings.ToLower(value))
+		case "snake":
+			return json.Set(data, p.OutputKey, strcase.ToSnake(value))
+		}
 	}
 
 	// data processing
 	if p.InputKey == "" && p.OutputKey == "" {
-		return p.bytesCase(data), nil
+		switch p.Options.Case {
+		case "upper":
+			return bytes.ToUpper(data), nil
+		case "lower":
+			return bytes.ToLower(data), nil
+		}
 	}
 
-	return nil, fmt.Errorf("byter settings %v: %v", p, ProcessorInvalidSettings)
-}
-
-func (p Case) stringsCase(s string) string {
-	switch t := p.Options.Case; t {
-	case "upper":
-		return strings.ToUpper(s)
-	case "lower":
-		return strings.ToLower(s)
-	case "snake":
-		return strcase.ToSnake(s)
-	default:
-		return ""
-	}
-}
-
-func (p Case) bytesCase(b []byte) []byte {
-	switch t := p.Options.Case; t {
-	case "upper":
-		return bytes.ToUpper(b)
-	case "lower":
-		return bytes.ToLower(b)
-	default:
-		return nil
-	}
+	return nil, fmt.Errorf("byter settings %+v: %w", p, ProcessorInvalidSettings)
 }

--- a/process/case_test.go
+++ b/process/case_test.go
@@ -17,40 +17,40 @@ var caseTests = []struct {
 	{
 		"JSON lower",
 		Case{
-			InputKey:  "case",
-			OutputKey: "case",
 			Options: CaseOptions{
 				Case: "lower",
 			},
+			InputKey:  "foo",
+			OutputKey: "foo",
 		},
-		[]byte(`{"case":"ABC"}`),
-		[]byte(`{"case":"abc"}`),
+		[]byte(`{"foo":"BAR"}`),
+		[]byte(`{"foo":"bar"}`),
 		nil,
 	},
 	{
 		"JSON upper",
 		Case{
-			InputKey:  "case",
-			OutputKey: "case",
 			Options: CaseOptions{
 				Case: "upper",
 			},
+			InputKey:  "foo",
+			OutputKey: "foo",
 		},
-		[]byte(`{"case":"abc"}`),
-		[]byte(`{"case":"ABC"}`),
+		[]byte(`{"foo":"bar"}`),
+		[]byte(`{"foo":"BAR"}`),
 		nil,
 	},
 	{
 		"JSON snake",
 		Case{
-			InputKey:  "case",
-			OutputKey: "case",
+			InputKey:  "foo",
+			OutputKey: "foo",
 			Options: CaseOptions{
 				Case: "snake",
 			},
 		},
-		[]byte(`{"case":"AbC"})`),
-		[]byte(`{"case":"ab_c"})`),
+		[]byte(`{"foo":"AbC"})`),
+		[]byte(`{"foo":"ab_c"})`),
 		nil,
 	},
 	{
@@ -63,10 +63,10 @@ var caseTests = []struct {
 }
 
 func TestCase(t *testing.T) {
+	ctx := context.TODO()
 	for _, test := range caseTests {
-		ctx := context.TODO()
 		res, err := test.proc.Byte(ctx, test.test)
-		if err != nil && errors.As(err, &test.err) {
+		if err != nil && errors.Is(err, test.err) {
 			continue
 		} else if err != nil {
 			t.Log(err)

--- a/process/concat.go
+++ b/process/concat.go
@@ -26,11 +26,11 @@ The processor uses this Jsonnet configuration:
 	{
 		type: 'concat',
 		settings: {
-			input_key: 'concat',
-			output_key: 'concat',
 			options: {
 				separator: '.',
-			}
+			},
+			input_key: 'concat',
+			output_key: 'concat',
 		},
 	}
 */
@@ -45,14 +45,14 @@ type Concat struct {
 func (p Concat) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
 	op, err := condition.OperatorFactory(p.Condition)
 	if err != nil {
-		return nil, fmt.Errorf("slicer settings %v: %v", p, err)
+		return nil, fmt.Errorf("slicer settings %+v: %w", p, err)
 	}
 
 	slice := NewSlice(&s)
 	for _, data := range s {
 		ok, err := op.Operate(data)
 		if err != nil {
-			return nil, fmt.Errorf("slicer settings %v: %v", p, err)
+			return nil, fmt.Errorf("slicer settings %+v: %w", p, err)
 		}
 
 		if !ok {
@@ -74,12 +74,12 @@ func (p Concat) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
 func (p Concat) Byte(ctx context.Context, data []byte) ([]byte, error) {
 	// error early if required options are missing
 	if p.Options.Separator == "" {
-		return nil, fmt.Errorf("byter settings %+v: %v", p, ProcessorInvalidSettings)
+		return nil, fmt.Errorf("byter settings %+v: %w", p, ProcessorInvalidSettings)
 	}
 
 	// only supports JSON, error early if there are no keys
 	if p.InputKey == "" && p.OutputKey == "" {
-		return nil, fmt.Errorf("byter settings %v: %v", p, ProcessorInvalidSettings)
+		return nil, fmt.Errorf("byter settings %+v: %w", p, ProcessorInvalidSettings)
 	}
 
 	// data is processed by retrieving and iterating the

--- a/process/concat_test.go
+++ b/process/concat_test.go
@@ -15,16 +15,16 @@ var concatTests = []struct {
 	err      error
 }{
 	{
-		"concat",
+		"JSON",
 		Concat{
-			InputKey:  "concat",
-			OutputKey: "concat",
 			Options: ConcatOptions{
 				Separator: ".",
 			},
+			InputKey:  "foo",
+			OutputKey: "foo",
 		},
-		[]byte(`{"concat":["foo","bar"]}`),
-		[]byte(`{"concat":"foo.bar"}`),
+		[]byte(`{"foo":["bar","baz"]}`),
+		[]byte(`{"foo":"bar.baz"}`),
 		nil,
 	},
 	{
@@ -37,10 +37,10 @@ var concatTests = []struct {
 }
 
 func TestConcat(t *testing.T) {
+	ctx := context.TODO()
 	for _, test := range concatTests {
-		ctx := context.TODO()
 		res, err := test.proc.Byte(ctx, test.test)
-		if err != nil && errors.As(err, &test.err) {
+		if err != nil && errors.Is(err, test.err) {
 			continue
 		} else if err != nil {
 			t.Log(err)

--- a/process/convert.go
+++ b/process/convert.go
@@ -34,11 +34,11 @@ The processor uses this Jsonnet configuration:
 	{
 		type: 'convert',
 		settings: {
-			input_key: 'convert',
-			output_key: 'convert',
 			options: {
 				type: 'bool',
-			}
+			},
+			input_key: 'convert',
+			output_key: 'convert',
 		},
 	}
 */
@@ -53,14 +53,14 @@ type Convert struct {
 func (p Convert) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
 	op, err := condition.OperatorFactory(p.Condition)
 	if err != nil {
-		return nil, fmt.Errorf("slicer settings %v: %v", p, err)
+		return nil, fmt.Errorf("slicer settings %+v: %w", p, err)
 	}
 
 	slice := NewSlice(&s)
 	for _, data := range s {
 		ok, err := op.Operate(data)
 		if err != nil {
-			return nil, fmt.Errorf("slicer settings %v: %v", p, err)
+			return nil, fmt.Errorf("slicer settings %+v: %w", p, err)
 		}
 
 		if !ok {
@@ -82,7 +82,7 @@ func (p Convert) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
 func (p Convert) Byte(ctx context.Context, data []byte) ([]byte, error) {
 	// error early if required options are missing
 	if p.Options.Type == "" {
-		return nil, fmt.Errorf("byter settings %+v: %v", p, ProcessorInvalidSettings)
+		return nil, fmt.Errorf("byter settings %+v: %w", p, ProcessorInvalidSettings)
 	}
 
 	// only supports JSON, error early if there are no keys
@@ -102,5 +102,5 @@ func (p Convert) Byte(ctx context.Context, data []byte) ([]byte, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("byter settings %v: %v", p, ProcessorInvalidSettings)
+	return nil, fmt.Errorf("byter settings %+v: %w", p, ProcessorInvalidSettings)
 }

--- a/process/convert_test.go
+++ b/process/convert_test.go
@@ -3,6 +3,7 @@ package process
 import (
 	"bytes"
 	"context"
+	"errors"
 	"testing"
 )
 
@@ -11,10 +12,10 @@ var convertTests = []struct {
 	proc     Convert
 	test     []byte
 	expected []byte
+	err      error
 }{
-	// strings
 	{
-		"json bool",
+		"bool true",
 		Convert{
 			InputKey:  "convert",
 			OutputKey: "convert",
@@ -24,9 +25,10 @@ var convertTests = []struct {
 		},
 		[]byte(`{"convert":"true"}`),
 		[]byte(`{"convert":true}`),
+		nil,
 	},
 	{
-		"json bool",
+		"bool false",
 		Convert{
 			InputKey:  "convert",
 			OutputKey: "convert",
@@ -36,9 +38,10 @@ var convertTests = []struct {
 		},
 		[]byte(`{"convert":"false"}`),
 		[]byte(`{"convert":false}`),
+		nil,
 	},
 	{
-		"json int",
+		"int",
 		Convert{
 			InputKey:  "convert",
 			OutputKey: "convert",
@@ -48,9 +51,10 @@ var convertTests = []struct {
 		},
 		[]byte(`{"convert":"-123"}`),
 		[]byte(`{"convert":-123}`),
+		nil,
 	},
 	{
-		"json float",
+		"float",
 		Convert{
 			InputKey:  "convert",
 			OutputKey: "convert",
@@ -60,9 +64,10 @@ var convertTests = []struct {
 		},
 		[]byte(`{"convert":"123.456"}`),
 		[]byte(`{"convert":123.456}`),
+		nil,
 	},
 	{
-		"json uint",
+		"uint",
 		Convert{
 			InputKey:  "convert",
 			OutputKey: "convert",
@@ -72,9 +77,10 @@ var convertTests = []struct {
 		},
 		[]byte(`{"convert":"123"}`),
 		[]byte(`{"convert":123}`),
+		nil,
 	},
 	{
-		"json string",
+		"string",
 		Convert{
 			InputKey:  "convert",
 			OutputKey: "convert",
@@ -84,9 +90,10 @@ var convertTests = []struct {
 		},
 		[]byte(`{"convert":123}`),
 		[]byte(`{"convert":"123"}`),
+		nil,
 	},
 	{
-		"json int",
+		"int",
 		Convert{
 			InputKey:  "convert",
 			OutputKey: "convert",
@@ -96,79 +103,7 @@ var convertTests = []struct {
 		},
 		[]byte(`{"convert":123.456}`),
 		[]byte(`{"convert":123}`),
-	},
-	// array support
-	{
-		"json array bool",
-		Convert{
-			InputKey:  "convert",
-			OutputKey: "convert",
-			Options: ConvertOptions{
-				Type: "bool",
-			},
-		},
-		[]byte(`{"convert":["true","false"]}`),
-		[]byte(`{"convert":[true,false]}`),
-	},
-	{
-		"json array int",
-		Convert{
-			InputKey:  "convert",
-			OutputKey: "convert",
-			Options: ConvertOptions{
-				Type: "int",
-			},
-		},
-		[]byte(`{"convert":["-123","-456"]}`),
-		[]byte(`{"convert":[-123,-456]}`),
-	},
-	{
-		"json array float",
-		Convert{
-			InputKey:  "convert",
-			OutputKey: "convert",
-			Options: ConvertOptions{
-				Type: "float",
-			},
-		},
-		[]byte(`{"convert":["-123.456","123.456"]}`),
-		[]byte(`{"convert":[-123.456,123.456]}`),
-	},
-	{
-		"json array uint",
-		Convert{
-			InputKey:  "convert",
-			OutputKey: "convert",
-			Options: ConvertOptions{
-				Type: "uint",
-			},
-		},
-		[]byte(`{"convert":["123","456"]}`),
-		[]byte(`{"convert":[123,456]}`),
-	},
-	{
-		"json array string",
-		Convert{
-			InputKey:  "convert",
-			OutputKey: "convert",
-			Options: ConvertOptions{
-				Type: "string",
-			},
-		},
-		[]byte(`{"convert":[123,123.456]}`),
-		[]byte(`{"convert":["123","123.456"]}`),
-	},
-	{
-		"json array int",
-		Convert{
-			InputKey:  "convert",
-			OutputKey: "convert",
-			Options: ConvertOptions{
-				Type: "int",
-			},
-		},
-		[]byte(`{"convert":[123.456,1.2]}`),
-		[]byte(`{"convert":[123,1]}`),
+		nil,
 	},
 }
 
@@ -176,8 +111,10 @@ func TestConvert(t *testing.T) {
 	for _, test := range convertTests {
 		ctx := context.TODO()
 		res, err := test.proc.Byte(ctx, test.test)
-		if err != nil {
-			t.Logf("%v", err)
+		if err != nil && errors.As(err, &test.err) {
+			continue
+		} else if err != nil {
+			t.Log(err)
 			t.Fail()
 		}
 

--- a/process/convert_test.go
+++ b/process/convert_test.go
@@ -17,101 +17,101 @@ var convertTests = []struct {
 	{
 		"bool true",
 		Convert{
-			InputKey:  "convert",
-			OutputKey: "convert",
 			Options: ConvertOptions{
 				Type: "bool",
 			},
+			InputKey:  "foo",
+			OutputKey: "foo",
 		},
-		[]byte(`{"convert":"true"}`),
-		[]byte(`{"convert":true}`),
+		[]byte(`{"foo":"true"}`),
+		[]byte(`{"foo":true}`),
 		nil,
 	},
 	{
 		"bool false",
 		Convert{
-			InputKey:  "convert",
-			OutputKey: "convert",
 			Options: ConvertOptions{
 				Type: "bool",
 			},
+			InputKey:  "foo",
+			OutputKey: "foo",
 		},
-		[]byte(`{"convert":"false"}`),
-		[]byte(`{"convert":false}`),
+		[]byte(`{"foo":"false"}`),
+		[]byte(`{"foo":false}`),
 		nil,
 	},
 	{
 		"int",
 		Convert{
-			InputKey:  "convert",
-			OutputKey: "convert",
 			Options: ConvertOptions{
 				Type: "int",
 			},
+			InputKey:  "foo",
+			OutputKey: "foo",
 		},
-		[]byte(`{"convert":"-123"}`),
-		[]byte(`{"convert":-123}`),
+		[]byte(`{"foo":"-123"}`),
+		[]byte(`{"foo":-123}`),
 		nil,
 	},
 	{
 		"float",
 		Convert{
-			InputKey:  "convert",
-			OutputKey: "convert",
 			Options: ConvertOptions{
 				Type: "float",
 			},
+			InputKey:  "foo",
+			OutputKey: "foo",
 		},
-		[]byte(`{"convert":"123.456"}`),
-		[]byte(`{"convert":123.456}`),
+		[]byte(`{"foo":"123.456"}`),
+		[]byte(`{"foo":123.456}`),
 		nil,
 	},
 	{
 		"uint",
 		Convert{
-			InputKey:  "convert",
-			OutputKey: "convert",
 			Options: ConvertOptions{
 				Type: "uint",
 			},
+			InputKey:  "foo",
+			OutputKey: "foo",
 		},
-		[]byte(`{"convert":"123"}`),
-		[]byte(`{"convert":123}`),
+		[]byte(`{"foo":"123"}`),
+		[]byte(`{"foo":123}`),
 		nil,
 	},
 	{
 		"string",
 		Convert{
-			InputKey:  "convert",
-			OutputKey: "convert",
 			Options: ConvertOptions{
 				Type: "string",
 			},
+			InputKey:  "foo",
+			OutputKey: "foo",
 		},
-		[]byte(`{"convert":123}`),
-		[]byte(`{"convert":"123"}`),
+		[]byte(`{"foo":123}`),
+		[]byte(`{"foo":"123"}`),
 		nil,
 	},
 	{
 		"int",
 		Convert{
-			InputKey:  "convert",
-			OutputKey: "convert",
 			Options: ConvertOptions{
 				Type: "int",
 			},
+			InputKey:  "foo",
+			OutputKey: "foo",
 		},
-		[]byte(`{"convert":123.456}`),
-		[]byte(`{"convert":123}`),
+		[]byte(`{"foo":123.456}`),
+		[]byte(`{"foo":123}`),
 		nil,
 	},
 }
 
 func TestConvert(t *testing.T) {
+	ctx := context.TODO()
 	for _, test := range convertTests {
-		ctx := context.TODO()
 		res, err := test.proc.Byte(ctx, test.test)
-		if err != nil && errors.As(err, &test.err) {
+		if err != nil && errors.Is(err, test.err) {
 			continue
 		} else if err != nil {
 			t.Log(err)

--- a/process/copy_test.go
+++ b/process/copy_test.go
@@ -3,6 +3,7 @@ package process
 import (
 	"bytes"
 	"context"
+	"errors"
 	"testing"
 )
 
@@ -11,6 +12,7 @@ var copyTests = []struct {
 	proc     Copy
 	test     []byte
 	expected []byte
+	err      error
 }{
 	{
 		"JSON",
@@ -20,6 +22,7 @@ var copyTests = []struct {
 		},
 		[]byte(`{"original":"foo"}`),
 		[]byte(`{"original":"foo","copy":"foo"}`),
+		nil,
 	},
 	{
 		"from JSON",
@@ -28,6 +31,7 @@ var copyTests = []struct {
 		},
 		[]byte(`{"copy":"foo"}`),
 		[]byte(`foo`),
+		nil,
 	},
 	{
 		"to JSON utf8",
@@ -36,6 +40,7 @@ var copyTests = []struct {
 		},
 		[]byte(`foo`),
 		[]byte(`{"copy":"foo"}`),
+		nil,
 	},
 	{
 		"to JSON zlib",
@@ -44,6 +49,7 @@ var copyTests = []struct {
 		},
 		[]byte{120, 156, 5, 192, 33, 13, 0, 0, 0, 128, 176, 182, 216, 247, 119, 44, 6, 2, 130, 1, 69},
 		[]byte(`{"copy":"eJwFwCENAAAAgLC22Pd3LAYCggFF"}`),
+		nil,
 	},
 }
 
@@ -51,8 +57,10 @@ func TestCopy(t *testing.T) {
 	ctx := context.TODO()
 	for _, test := range copyTests {
 		res, err := test.proc.Byte(ctx, test.test)
-		if err != nil {
-			t.Logf("%v", err)
+		if err != nil && errors.As(err, &test.err) {
+			continue
+		} else if err != nil {
+			t.Log(err)
 			t.Fail()
 		}
 

--- a/process/copy_test.go
+++ b/process/copy_test.go
@@ -13,35 +13,43 @@ var copyTests = []struct {
 	expected []byte
 }{
 	{
-		"json",
+		"JSON",
 		Copy{
 			InputKey:  "original",
 			OutputKey: "copy",
 		},
-		[]byte(`{"original":"hello"}`),
-		[]byte(`{"original":"hello","copy":"hello"}`),
+		[]byte(`{"original":"foo"}`),
+		[]byte(`{"original":"foo","copy":"foo"}`),
 	},
 	{
-		"from json",
+		"from JSON",
 		Copy{
 			InputKey: "copy",
 		},
-		[]byte(`{"copy":"hello"}`),
-		[]byte(`hello`),
+		[]byte(`{"copy":"foo"}`),
+		[]byte(`foo`),
 	},
 	{
-		"to json",
+		"to JSON utf8",
 		Copy{
 			OutputKey: "copy",
 		},
-		[]byte(`hello`),
-		[]byte(`{"copy":"hello"}`),
+		[]byte(`foo`),
+		[]byte(`{"copy":"foo"}`),
+	},
+	{
+		"to JSON zlib",
+		Copy{
+			OutputKey: "copy",
+		},
+		[]byte{120, 156, 5, 192, 33, 13, 0, 0, 0, 128, 176, 182, 216, 247, 119, 44, 6, 2, 130, 1, 69},
+		[]byte(`{"copy":"eJwFwCENAAAAgLC22Pd3LAYCggFF"}`),
 	},
 }
 
 func TestCopy(t *testing.T) {
+	ctx := context.TODO()
 	for _, test := range copyTests {
-		ctx := context.TODO()
 		res, err := test.proc.Byte(ctx, test.test)
 		if err != nil {
 			t.Logf("%v", err)

--- a/process/copy_test.go
+++ b/process/copy_test.go
@@ -17,38 +17,47 @@ var copyTests = []struct {
 	{
 		"JSON",
 		Copy{
-			InputKey:  "original",
-			OutputKey: "copy",
+			InputKey:  "foo",
+			OutputKey: "baz",
 		},
-		[]byte(`{"original":"foo"}`),
-		[]byte(`{"original":"foo","copy":"foo"}`),
+		[]byte(`{"foo":"bar"}`),
+		[]byte(`{"foo":"bar","baz":"bar"}`),
 		nil,
 	},
 	{
 		"from JSON",
 		Copy{
-			InputKey: "copy",
+			InputKey: "foo",
 		},
-		[]byte(`{"copy":"foo"}`),
-		[]byte(`foo`),
+		[]byte(`{"foo":"bar"}`),
+		[]byte(`bar`),
+		nil,
+	},
+	{
+		"from JSON nested",
+		Copy{
+			InputKey: "foo",
+		},
+		[]byte(`{"foo":{"bar":"baz"}}`),
+		[]byte(`{"bar":"baz"}`),
 		nil,
 	},
 	{
 		"to JSON utf8",
 		Copy{
-			OutputKey: "copy",
+			OutputKey: "bar",
 		},
-		[]byte(`foo`),
-		[]byte(`{"copy":"foo"}`),
+		[]byte(`baz`),
+		[]byte(`{"bar":"baz"}`),
 		nil,
 	},
 	{
 		"to JSON zlib",
 		Copy{
-			OutputKey: "copy",
+			OutputKey: "bar",
 		},
-		[]byte{120, 156, 5, 192, 33, 13, 0, 0, 0, 128, 176, 182, 216, 247, 119, 44, 6, 2, 130, 1, 69},
-		[]byte(`{"copy":"eJwFwCENAAAAgLC22Pd3LAYCggFF"}`),
+		[]byte{120, 156, 5, 192, 49, 13, 0, 0, 0, 194, 48, 173, 76, 2, 254, 143, 166, 29, 2, 93, 1, 54},
+		[]byte(`{"bar":"eJwFwDENAAAAwjCtTAL+j6YdAl0BNg=="}`),
 		nil,
 	},
 }
@@ -57,7 +66,7 @@ func TestCopy(t *testing.T) {
 	ctx := context.TODO()
 	for _, test := range copyTests {
 		res, err := test.proc.Byte(ctx, test.test)
-		if err != nil && errors.As(err, &test.err) {
+		if err != nil && errors.Is(err, test.err) {
 			continue
 		} else if err != nil {
 			t.Log(err)

--- a/process/count.go
+++ b/process/count.go
@@ -19,9 +19,9 @@ type Count struct{}
 
 // Slice processes a slice of bytes with the Count processor. Conditions are optionally applied on the bytes to enable processing.
 func (p Count) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
-	processed, err := json.Set([]byte(""), "count", len(s))
+	processed, err := json.Set([]byte{}, "count", len(s))
 	if err != nil {
-		return nil, fmt.Errorf("slicer settings %v: %v", p, err)
+		return nil, fmt.Errorf("slicer settings %+v: %w", p, err)
 	}
 
 	slice := make([][]byte, 1, 1)

--- a/process/count_test.go
+++ b/process/count_test.go
@@ -3,6 +3,7 @@ package process
 import (
 	"bytes"
 	"context"
+	"errors"
 	"testing"
 )
 
@@ -11,6 +12,7 @@ var countTests = []struct {
 	proc     Count
 	test     [][]byte
 	expected []byte
+	err      error
 }{
 	{
 		"count",
@@ -21,6 +23,7 @@ var countTests = []struct {
 			[]byte(`{"foo":"qux"}`),
 		},
 		[]byte(`{"count":3}`),
+		nil,
 	},
 }
 
@@ -28,7 +31,9 @@ func TestCount(t *testing.T) {
 	ctx := context.TODO()
 	for _, test := range countTests {
 		res, err := test.proc.Slice(ctx, test.test)
-		if err != nil {
+		if err != nil && errors.As(err, &test.err) {
+			continue
+		} else if err != nil {
 			t.Log(err)
 			t.Fail()
 		}

--- a/process/count_test.go
+++ b/process/count_test.go
@@ -31,7 +31,7 @@ func TestCount(t *testing.T) {
 	ctx := context.TODO()
 	for _, test := range countTests {
 		res, err := test.proc.Slice(ctx, test.test)
-		if err != nil && errors.As(err, &test.err) {
+		if err != nil && errors.Is(err, test.err) {
 			continue
 		} else if err != nil {
 			t.Log(err)

--- a/process/delete.go
+++ b/process/delete.go
@@ -14,7 +14,7 @@ const DeleteInvalidSettings = errors.Error("DeleteInvalidSettings")
 
 /*
 Delete processes data by deleting JSON keys. The processor supports these patterns:
-	json:
+	JSON:
 	  	{"foo":"bar","baz":"qux"} >>> {"foo":"bar"}
 
 The processor uses this Jsonnet configuration:
@@ -34,14 +34,14 @@ type Delete struct {
 func (p Delete) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
 	op, err := condition.OperatorFactory(p.Condition)
 	if err != nil {
-		return nil, fmt.Errorf("slicer settings %v: %v", p, err)
+		return nil, fmt.Errorf("slicer settings %+v: %w", p, err)
 	}
 
 	slice := NewSlice(&s)
 	for _, data := range s {
 		ok, err := op.Operate(data)
 		if err != nil {
-			return nil, fmt.Errorf("slicer settings %v: %v", p, err)
+			return nil, fmt.Errorf("slicer settings %+v: %w", p, err)
 		}
 
 		if !ok {
@@ -61,10 +61,10 @@ func (p Delete) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
 
 // Byte processes bytes with the Delete processor.
 func (p Delete) Byte(ctx context.Context, object []byte) ([]byte, error) {
-	// json processing
-	if p.InputKey != "" {
-		return json.Delete(object, p.InputKey)
+	// only supports JSON, error early if there are no keys
+	if p.InputKey == "" {
+		return nil, fmt.Errorf("byter settings %+v: %w", p, ProcessorInvalidSettings)
 	}
 
-	return nil, fmt.Errorf("byter settings %v: %v", p, DeleteInvalidSettings)
+	return json.Delete(object, p.InputKey)
 }

--- a/process/delete_test.go
+++ b/process/delete_test.go
@@ -3,6 +3,7 @@ package process
 import (
 	"bytes"
 	"context"
+	"errors"
 	"testing"
 )
 
@@ -11,6 +12,7 @@ var deleteTests = []struct {
 	proc     Delete
 	test     []byte
 	expected []byte
+	err      error
 }{
 	// strings
 	{
@@ -20,6 +22,7 @@ var deleteTests = []struct {
 		},
 		[]byte(`{"hello":"123","delete":"456"}`),
 		[]byte(`{"hello":"123"}`),
+		nil,
 	},
 }
 
@@ -27,8 +30,10 @@ func TestDelete(t *testing.T) {
 	for _, test := range deleteTests {
 		ctx := context.TODO()
 		res, err := test.proc.Byte(ctx, test.test)
-		if err != nil {
-			t.Logf("%v", err)
+		if err != nil && errors.As(err, &test.err) {
+			continue
+		} else if err != nil {
+			t.Log(err)
 			t.Fail()
 		}
 

--- a/process/delete_test.go
+++ b/process/delete_test.go
@@ -14,23 +14,31 @@ var deleteTests = []struct {
 	expected []byte
 	err      error
 }{
-	// strings
 	{
-		"delete",
+		"string",
 		Delete{
-			InputKey: "delete",
+			InputKey: "baz",
 		},
-		[]byte(`{"hello":"123","delete":"456"}`),
-		[]byte(`{"hello":"123"}`),
+		[]byte(`{"foo":"bar","baz":"qux"}`),
+		[]byte(`{"foo":"bar"}`),
+		nil,
+	},
+	{
+		"JSON",
+		Delete{
+			InputKey: "baz",
+		},
+		[]byte(`{"foo":"bar","baz":{"qux":"quux"}}`),
+		[]byte(`{"foo":"bar"}`),
 		nil,
 	},
 }
 
 func TestDelete(t *testing.T) {
+	ctx := context.TODO()
 	for _, test := range deleteTests {
-		ctx := context.TODO()
 		res, err := test.proc.Byte(ctx, test.test)
-		if err != nil && errors.As(err, &test.err) {
+		if err != nil && errors.Is(err, test.err) {
 			continue
 		} else if err != nil {
 			t.Log(err)

--- a/process/domain.go
+++ b/process/domain.go
@@ -12,10 +12,7 @@ import (
 	"github.com/brexhq/substation/internal/json"
 )
 
-// DomainInvalidSettings is returned when the Domain processor is configured with invalid Input and Output settings.
-const DomainInvalidSettings = errors.Error("DomainInvalidSettings")
-
-// DomainNoSubdomain is used when a domain without a subdomain is processed
+// DomainNoSubdomain is returned when a domain without a subdomain is processed.
 const DomainNoSubdomain = errors.Error("DomainNoSubdomain")
 
 /*
@@ -33,10 +30,8 @@ type DomainOptions struct {
 
 /*
 Domain processes data by parsing fully qualified domain names into labels. The processor supports these patterns:
-	json:
+	JSON:
 		{"domain":"example.com"} >>> {"domain":"example.com","tld":"com"}
-	json array:
-		{"domain":["example.com","example.top"]} >>> {"domain":["example.com","example.top"],"tld":["com","top"]}
 	data:
 		example.com >>> com
 
@@ -53,10 +48,10 @@ The processor uses this Jsonnet configuration:
 	}
 */
 type Domain struct {
+	Options   DomainOptions            `json:"options"`
 	Condition condition.OperatorConfig `json:"condition"`
 	InputKey  string                   `json:"input_key"`
 	OutputKey string                   `json:"output_key"`
-	Options   DomainOptions            `json:"options"`
 }
 
 // Slice processes a slice of bytes with the Domain processor. Conditions are optionally applied on the bytes to enable processing.
@@ -90,22 +85,16 @@ func (p Domain) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
 
 // Byte processes bytes with the Domain processor.
 func (p Domain) Byte(ctx context.Context, data []byte) ([]byte, error) {
-	// json processing
+	// error early if required options are missing
+	if p.Options.Function == "" {
+		return nil, fmt.Errorf("byter settings %+v: %v", p, ProcessorInvalidSettings)
+	}
+
+	// JSON processing
 	if p.InputKey != "" && p.OutputKey != "" {
 		value := json.Get(data, p.InputKey)
-		if !value.IsArray() {
-			label, _ := p.domain(value.String())
-			return json.Set(data, p.OutputKey, label)
-		}
-
-		// json array processing
-		var array []string
-		for _, v := range value.Array() {
-			label, _ := p.domain(v.String())
-			array = append(array, label)
-		}
-
-		return json.Set(data, p.OutputKey, array)
+		label, _ := p.domain(value.String())
+		return json.Set(data, p.OutputKey, label)
 	}
 
 	// data processing
@@ -114,7 +103,7 @@ func (p Domain) Byte(ctx context.Context, data []byte) ([]byte, error) {
 		return []byte(label), nil
 	}
 
-	return nil, fmt.Errorf("byter settings %v: %v", p, DomainInvalidSettings)
+	return nil, fmt.Errorf("byter settings %v: %v", p, ProcessorInvalidSettings)
 }
 
 func (p Domain) domain(s string) (string, error) {
@@ -134,10 +123,10 @@ func (p Domain) domain(s string) (string, error) {
 			return "", fmt.Errorf("domain %s: %v", s, DomainNoSubdomain)
 		}
 
-		// subdomain is the input string minus the domain and a leading dot
-		// 	input == "foo.bar.com"
-		// 	domain == "bar.com"
-		// 	subdomain == "foo" ("foo.bar.com" minus ".bar.com")
+		// subdomain is the input string minus the domain and a leading dot:
+		// input == "foo.bar.com"
+		// domain == "bar.com"
+		// subdomain == "foo" ("foo.bar.com" minus ".bar.com")
 		subdomain := strings.Replace(s, "."+domain, "", 1)
 		if subdomain == domain {
 			return "", fmt.Errorf("domain %s: %v", s, DomainNoSubdomain)

--- a/process/domain.go
+++ b/process/domain.go
@@ -58,14 +58,14 @@ type Domain struct {
 func (p Domain) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
 	op, err := condition.OperatorFactory(p.Condition)
 	if err != nil {
-		return nil, fmt.Errorf("slicer settings %v: %v", p, err)
+		return nil, fmt.Errorf("slicer settings %+v: %w", p, err)
 	}
 
 	slice := NewSlice(&s)
 	for _, data := range s {
 		ok, err := op.Operate(data)
 		if err != nil {
-			return nil, fmt.Errorf("slicer settings %v: %v", p, err)
+			return nil, fmt.Errorf("slicer settings %+v: %w", p, err)
 		}
 
 		if !ok {
@@ -87,7 +87,7 @@ func (p Domain) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
 func (p Domain) Byte(ctx context.Context, data []byte) ([]byte, error) {
 	// error early if required options are missing
 	if p.Options.Function == "" {
-		return nil, fmt.Errorf("byter settings %+v: %v", p, ProcessorInvalidSettings)
+		return nil, fmt.Errorf("byter settings %+v: %w", p, ProcessorInvalidSettings)
 	}
 
 	// JSON processing
@@ -103,11 +103,11 @@ func (p Domain) Byte(ctx context.Context, data []byte) ([]byte, error) {
 		return []byte(label), nil
 	}
 
-	return nil, fmt.Errorf("byter settings %v: %v", p, ProcessorInvalidSettings)
+	return nil, fmt.Errorf("byter settings %+v: %w", p, ProcessorInvalidSettings)
 }
 
 func (p Domain) domain(s string) (string, error) {
-	switch f := p.Options.Function; f {
+	switch p.Options.Function {
 	case "tld":
 		tld, _ := publicsuffix.PublicSuffix(s)
 		return tld, nil

--- a/process/domain_test.go
+++ b/process/domain_test.go
@@ -10,62 +10,62 @@ import (
 var domainTests = []struct {
 	name     string
 	proc     Domain
-	err      error
 	test     []byte
 	expected []byte
+	err      error
 }{
 	{
-		"json tld",
+		"JSON tld",
 		Domain{
-			InputKey:  "domain",
-			OutputKey: "tld",
 			Options: DomainOptions{
 				Function: "tld",
 			},
+			InputKey:  "foo",
+			OutputKey: "foo",
 		},
+		[]byte(`{"foo":"bar.com"}`),
+		[]byte(`{"foo":"com"}`),
 		nil,
-		[]byte(`{"domain":"example.com"}`),
-		[]byte(`{"domain":"example.com","tld":"com"}`),
 	},
 	{
-		"json domain",
+		"JSON domain",
 		Domain{
-			InputKey:  "domain",
-			OutputKey: "domain",
 			Options: DomainOptions{
 				Function: "domain",
 			},
+			InputKey:  "foo",
+			OutputKey: "foo",
 		},
+		[]byte(`{"foo":"www.example.com"}`),
+		[]byte(`{"foo":"example.com"}`),
 		nil,
-		[]byte(`{"domain":"www.example.com"}`),
-		[]byte(`{"domain":"example.com"}`),
 	},
 	{
-		"json subdomain",
+		"JSON subdomain",
 		Domain{
-			InputKey:  "domain",
-			OutputKey: "subdomain",
 			Options: DomainOptions{
 				Function: "subdomain",
 			},
+			InputKey:  "foo",
+			OutputKey: "foo",
 		},
+		[]byte(`{"foo":"www.bar.com"}`),
+		[]byte(`{"foo":"www"}`),
 		nil,
-		[]byte(`{"domain":"www.example.com"}`),
-		[]byte(`{"domain":"www.example.com","subdomain":"www"}`),
 	},
 	// empty subdomain, returns empty
 	{
-		"json subdomain",
+		"JSON subdomain",
 		Domain{
-			InputKey:  "domain",
-			OutputKey: "subdomain",
 			Options: DomainOptions{
 				Function: "subdomain",
 			},
+			InputKey:  "foo",
+			OutputKey: "foo",
 		},
+		[]byte(`{"foo":"example.com"}`),
+		[]byte(`{"foo":""}`),
 		nil,
-		[]byte(`{"domain":"example.com"}`),
-		[]byte(`{"domain":"example.com","subdomain":""}`),
 	},
 	{
 		"data",
@@ -74,24 +74,24 @@ var domainTests = []struct {
 				Function: "subdomain",
 			},
 		},
-		nil,
-		[]byte(`www.example.com`),
+		[]byte(`www.bar.com`),
 		[]byte(`www`),
+		nil,
 	},
 	{
 		"invalid settings",
 		Domain{},
+		[]byte{},
+		[]byte{},
 		ProcessorInvalidSettings,
-		[]byte{},
-		[]byte{},
 	},
 }
 
 func TestDomain(t *testing.T) {
+	ctx := context.TODO()
 	for _, test := range domainTests {
-		ctx := context.TODO()
 		res, err := test.proc.Byte(ctx, test.test)
-		if err != nil && errors.As(err, &test.err) {
+		if err != nil && errors.Is(err, test.err) {
 			continue
 		} else if err != nil {
 			t.Log(err)

--- a/process/drop.go
+++ b/process/drop.go
@@ -21,14 +21,14 @@ type Drop struct {
 func (p Drop) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
 	op, err := condition.OperatorFactory(p.Condition)
 	if err != nil {
-		return nil, fmt.Errorf("slicer settings %v: %v", p, err)
+		return nil, fmt.Errorf("slicer settings %+v: %w", p, err)
 	}
 
 	slice := NewSlice(&s)
 	for _, data := range s {
 		ok, err := op.Operate(data)
 		if err != nil {
-			return nil, fmt.Errorf("slicer settings %v: %v", p, err)
+			return nil, fmt.Errorf("slicer settings %+v: %w", p, err)
 		}
 
 		if !ok {

--- a/process/drop_test.go
+++ b/process/drop_test.go
@@ -2,6 +2,7 @@ package process
 
 import (
 	"context"
+	"errors"
 	"testing"
 )
 
@@ -9,6 +10,7 @@ var dropTests = []struct {
 	name string
 	proc Drop
 	test [][]byte
+	err  error
 }{
 	{
 		"drop",
@@ -18,6 +20,7 @@ var dropTests = []struct {
 			[]byte(`{"foo":"baz"}`),
 			[]byte(`{"foo":"qux"}`),
 		},
+		nil,
 	},
 }
 
@@ -25,7 +28,9 @@ func TestDrop(t *testing.T) {
 	ctx := context.TODO()
 	for _, test := range dropTests {
 		res, err := test.proc.Slice(ctx, test.test)
-		if err != nil {
+		if err != nil && errors.Is(err, test.err) {
+			continue
+		} else if err != nil {
 			t.Log(err)
 			t.Fail()
 		}

--- a/process/dynamodb.go
+++ b/process/dynamodb.go
@@ -8,12 +8,8 @@ import (
 
 	"github.com/brexhq/substation/condition"
 	"github.com/brexhq/substation/internal/aws/dynamodb"
-	"github.com/brexhq/substation/internal/errors"
 	"github.com/brexhq/substation/internal/json"
 )
-
-// DynamoDBInvalidSettings is returned when the DynamoDB processor is configured with invalid Input and Output settings.
-const DynamoDBInvalidSettings = errors.Error("DynamoDBInvalidSettings")
 
 /*
 DynamoDBOptions contains custom options settings for the DynamoDB processor (https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html#API_Query_RequestSyntax):
@@ -39,7 +35,7 @@ type DynamoDBOptions struct {
 
 /*
 DynamoDB processes data by querying a DynamoDB table and returning all matched items as an array of JSON objects. The processor supports these patterns:
-	json:
+	JSON:
 		{"ddb":{"PK":"foo"}} >>> {"ddb":[{"foo":"bar"}]}
 
 The processor uses this Jsonnet configuration:
@@ -60,10 +56,10 @@ The processor uses this Jsonnet configuration:
 	}
 */
 type DynamoDB struct {
+	Options   DynamoDBOptions          `json:"options"`
 	Condition condition.OperatorConfig `json:"condition"`
 	InputKey  string                   `json:"input_key"`
 	OutputKey string                   `json:"output_key"`
-	Options   DynamoDBOptions          `json:"options"`
 }
 
 var dynamodbAPI dynamodb.API
@@ -104,26 +100,30 @@ func (p DynamoDB) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
 
 // Byte processes bytes with the DynamoDB processor.
 func (p DynamoDB) Byte(ctx context.Context, data []byte) ([]byte, error) {
+	// error early if required options are missing
+	if p.Options.Table == "" || p.Options.KeyConditionExpression == "" {
+		return nil, fmt.Errorf("byter settings %+v: %v", p, ProcessorInvalidSettings)
+	}
+
 	// lazy load API
 	if !dynamodbAPI.IsEnabled() {
 		dynamodbAPI.Setup()
 	}
 
-	// only supports json, error early if there are no keys
+	// only supports JSON, error early if there are no keys
 	if p.InputKey == "" && p.OutputKey == "" {
-		return nil, fmt.Errorf("byter settings %v: %v", p, DynamoDBInvalidSettings)
+		return nil, fmt.Errorf("byter settings %v: %v", p, ProcessorInvalidSettings)
 	}
 
-	// json processing
 	request := json.Get(data, p.InputKey)
 	if !request.IsObject() {
-		return nil, fmt.Errorf("byter settings %v: %v", p, DynamoDBInvalidSettings)
+		return nil, fmt.Errorf("byter settings %v: %v", p, ProcessorInvalidSettings)
 	}
 
 	// PK is a required field
 	pk := json.Get([]byte(request.Raw), "PK").String()
 	if pk == "" {
-		return nil, fmt.Errorf("byter settings %v: %v", p, DynamoDBInvalidSettings)
+		return nil, fmt.Errorf("byter settings %v: %v", p, ProcessorInvalidSettings)
 	}
 
 	sk := json.Get([]byte(request.Raw), "SK").String()

--- a/process/expand.go
+++ b/process/expand.go
@@ -18,9 +18,6 @@ The processor uses this Jsonnet configuration:
 		type: 'expand',
 		settings: {
 			input_key: 'expand',
-			options: {
-				retain: ['baz'],
-			}
 		},
 	}
 */
@@ -33,19 +30,19 @@ type Expand struct {
 func (p Expand) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
 	// only supports JSON, error early if there is no input key
 	if p.InputKey == "" {
-		return nil, fmt.Errorf("slicer settings %v: %v", p, ProcessorInvalidSettings)
+		return nil, fmt.Errorf("slicer settings %+v: %w", p, ProcessorInvalidSettings)
 	}
 
 	op, err := condition.OperatorFactory(p.Condition)
 	if err != nil {
-		return nil, fmt.Errorf("slicer settings %v: %v", p, err)
+		return nil, fmt.Errorf("slicer settings %+v: %w", p, err)
 	}
 
 	slice := NewSlice(&s)
 	for _, data := range s {
 		ok, err := op.Operate(data)
 		if err != nil {
-			return nil, fmt.Errorf("slicer settings %v: %v", p, err)
+			return nil, fmt.Errorf("slicer settings %+v: %w", p, err)
 		}
 
 		if !ok {
@@ -76,7 +73,7 @@ func (p Expand) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
 
 				expand, err = json.Set(expand, k, v)
 				if err != nil {
-					return nil, fmt.Errorf("slicer settings %v: %v", p, err)
+					return nil, fmt.Errorf("slicer settings %+v: %w", p, err)
 				}
 			}
 

--- a/process/expand.go
+++ b/process/expand.go
@@ -5,25 +5,12 @@ import (
 	"fmt"
 
 	"github.com/brexhq/substation/condition"
-	"github.com/brexhq/substation/internal/errors"
 	"github.com/brexhq/substation/internal/json"
 )
 
-// ExpandInvalidSettings is returned when the Expand processor is configured with invalid Input and Output settings.
-const ExpandInvalidSettings = errors.Error("ExpandInvalidSettings")
-
-/*
-ExpandOptions contains custom options settings for the Expand processor:
-	Retain (optional):
-		array of JSON keys to retain from the original object
-*/
-type ExpandOptions struct {
-	Retain []string `json:"retain"` // retain fields found anywhere in input
-}
-
 /*
 Expand processes data by creating individual events from objects in JSON arrays. The processor supports these patterns:
-	json array:
+	JSON:
 		{"expand":[{"foo":"bar"}],"baz":"qux"} >>> {"foo":"bar","baz":"qux"}
 
 The processor uses this Jsonnet configuration:
@@ -40,14 +27,13 @@ The processor uses this Jsonnet configuration:
 type Expand struct {
 	Condition condition.OperatorConfig `json:"condition"`
 	InputKey  string                   `json:"input_key"`
-	Options   ExpandOptions            `json:"options"`
 }
 
 // Slice processes a slice of bytes with the Expand processor. Conditions are optionally applied on the bytes to enable processing.
 func (p Expand) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
-	// only supports json, error early if there is no input key
+	// only supports JSON, error early if there is no input key
 	if p.InputKey == "" {
-		return nil, fmt.Errorf("slicer settings %v: %v", p, ExpandInvalidSettings)
+		return nil, fmt.Errorf("slicer settings %v: %v", p, ProcessorInvalidSettings)
 	}
 
 	op, err := condition.OperatorFactory(p.Condition)
@@ -67,20 +53,34 @@ func (p Expand) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
 			continue
 		}
 
-		// json array processing
-		value := json.Get(data, p.InputKey)
-		for _, x := range value.Array() {
+		// data is processed by retrieving and iterating the
+		// array (InputKey) containing JSON objects and setting
+		// any additional keys from the root object into each
+		// expanded object
+		//
+		// root:
+		// 	{"expand":[{"foo":"bar"},{"baz":"qux"}],"quux":"corge"}
+		// expanded:
+		// 	{"foo":"bar","quux":"corge"}
+		// 	{"baz":"qux","quux":"corge"}
+		root := json.Get(data, "@this")
+		v := json.Get(data, p.InputKey)
+		for _, value := range v.Array() {
 			var err error
-			processed := []byte(x.String())
-			for _, r := range p.Options.Retain {
-				v := json.Get(data, r)
-				processed, err = json.Set(processed, r, v)
+
+			expand := []byte(value.String())
+			for k, v := range root.Map() {
+				if k == p.InputKey {
+					continue
+				}
+
+				expand, err = json.Set(expand, k, v)
 				if err != nil {
 					return nil, fmt.Errorf("slicer settings %v: %v", p, err)
 				}
 			}
 
-			slice = append(slice, processed)
+			slice = append(slice, expand)
 		}
 	}
 

--- a/process/flatten.go
+++ b/process/flatten.go
@@ -42,14 +42,14 @@ type Flatten struct {
 func (p Flatten) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
 	op, err := condition.OperatorFactory(p.Condition)
 	if err != nil {
-		return nil, fmt.Errorf("slicer settings %v: %v", p, err)
+		return nil, fmt.Errorf("slicer settings %+v: %w", p, err)
 	}
 
 	slice := NewSlice(&s)
 	for _, data := range s {
 		ok, err := op.Operate(data)
 		if err != nil {
-			return nil, fmt.Errorf("slicer settings %v: %v", p, err)
+			return nil, fmt.Errorf("slicer settings %+v: %w", p, err)
 		}
 
 		if !ok {
@@ -71,7 +71,7 @@ func (p Flatten) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
 func (p Flatten) Byte(ctx context.Context, data []byte) ([]byte, error) {
 	// only supports JSON, error early if there are no keys
 	if p.InputKey == "" && p.OutputKey == "" {
-		return nil, fmt.Errorf("byter settings %+v: %v", p, ProcessorInvalidSettings)
+		return nil, fmt.Errorf("byter settings %+v: %w", p, ProcessorInvalidSettings)
 	}
 
 	var value json.Result

--- a/process/flatten.go
+++ b/process/flatten.go
@@ -5,12 +5,8 @@ import (
 	"fmt"
 
 	"github.com/brexhq/substation/condition"
-	"github.com/brexhq/substation/internal/errors"
 	"github.com/brexhq/substation/internal/json"
 )
-
-// FlattenInvalidSettings is returned when the Flatten processor is configured with invalid Input and Output settings.
-const FlattenInvalidSettings = errors.Error("FlattenInvalidSettings")
 
 /*
 FlattenOptions contains custom options settings for the Flatten processor:
@@ -23,7 +19,7 @@ type FlattenOptions struct {
 
 /*
 Flatten processes data by flattening JSON arrays. The processor supports these patterns:
-	json:
+	JSON:
 		{"flatten":["foo",["bar"]]} >>> {"flatten":["foo","bar"]}
 
 The processor uses this Jsonnet configuration:
@@ -36,10 +32,10 @@ The processor uses this Jsonnet configuration:
 	}
 */
 type Flatten struct {
+	Options   FlattenOptions           `json:"options"`
 	Condition condition.OperatorConfig `json:"condition"`
 	InputKey  string                   `json:"input_key"`
 	OutputKey string                   `json:"output_key"`
-	Options   FlattenOptions           `json:"options"`
 }
 
 // Slice processes a slice of bytes with the Flatten processor. Conditions are optionally applied on the bytes to enable processing.
@@ -73,9 +69,9 @@ func (p Flatten) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
 
 // Byte processes bytes with the Flatten processor.
 func (p Flatten) Byte(ctx context.Context, data []byte) ([]byte, error) {
-	// only supports json, error early if there are no keys
+	// only supports JSON, error early if there are no keys
 	if p.InputKey == "" && p.OutputKey == "" {
-		return nil, fmt.Errorf("byter settings %v: %v", p, FlattenInvalidSettings)
+		return nil, fmt.Errorf("byter settings %+v: %v", p, ProcessorInvalidSettings)
 	}
 
 	var value json.Result

--- a/process/flatten_test.go
+++ b/process/flatten_test.go
@@ -10,9 +10,9 @@ import (
 var flattenTests = []struct {
 	name     string
 	proc     Flatten
-	err      error
 	test     []byte
 	expected []byte
+	err      error
 }{
 	{
 		"json",
@@ -20,9 +20,9 @@ var flattenTests = []struct {
 			InputKey:  "flatten",
 			OutputKey: "flatten",
 		},
-		nil,
 		[]byte(`{"flatten":["foo",["bar"]]}`),
 		[]byte(`{"flatten":["foo","bar"]}`),
+		nil,
 	},
 	{
 		"json deep flatten",
@@ -33,9 +33,9 @@ var flattenTests = []struct {
 			InputKey:  "flatten",
 			OutputKey: "flatten",
 		},
-		nil,
 		[]byte(`{"flatten":[["foo"],[[["bar",[["baz"]]]]]]}`),
 		[]byte(`{"flatten":["foo","bar","baz"]}`),
+		nil,
 	},
 	{
 		"invalid settings",
@@ -46,17 +46,17 @@ var flattenTests = []struct {
 			InputKey:  "flatten",
 			OutputKey: "flatten",
 		},
-		ProcessorInvalidSettings,
 		[]byte(`{"flatten":[["foo"],[[["bar",[["baz"]]]]]]}`),
 		[]byte(`{"flatten":["foo","bar","baz"]}`),
+		ProcessorInvalidSettings,
 	},
 }
 
 func TestFlatten(t *testing.T) {
+	ctx := context.TODO()
 	for _, test := range flattenTests {
-		ctx := context.TODO()
 		res, err := test.proc.Byte(ctx, test.test)
-		if err != nil && errors.As(err, &test.err) {
+		if err != nil && errors.Is(err, test.err) {
 			continue
 		} else if err != nil {
 			t.Log(err)

--- a/process/flatten_test.go
+++ b/process/flatten_test.go
@@ -3,12 +3,14 @@ package process
 import (
 	"bytes"
 	"context"
+	"errors"
 	"testing"
 )
 
 var flattenTests = []struct {
 	name     string
 	proc     Flatten
+	err      error
 	test     []byte
 	expected []byte
 }{
@@ -18,18 +20,33 @@ var flattenTests = []struct {
 			InputKey:  "flatten",
 			OutputKey: "flatten",
 		},
+		nil,
 		[]byte(`{"flatten":["foo",["bar"]]}`),
 		[]byte(`{"flatten":["foo","bar"]}`),
 	},
 	{
 		"json deep flatten",
 		Flatten{
-			InputKey:  "flatten",
-			OutputKey: "flatten",
 			Options: FlattenOptions{
 				Deep: true,
 			},
+			InputKey:  "flatten",
+			OutputKey: "flatten",
 		},
+		nil,
+		[]byte(`{"flatten":[["foo"],[[["bar",[["baz"]]]]]]}`),
+		[]byte(`{"flatten":["foo","bar","baz"]}`),
+	},
+	{
+		"invalid settings",
+		Flatten{
+			Options: FlattenOptions{
+				Deep: true,
+			},
+			InputKey:  "flatten",
+			OutputKey: "flatten",
+		},
+		ProcessorInvalidSettings,
 		[]byte(`{"flatten":[["foo"],[[["bar",[["baz"]]]]]]}`),
 		[]byte(`{"flatten":["foo","bar","baz"]}`),
 	},
@@ -39,8 +56,10 @@ func TestFlatten(t *testing.T) {
 	for _, test := range flattenTests {
 		ctx := context.TODO()
 		res, err := test.proc.Byte(ctx, test.test)
-		if err != nil {
-			t.Logf("%v", err)
+		if err != nil && errors.As(err, &test.err) {
+			continue
+		} else if err != nil {
+			t.Log(err)
 			t.Fail()
 		}
 

--- a/process/for_each.go
+++ b/process/for_each.go
@@ -1,0 +1,147 @@
+package process
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/brexhq/substation/condition"
+	"github.com/brexhq/substation/internal/config"
+	"github.com/brexhq/substation/internal/json"
+)
+
+/*
+ForEachOptions contains custom options for the ForEach processor:
+	Processor:
+		processor to apply to the data
+*/
+type ForEachOptions struct {
+	Processor config.Config
+}
+
+/*
+ForEach processes data by iterating and applying a processor to each element in a JSON array. The processor supports these patterns:
+	json:
+		{"input":["ABC","DEF"]} >>> {"input":["ABC","DEF"],"output":["abc","def"]}
+
+The processor uses this Jsonnet configuration:
+	{
+		type: 'for_each',
+		settings: {
+			input_key: 'input',
+			output_key: 'output.-1',
+			options: {
+				processor: {
+					type: 'case',
+					settings: {
+						options: {
+							case: 'lower',
+						}
+					}
+				},
+			},
+		},
+	}
+*/
+type ForEach struct {
+	Condition condition.OperatorConfig `json:"condition"`
+	Options   ForEachOptions           `json:"options"`
+	InputKey  string                   `json:"input_key"`
+	OutputKey string                   `json:"output_key"`
+}
+
+// Slice processes a slice of bytes with the ForEach processor. Conditions are optionally applied on the bytes to enable processing.
+func (p ForEach) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
+	op, err := condition.OperatorFactory(p.Condition)
+	if err != nil {
+		return nil, fmt.Errorf("slicer settings %v: %v", p, err)
+	}
+
+	slice := NewSlice(&s)
+	for _, data := range s {
+		ok, err := op.Operate(data)
+		if err != nil {
+			return nil, fmt.Errorf("slicer settings %v: %v", p, err)
+		}
+
+		if !ok {
+			slice = append(slice, data)
+			continue
+		}
+
+		processed, err := p.Byte(ctx, data)
+		if err != nil {
+			return nil, fmt.Errorf("slicer: %v", err)
+		}
+		slice = append(slice, processed)
+	}
+
+	return slice, nil
+}
+
+/*
+Byte processes bytes with the ForEach processor.
+
+Data is processed by iterating an input JSON array,
+encapsulating the elements in a temporary JSON
+object, and running the configured processor. This
+technique avoids parsing errors when handling arrays
+that contain JSON objects, such as:
+	{"for_each":[{"foo":"bar"},{"foo":"baz"}]}
+
+The temporary JSON object uses the configured
+processor's name as its key (e.g., "case"). If the
+configured processor has keys set (e.g., "foo"), then
+the keys are concatenated (e.g., "case.foo"). The example
+above produces this temporary JSON during processing:
+	{"case":{"foo":"bar"}}
+	{"case":{"foo":"baz"}}
+*/
+func (p ForEach) Byte(ctx context.Context, data []byte) ([]byte, error) {
+	// only supports json, error early if there are no keys
+	if p.InputKey == "" && p.OutputKey == "" {
+		return nil, fmt.Errorf("byter settings %v: %v", p, ProcessorInvalidSettings)
+	}
+
+	if _, ok := p.Options.Processor.Settings["input_key"]; ok {
+		p.Options.Processor.Settings["input_key"] = p.Options.Processor.Type + "." + p.Options.Processor.Settings["input_key"].(string)
+	} else {
+		p.Options.Processor.Settings["input_key"] = p.Options.Processor.Type
+	}
+
+	if _, ok := p.Options.Processor.Settings["output_key"]; ok {
+		p.Options.Processor.Settings["output_key"] = p.Options.Processor.Type + "." + p.Options.Processor.Settings["output_key"].(string)
+	} else {
+		p.Options.Processor.Settings["output_key"] = p.Options.Processor.Type
+	}
+
+	byter, err := ByterFactory(p.Options.Processor)
+	if err != nil {
+		return nil, err
+	}
+
+	value := json.Get(data, p.InputKey)
+	if !value.IsArray() {
+		return data, nil
+	}
+
+	for _, v := range value.Array() {
+		var tmp []byte
+		tmp, err := json.Set(tmp, p.Options.Processor.Type, v)
+		if err != nil {
+			return nil, fmt.Errorf("byter settings %v: %v", p, err)
+		}
+
+		tmp, err = byter.Byte(ctx, tmp)
+		if err != nil {
+			return nil, fmt.Errorf("byter settings %v: %v", p, err)
+		}
+
+		res := json.Get(tmp, p.Options.Processor.Type)
+		data, err = json.Set(data, p.OutputKey, res)
+		if err != nil {
+			return nil, fmt.Errorf("byter settings %v: %v", p, err)
+		}
+	}
+
+	return data, nil
+}

--- a/process/for_each_test.go
+++ b/process/for_each_test.go
@@ -1,0 +1,339 @@
+package process
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/brexhq/substation/internal/config"
+)
+
+var foreachTests = []struct {
+	name     string
+	proc     ForEach
+	test     []byte
+	expected []byte
+}{
+	{
+		"base64",
+		ForEach{
+			InputKey:  "input",
+			OutputKey: "output.-1",
+			Options: ForEachOptions{
+				Processor: config.Config{
+					Type: "base64",
+					Settings: map[string]interface{}{
+						"options": map[string]interface{}{
+							"direction": "from",
+						},
+					},
+				},
+			},
+		},
+		[]byte(`{"input":["Zm9v","YmFy"]}`),
+		[]byte(`{"input":["Zm9v","YmFy"],"output":["foo","bar"]}`),
+	},
+	{
+		"capture",
+		ForEach{
+			InputKey:  "input",
+			OutputKey: "output.-1",
+			Options: ForEachOptions{
+				Processor: config.Config{
+					Type: "capture",
+					Settings: map[string]interface{}{
+						"options": map[string]interface{}{
+							"expression": "^([^@]*)@.*$",
+							"function":   "find",
+						},
+					},
+				},
+			},
+		},
+		[]byte(`{"input":["foo@qux.com","bar@qux.com"]}`),
+		[]byte(`{"input":["foo@qux.com","bar@qux.com"],"output":["foo","bar"]}`),
+	},
+	{
+		"case",
+		ForEach{
+			InputKey:  "input",
+			OutputKey: "output.-1",
+			Options: ForEachOptions{
+				Processor: config.Config{
+					Type: "case",
+					Settings: map[string]interface{}{
+						"options": map[string]interface{}{
+							"case": "lower",
+						},
+					},
+				},
+			},
+		},
+		[]byte(`{"input":["ABC","DEF"]}`),
+		[]byte(`{"input":["ABC","DEF"],"output":["abc","def"]}`),
+	},
+	{
+		"concat",
+		ForEach{
+			InputKey:  "input",
+			OutputKey: "output.-1",
+			Options: ForEachOptions{
+				Processor: config.Config{
+					Type: "concat",
+					Settings: map[string]interface{}{
+						"options": map[string]interface{}{
+							"separator": ".",
+						},
+					},
+				},
+			},
+		},
+		[]byte(`{"input":[["foo","bar"],["baz","qux"]]}`),
+		[]byte(`{"input":[["foo","bar"],["baz","qux"]],"output":["foo.bar","baz.qux"]}`),
+	},
+	{
+		"convert",
+		ForEach{
+			InputKey:  "input",
+			OutputKey: "output.-1",
+			Options: ForEachOptions{
+				Processor: config.Config{
+					Type: "convert",
+					Settings: map[string]interface{}{
+						"options": map[string]interface{}{
+							"type": "bool",
+						},
+					},
+				},
+			},
+		},
+		[]byte(`{"input":["true","false"]}`),
+		[]byte(`{"input":["true","false"],"output":[true,false]}`),
+	},
+	{
+		"domain",
+		ForEach{
+			InputKey:  "input",
+			OutputKey: "output.-1",
+			Options: ForEachOptions{
+				Processor: config.Config{
+					Type: "domain",
+					Settings: map[string]interface{}{
+						"options": map[string]interface{}{
+							"function": "subdomain",
+						},
+					},
+				},
+			},
+		},
+		[]byte(`{"input":["www.example.com","mail.example.top"]}`),
+		[]byte(`{"input":["www.example.com","mail.example.top"],"output":["www","mail"]}`),
+	},
+	{
+		"flatten",
+		ForEach{
+			InputKey:  "input",
+			OutputKey: "output.-1",
+			Options: ForEachOptions{
+				Processor: config.Config{
+					Type: "flatten",
+					Settings: map[string]interface{}{
+						"input_key":  "flatten",
+						"output_key": "flatten",
+						"options": map[string]interface{}{
+							"deep": true,
+						},
+					},
+				},
+			},
+		},
+		[]byte(`{"input":[{"flatten":[["foo"],[[["bar",[["baz"]]]]]]},{"flatten":[["foo"],[[["bar",[["baz"]]]]]]}]}`),
+		[]byte(`{"input":[{"flatten":[["foo"],[[["bar",[["baz"]]]]]]},{"flatten":[["foo"],[[["bar",[["baz"]]]]]]}],"output":[{"flatten":["foo","bar","baz"]},{"flatten":["foo","bar","baz"]}]}`),
+	},
+	{
+		"group",
+		ForEach{
+			InputKey:  "input",
+			OutputKey: "output.-1",
+			Options: ForEachOptions{
+				Processor: config.Config{
+					Type: "group",
+					Settings: map[string]interface{}{
+						"input_key":  "group",
+						"output_key": "group",
+					},
+				},
+			},
+		},
+		[]byte(`{"input":[{"group":[["foo","bar"],[123,456]]},{"group":[["foo","bar"],[123,456]]}]}`),
+		[]byte(`{"input":[{"group":[["foo","bar"],[123,456]]},{"group":[["foo","bar"],[123,456]]}],"output":[{"group":[["foo",123],["bar",456]]},{"group":[["foo",123],["bar",456]]}]}`),
+	},
+	{
+		"hash",
+		ForEach{
+			InputKey:  "input",
+			OutputKey: "output.-1",
+			Options: ForEachOptions{
+				Processor: config.Config{
+					Type: "hash",
+					Settings: map[string]interface{}{
+						"options": map[string]interface{}{
+							"algorithm": "sha256",
+						},
+					},
+				},
+			},
+		},
+		[]byte(`{"input":["foo","bar","baz"]}`),
+		[]byte(`{"input":["foo","bar","baz"],"output":["2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae","fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9","baa5a0964d3320fbc0c6a922140453c8513ea24ab8fd0577034804a967248096"]}`),
+	},
+	{
+		"insert",
+		ForEach{
+			InputKey:  "input",
+			OutputKey: "output.-1",
+			Options: ForEachOptions{
+				Processor: config.Config{
+					Type: "insert",
+					Settings: map[string]interface{}{
+						"output_key": "baz",
+						"options": map[string]interface{}{
+							"value": "qux",
+						},
+					},
+				},
+			},
+		},
+		[]byte(`{"input":[{"foo":"bar"},{"baz":"quux"}]}`),
+		[]byte(`{"input":[{"foo":"bar"},{"baz":"quux"}],"output":[{"foo":"bar","baz":"qux"},{"baz":"qux"}]}`),
+	},
+	{
+		"math",
+		ForEach{
+			InputKey:  "input",
+			OutputKey: "output.-1",
+			Options: ForEachOptions{
+				Processor: config.Config{
+					Type: "math",
+					Settings: map[string]interface{}{
+						"options": map[string]interface{}{
+							"operation": "add",
+						},
+					},
+				},
+			},
+		},
+		[]byte(`{"input":[[2,3],[4,5]]}`),
+		[]byte(`{"input":[[2,3],[4,5]],"output":[5,9]}`),
+	},
+	{
+		"pipeline",
+		ForEach{
+			InputKey:  "input",
+			OutputKey: "output.-1",
+			Options: ForEachOptions{
+				Processor: config.Config{
+					Type: "pipeline",
+					Settings: map[string]interface{}{
+						"options": map[string]interface{}{
+							"processors": []config.Config{
+								{
+									Type: "base64",
+									Settings: map[string]interface{}{
+										"options": map[string]interface{}{
+											"direction": "from",
+										},
+									},
+								},
+								{
+									Type: "gzip",
+									Settings: map[string]interface{}{
+										"options": map[string]interface{}{
+											"direction": "from",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		[]byte(`{"input":["H4sIAMpcy2IA/wXAIQ0AAACAsLbY93csBiFlc4wDAAAA","H4sIAI/bzmIA/wXAMQ0AAADCMK1MAv6Pph2qjP92AwAAAA=="]}`),
+		[]byte(`{"input":["H4sIAMpcy2IA/wXAIQ0AAACAsLbY93csBiFlc4wDAAAA","H4sIAI/bzmIA/wXAMQ0AAADCMK1MAv6Pph2qjP92AwAAAA=="],"output":["foo","bar"]}`),
+	},
+	{
+		"replace",
+		ForEach{
+			InputKey:  "input",
+			OutputKey: "output.-1",
+			Options: ForEachOptions{
+				Processor: config.Config{
+					Type: "replace",
+					Settings: map[string]interface{}{
+						"options": map[string]interface{}{
+							"old": "r",
+							"new": "z",
+						},
+					},
+				},
+			},
+		},
+		[]byte(`{"input":["bar","bard"]}`),
+		[]byte(`{"input":["bar","bard"],"output":["baz","bazd"]}`),
+	},
+	{
+		"time",
+		ForEach{
+			InputKey:  "input",
+			OutputKey: "output.-1",
+			Options: ForEachOptions{
+				Processor: config.Config{
+					Type: "time",
+					Settings: map[string]interface{}{
+						"options": map[string]interface{}{
+							"input_format":  "2006-01-02T15:04:05Z",
+							"output_format": "2006-01-02T15:04:05.000000Z",
+						},
+					},
+				},
+			},
+		},
+		[]byte(`{"input":["2021-03-06T00:02:57Z","2021-03-06T00:03:57Z","2021-03-06T00:04:57Z"]}`),
+		[]byte(`{"input":["2021-03-06T00:02:57Z","2021-03-06T00:03:57Z","2021-03-06T00:04:57Z"],"output":["2021-03-06T00:02:57.000000Z","2021-03-06T00:03:57.000000Z","2021-03-06T00:04:57.000000Z"]}`),
+	},
+}
+
+func TestForEach(t *testing.T) {
+	for _, test := range foreachTests {
+		ctx := context.TODO()
+		res, err := test.proc.Byte(ctx, test.test)
+		if err != nil {
+			t.Logf("%v", err)
+			t.Fail()
+		}
+
+		if c := bytes.Compare(res, test.expected); c != 0 {
+			t.Logf("expected %s, got %s", test.expected, res)
+			t.Fail()
+		}
+	}
+}
+
+func benchmarkForEachByte(b *testing.B, byter ForEach, test []byte) {
+	ctx := context.TODO()
+	for i := 0; i < b.N; i++ {
+		byter.Byte(ctx, test)
+	}
+}
+
+func BenchmarkForEachByte(b *testing.B) {
+	for _, test := range foreachTests {
+		b.Run(string(test.name),
+			func(b *testing.B) {
+				benchmarkForEachByte(b, test.proc, test.test)
+			},
+		)
+		break
+	}
+}

--- a/process/group.go
+++ b/process/group.go
@@ -19,7 +19,7 @@ type GroupOptions struct {
 
 /*
 Group processes data by grouping JSON arrays into an array of tuples or array of JSON objects. The processor supports these patterns:
-	json array:
+	JSON array:
 		{"group":[["foo","bar"],[111,222]]} >>> {"group":[["foo",111],["bar",222]]}
 		{"group":[["foo","bar"],[111,222]]} >>> {"group":[{"name":foo","size":111},{"name":"bar","size":222}]}
 
@@ -29,7 +29,6 @@ The processor uses this Jsonnet configuration:
 		settings: {
 			input_key: 'group',
 			output_key: 'group',
-			}
 		},
 	}
 */
@@ -44,14 +43,14 @@ type Group struct {
 func (p Group) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
 	op, err := condition.OperatorFactory(p.Condition)
 	if err != nil {
-		return nil, fmt.Errorf("slicer settings %v: %v", p, err)
+		return nil, fmt.Errorf("slicer settings %+v: %w", p, err)
 	}
 
 	slice := NewSlice(&s)
 	for _, data := range s {
 		ok, err := op.Operate(data)
 		if err != nil {
-			return nil, fmt.Errorf("slicer settings %v: %v", p, err)
+			return nil, fmt.Errorf("slicer settings %+v: %w", p, err)
 		}
 
 		if !ok {
@@ -73,7 +72,7 @@ func (p Group) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
 func (p Group) Byte(ctx context.Context, data []byte) ([]byte, error) {
 	// only supports JSON arrays, error early if there are no keys
 	if p.InputKey == "" && p.OutputKey == "" {
-		return nil, fmt.Errorf("byter settings %+v: %v", p, ProcessorInvalidSettings)
+		return nil, fmt.Errorf("byter settings %+v: %w", p, ProcessorInvalidSettings)
 	}
 
 	if len(p.Options.Keys) == 0 {
@@ -114,7 +113,7 @@ func (p Group) Byte(ctx context.Context, data []byte) ([]byte, error) {
 		for x1, v1 := range v.Array() {
 			cache[x1], err = json.Set(cache[x1], p.Options.Keys[x], v1)
 			if err != nil {
-				return nil, fmt.Errorf("byter settings %+v: %v", p, err)
+				return nil, fmt.Errorf("byter settings %+v: %w", p, err)
 			}
 		}
 	}
@@ -125,12 +124,11 @@ func (p Group) Byte(ctx context.Context, data []byte) ([]byte, error) {
 	for i := 0; i < len(cache); i++ {
 		tmp, err = json.Set(tmp, fmt.Sprintf("%d", i), cache[i])
 		if err != nil {
-			return nil, fmt.Errorf("byter settings %+v: %v", p, err)
+			return nil, fmt.Errorf("byter settings %+v: %w", p, err)
 		}
 	}
 
 	// JSON arrays must be set using SetRaw to preserve structure
-	//
 	// [{"name":"foo","size":123},{"name":"bar","size":456}]
 	return json.SetRaw(data, p.OutputKey, tmp)
 }

--- a/process/group.go
+++ b/process/group.go
@@ -5,12 +5,8 @@ import (
 	"fmt"
 
 	"github.com/brexhq/substation/condition"
-	"github.com/brexhq/substation/internal/errors"
 	"github.com/brexhq/substation/internal/json"
 )
-
-// GroupInvalidSettings is returned when the Group processor is configured with invalid Input and Output settings.
-const GroupInvalidSettings = errors.Error("GroupInvalidSettings")
 
 /*
 GroupOptions contains custom options for the Group processor:
@@ -38,10 +34,10 @@ The processor uses this Jsonnet configuration:
 	}
 */
 type Group struct {
+	Options   GroupOptions             `json:"options"`
 	Condition condition.OperatorConfig `json:"condition"`
 	InputKey  string                   `json:"input_key"`
 	OutputKey string                   `json:"output_key"`
-	Options   GroupOptions             `json:"options"`
 }
 
 // Slice processes a slice of bytes with the Group processor. Conditions are optionally applied on the bytes to enable processing.
@@ -75,13 +71,9 @@ func (p Group) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
 
 // Byte processes bytes with the Group processor.
 func (p Group) Byte(ctx context.Context, data []byte) ([]byte, error) {
-	// only supports json arrays, error early if there are no keys
+	// only supports JSON arrays, error early if there are no keys
 	if p.InputKey == "" && p.OutputKey == "" {
-		return nil, fmt.Errorf("byter settings %v: %v", p, GroupInvalidSettings)
-	}
-
-	if !json.Get(data, p.InputKey).Exists() {
-		return data, nil
+		return nil, fmt.Errorf("byter settings %+v: %v", p, ProcessorInvalidSettings)
 	}
 
 	if len(p.Options.Keys) == 0 {
@@ -122,22 +114,23 @@ func (p Group) Byte(ctx context.Context, data []byte) ([]byte, error) {
 		for x1, v1 := range v.Array() {
 			cache[x1], err = json.Set(cache[x1], p.Options.Keys[x], v1)
 			if err != nil {
-				return nil, fmt.Errorf("byter settings %v: %v", p, err)
+				return nil, fmt.Errorf("byter settings %+v: %v", p, err)
 			}
 		}
 	}
 
 	// inserts pre-formatted JSON into an array based
-	// 	on the length of the map
-	// pre-formatted JSON requires use of SetRaw
+	// on the length of the map
 	var tmp []byte
 	for i := 0; i < len(cache); i++ {
-		tmp, err = json.SetRaw(tmp, fmt.Sprintf("%d", i), cache[i])
+		tmp, err = json.Set(tmp, fmt.Sprintf("%d", i), cache[i])
 		if err != nil {
-			return nil, fmt.Errorf("byter settings %v: %v", p, err)
+			return nil, fmt.Errorf("byter settings %+v: %v", p, err)
 		}
 	}
 
+	// JSON arrays must be set using SetRaw to preserve structure
+	//
 	// [{"name":"foo","size":123},{"name":"bar","size":456}]
 	return json.SetRaw(data, p.OutputKey, tmp)
 }

--- a/process/group_test.go
+++ b/process/group_test.go
@@ -10,9 +10,9 @@ import (
 var groupTests = []struct {
 	name     string
 	proc     Group
-	err      error
 	test     []byte
 	expected []byte
+	err      error
 }{
 	{
 		"tuples",
@@ -20,9 +20,9 @@ var groupTests = []struct {
 			InputKey:  "group",
 			OutputKey: "group",
 		},
-		nil,
 		[]byte(`{"group":[["foo","bar"],[123,456]]}`),
 		[]byte(`{"group":[["foo",123],["bar",456]]}`),
+		nil,
 	},
 	{
 		"objects",
@@ -33,16 +33,16 @@ var groupTests = []struct {
 			InputKey:  "group",
 			OutputKey: "group",
 		},
-		nil,
 		[]byte(`{"group":[["foo","bar"],[123,456]]}`),
 		[]byte(`{"group":[{"name":{"test":"foo"},"size":123},{"name":{"test":"bar"},"size":456}]}`),
+		nil,
 	},
 	{
 		"invalid settings",
 		Group{},
+		[]byte{},
+		[]byte{},
 		ProcessorInvalidSettings,
-		[]byte{},
-		[]byte{},
 	},
 }
 
@@ -50,7 +50,7 @@ func TestGroup(t *testing.T) {
 	ctx := context.TODO()
 	for _, test := range groupTests {
 		res, err := test.proc.Byte(ctx, test.test)
-		if err != nil && errors.As(err, &test.err) {
+		if err != nil && errors.Is(err, test.err) {
 			continue
 		} else if err != nil {
 			t.Log(err)

--- a/process/group_test.go
+++ b/process/group_test.go
@@ -3,12 +3,14 @@ package process
 import (
 	"bytes"
 	"context"
+	"errors"
 	"testing"
 )
 
 var groupTests = []struct {
 	name     string
 	proc     Group
+	err      error
 	test     []byte
 	expected []byte
 }{
@@ -18,32 +20,29 @@ var groupTests = []struct {
 			InputKey:  "group",
 			OutputKey: "group",
 		},
+		nil,
 		[]byte(`{"group":[["foo","bar"],[123,456]]}`),
 		[]byte(`{"group":[["foo",123],["bar",456]]}`),
 	},
 	{
 		"objects",
 		Group{
-			InputKey:  "group",
-			OutputKey: "group",
 			Options: GroupOptions{
 				Keys: []string{"name.test", "size"},
 			},
+			InputKey:  "group",
+			OutputKey: "group",
 		},
+		nil,
 		[]byte(`{"group":[["foo","bar"],[123,456]]}`),
 		[]byte(`{"group":[{"name":{"test":"foo"},"size":123},{"name":{"test":"bar"},"size":456}]}`),
 	},
 	{
-		"null input",
-		Group{
-			InputKey:  "group",
-			OutputKey: "group",
-			Options: GroupOptions{
-				Keys: []string{"name.test", "size"},
-			},
-		},
-		[]byte(`{"foo":"bar"}`),
-		[]byte(`{"foo":"bar"}`),
+		"invalid settings",
+		Group{},
+		ProcessorInvalidSettings,
+		[]byte{},
+		[]byte{},
 	},
 }
 
@@ -51,8 +50,10 @@ func TestGroup(t *testing.T) {
 	ctx := context.TODO()
 	for _, test := range groupTests {
 		res, err := test.proc.Byte(ctx, test.test)
-		if err != nil {
-			t.Logf("%v", err)
+		if err != nil && errors.As(err, &test.err) {
+			continue
+		} else if err != nil {
+			t.Log(err)
 			t.Fail()
 		}
 

--- a/process/gzip.go
+++ b/process/gzip.go
@@ -32,7 +32,9 @@ The processor uses this Jsonnet configuration:
 	{
 		type: 'gzip',
 		settings: {
-			direction: 'from',
+			options: {
+				direction: 'from',
+			},
 		},
 	}
 */
@@ -45,14 +47,14 @@ type Gzip struct {
 func (p Gzip) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
 	op, err := condition.OperatorFactory(p.Condition)
 	if err != nil {
-		return nil, fmt.Errorf("slicer settings %v: %v", p, err)
+		return nil, fmt.Errorf("slicer settings %+v: %w", p, err)
 	}
 
 	slice := NewSlice(&s)
 	for _, data := range s {
 		ok, err := op.Operate(data)
 		if err != nil {
-			return nil, fmt.Errorf("slicer settings %v: %v", p, err)
+			return nil, fmt.Errorf("slicer settings %+v: %w", p, err)
 		}
 
 		if !ok {
@@ -74,27 +76,27 @@ func (p Gzip) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
 func (p Gzip) Byte(ctx context.Context, data []byte) ([]byte, error) {
 	// error early if required options are missing
 	if p.Options.Direction == "" {
-		return nil, fmt.Errorf("byter settings %+v: %v", p, ProcessorInvalidSettings)
+		return nil, fmt.Errorf("byter settings %+v: %w", p, ProcessorInvalidSettings)
 	}
 
 	switch s := p.Options.Direction; s {
 	case "from":
 		tmp, err := p.from(data)
 		if err != nil {
-			return nil, fmt.Errorf("byter settings %+v: %v", p, err)
+			return nil, fmt.Errorf("byter settings %+v: %w", p, err)
 		}
 
 		return tmp, nil
 	case "to":
 		tmp, err := p.to(data)
 		if err != nil {
-			return nil, fmt.Errorf("byter settings %+v: %v", p, err)
+			return nil, fmt.Errorf("byter settings %+v: %w", p, err)
 		}
 
 		return tmp, nil
-	default:
-		return nil, fmt.Errorf("byter settings %+v: %v", p, ProcessorInvalidDirection)
 	}
+
+	return nil, fmt.Errorf("byter settings %+v: %w", p, ProcessorInvalidSettings)
 }
 
 func (p Gzip) from(data []byte) ([]byte, error) {

--- a/process/gzip_test.go
+++ b/process/gzip_test.go
@@ -10,9 +10,9 @@ import (
 var gzipTests = []struct {
 	name     string
 	proc     Gzip
-	err      error
 	test     []byte
 	expected []byte
+	err      error
 }{
 	{
 		"from",
@@ -21,9 +21,9 @@ var gzipTests = []struct {
 				Direction: "from",
 			},
 		},
-		nil,
 		[]byte{31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 74, 203, 207, 7, 4, 0, 0, 255, 255, 33, 101, 115, 140, 3, 0, 0, 0},
 		[]byte(`foo`),
+		nil,
 	},
 	{
 		"to",
@@ -32,23 +32,16 @@ var gzipTests = []struct {
 				Direction: "to",
 			},
 		},
-		nil,
 		[]byte(`foo`),
 		[]byte{31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 74, 203, 207, 7, 4, 0, 0, 255, 255, 33, 101, 115, 140, 3, 0, 0, 0},
+		nil,
 	},
 	{
 		"missing required options",
 		Gzip{},
+		[]byte{},
+		[]byte{},
 		ProcessorInvalidSettings,
-		[]byte{},
-		[]byte{},
-	},
-	{
-		"unsupported direction",
-		Gzip{},
-		ProcessorInvalidDirection,
-		[]byte(`foo`),
-		[]byte{},
 	},
 }
 
@@ -56,7 +49,7 @@ func TestGzip(t *testing.T) {
 	ctx := context.TODO()
 	for _, test := range gzipTests {
 		res, err := test.proc.Byte(ctx, test.test)
-		if err != nil && errors.As(err, &test.err) {
+		if err != nil && errors.Is(err, test.err) {
 			continue
 		} else if err != nil {
 			t.Log(err)

--- a/process/hash_test.go
+++ b/process/hash_test.go
@@ -10,77 +10,77 @@ import (
 var hashTests = []struct {
 	name     string
 	proc     Hash
-	err      error
 	test     []byte
 	expected []byte
+	err      error
 }{
 	{
-		"json md5",
+		"JSON md5",
 		Hash{
-			InputKey:  "hash",
-			OutputKey: "hash",
 			Options: HashOptions{
 				Algorithm: "md5",
 			},
+			InputKey:  "foo",
+			OutputKey: "foo",
 		},
+		[]byte(`{"foo":"bar"}`),
+		[]byte(`{"foo":"37b51d194a7513e45b56f6524f2d51f2"}`),
 		nil,
-		[]byte(`{"hash":"foo"}`),
-		[]byte(`{"hash":"acbd18db4cc2f85cedef654fccc4a4d8"}`),
 	},
 	{
-		"json sha256",
+		"JSON sha256",
 		Hash{
-			InputKey:  "hash",
-			OutputKey: "hash",
+			Options: HashOptions{
+				Algorithm: "sha256",
+			},
+			InputKey:  "foo",
+			OutputKey: "foo",
+		},
+		[]byte(`{"foo":"bar"}`),
+		[]byte(`{"foo":"fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9"}`),
+		nil,
+	},
+	{
+		"JSON @this sha256",
+		Hash{
+			InputKey:  "@this",
+			OutputKey: "foo",
 			Options: HashOptions{
 				Algorithm: "sha256",
 			},
 		},
+		[]byte(`{"foo":"bar"}`),
+		[]byte(`{"foo":"7a38bf81f383f69433ad6e900d35b3e2385593f76a7b7ab5d4355b8ba41ee24b"}`),
 		nil,
-		[]byte(`{"hash":"foo"}`),
-		[]byte(`{"hash":"2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"}`),
 	},
 	{
-		"json @this md5",
-		Hash{
-			InputKey:  "@this",
-			OutputKey: "hash",
-			Options: HashOptions{
-				Algorithm: "md5",
-			},
-		},
-		nil,
-		[]byte(`{"hash":"foo"}`),
-		[]byte(`{"hash":"92568430636b469705c89466dfd39646"}`),
-	},
-	{
-		"data",
+		"data md5",
 		Hash{
 			Options: HashOptions{
 				Algorithm: "md5",
 			},
 		},
-		nil,
 		[]byte(`foo`),
 		[]byte(`acbd18db4cc2f85cedef654fccc4a4d8`),
+		nil,
 	},
 	{
-		"missing required options",
-		Hash{},
-		ProcessorInvalidSettings,
-		[]byte{},
-		[]byte{},
-	},
-	{
-		"unsupported algorithm",
+		"data sha256",
 		Hash{
 			Options: HashOptions{
-				Algorithm: "foo",
+				Algorithm: "sha256",
 			},
 		},
-		HashUnsupportedAlgorithm,
 		[]byte(`foo`),
+		[]byte(`2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae`),
+		nil,
+	},
+	{
+		"invalid settings",
+		Hash{},
 		[]byte{},
+		[]byte{},
+		ProcessorInvalidSettings,
 	},
 }
 
@@ -88,7 +88,7 @@ func TestHash(t *testing.T) {
 	ctx := context.TODO()
 	for _, test := range hashTests {
 		res, err := test.proc.Byte(ctx, test.test)
-		if err != nil && errors.As(err, &test.err) {
+		if err != nil && errors.Is(err, test.err) {
 			continue
 		} else if err != nil {
 			t.Log(err)

--- a/process/insert.go
+++ b/process/insert.go
@@ -5,12 +5,8 @@ import (
 	"fmt"
 
 	"github.com/brexhq/substation/condition"
-	"github.com/brexhq/substation/internal/errors"
 	"github.com/brexhq/substation/internal/json"
 )
-
-// InsertInvalidSettings is returned when the Insert processor is configured with invalid Input and Output settings.
-const InsertInvalidSettings = errors.Error("InsertInvalidSettings")
 
 /*
 InsertOptions contains custom options for the Insert processor:
@@ -38,9 +34,9 @@ The processor uses this Jsonnet configuration:
 	}
 */
 type Insert struct {
+	Options   InsertOptions            `json:"options"`
 	Condition condition.OperatorConfig `json:"condition"`
 	OutputKey string                   `json:"output_key"`
-	Options   InsertOptions            `json:"options"`
 }
 
 // Slice processes a slice of bytes with the Insert processor. Conditions are optionally applied on the bytes to enable processing.
@@ -74,10 +70,10 @@ func (p Insert) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
 
 // Byte processes bytes with the Insert processor.
 func (p Insert) Byte(ctx context.Context, data []byte) ([]byte, error) {
-	// json processing
+	// JSON processing
 	if p.OutputKey != "" {
 		return json.Set(data, p.OutputKey, p.Options.Value)
 	}
 
-	return nil, fmt.Errorf("byter settings %v: %v", p, InsertInvalidSettings)
+	return nil, fmt.Errorf("byter settings %+v: %v", p, ProcessorInvalidSettings)
 }

--- a/process/insert_test.go
+++ b/process/insert_test.go
@@ -10,9 +10,9 @@ import (
 var insertTests = []struct {
 	name     string
 	proc     Insert
-	err      error
 	test     []byte
 	expected []byte
+	err      error
 }{
 	{
 		"byte",
@@ -22,9 +22,9 @@ var insertTests = []struct {
 			},
 			OutputKey: "foo",
 		},
-		nil,
 		[]byte{},
 		[]byte(`{"foo":"bar"}`),
+		nil,
 	},
 	{
 		"string",
@@ -34,9 +34,9 @@ var insertTests = []struct {
 			},
 			OutputKey: "foo",
 		},
-		nil,
 		[]byte{},
 		[]byte(`{"foo":"bar"}`),
+		nil,
 	},
 	{
 		"int",
@@ -44,11 +44,11 @@ var insertTests = []struct {
 			Options: InsertOptions{
 				Value: 10,
 			},
-			OutputKey: "int",
+			OutputKey: "foo",
 		},
-		nil,
 		[]byte(`{"foo":"bar"}`),
-		[]byte(`{"foo":"bar","int":10}`),
+		[]byte(`{"foo":10}`),
+		nil,
 	},
 	{
 		"string array",
@@ -56,11 +56,11 @@ var insertTests = []struct {
 			Options: InsertOptions{
 				Value: []string{"bar", "baz", "qux"},
 			},
-			OutputKey: "array",
+			OutputKey: "foo",
 		},
-		nil,
 		[]byte(`{"foo":"bar"}`),
-		[]byte(`{"foo":"bar","array":["bar","baz","qux"]}`),
+		[]byte(`{"foo":["bar","baz","qux"]}`),
+		nil,
 	},
 	{
 		"map",
@@ -70,11 +70,11 @@ var insertTests = []struct {
 					"baz": "qux",
 				},
 			},
-			OutputKey: "map",
+			OutputKey: "foo",
 		},
-		nil,
 		[]byte(`{"foo":"bar"}`),
-		[]byte(`{"foo":"bar","map":{"baz":"qux"}}`),
+		[]byte(`{"foo":{"baz":"qux"}}`),
+		nil,
 	},
 	{
 		"JSON",
@@ -82,30 +82,30 @@ var insertTests = []struct {
 			Options: InsertOptions{
 				Value: `{"baz":"qux"}`,
 			},
-			OutputKey: "insert",
+			OutputKey: "foo",
 		},
-		nil,
 		[]byte(`{"foo":"bar"}`),
-		[]byte(`{"foo":"bar","insert":{"baz":"qux"}}`),
+		[]byte(`{"foo":{"baz":"qux"}}`),
+		nil,
 	},
 	{
 		"zlib",
 		Insert{
 			Options: InsertOptions{
-				Value: []byte{120, 156, 5, 192, 33, 13, 0, 0, 0, 128, 176, 182, 216, 247, 119, 44, 6, 2, 130, 1, 69},
+				Value: []byte{120, 156, 5, 192, 49, 13, 0, 0, 0, 194, 48, 173, 76, 2, 254, 143, 166, 29, 2, 93, 1, 54},
 			},
-			OutputKey: "insert",
+			OutputKey: "foo",
 		},
-		nil,
 		[]byte(`{"foo":"bar"}`),
-		[]byte(`{"foo":"bar","insert":"eJwFwCENAAAAgLC22Pd3LAYCggFF"}`),
+		[]byte(`{"foo":"eJwFwDENAAAAwjCtTAL+j6YdAl0BNg=="}`),
+		nil,
 	},
 	{
-		"missing required options",
+		"invalid settings",
 		Insert{},
+		[]byte{},
+		[]byte{},
 		ProcessorInvalidSettings,
-		[]byte{},
-		[]byte{},
 	},
 }
 
@@ -113,7 +113,7 @@ func TestInsert(t *testing.T) {
 	ctx := context.TODO()
 	for _, test := range insertTests {
 		res, err := test.proc.Byte(ctx, test.test)
-		if err != nil && errors.As(err, &test.err) {
+		if err != nil && errors.Is(err, test.err) {
 			continue
 		} else if err != nil {
 			t.Log(err)

--- a/process/lambda_test.go
+++ b/process/lambda_test.go
@@ -25,23 +25,23 @@ func (m mockedInvoke) InvokeWithContext(ctx aws.Context, input *lambda.InvokeInp
 var lambdaTests = []struct {
 	name     string
 	proc     Lambda
-	err      error
 	test     []byte
 	expected []byte
+	err      error
 	api      lamb.API
 }{
 	{
-		"json",
+		"JSON",
 		Lambda{
-			InputKey:  "lambda",
-			OutputKey: "lambda",
 			Options: LambdaOptions{
-				Function: "test",
+				Function: "fooer",
 			},
+			InputKey:  "foo",
+			OutputKey: "foo",
 		},
+		[]byte(`{"foo":{"bar":"baz"}}`),
+		[]byte(`{"foo":{"baz":"qux"}}`),
 		nil,
-		[]byte(`{"foo":"bar","lambda":{"foo":"baz"}}`),
-		[]byte(`{"foo":"bar","lambda":{"baz":"qux"}}`),
 		lamb.API{
 			Client: mockedInvoke{
 				Resp: lambda.InvokeOutput{
@@ -51,15 +51,11 @@ var lambdaTests = []struct {
 		},
 	},
 	{
-		"missing required options",
-		Lambda{
-			InputKey:  "lambda",
-			OutputKey: "lambda",
-			Options:   LambdaOptions{},
-		},
-		nil,
+		"invalid settings",
+		Lambda{},
 		[]byte{},
 		[]byte{},
+		ProcessorInvalidSettings,
 		lamb.API{
 			Client: mockedInvoke{
 				Resp: lambda.InvokeOutput{
@@ -75,7 +71,7 @@ func TestLambda(t *testing.T) {
 	for _, test := range lambdaTests {
 		lambdaAPI = test.api
 		res, err := test.proc.Byte(ctx, test.test)
-		if err != nil && errors.As(err, &test.err) {
+		if err != nil && errors.Is(err, test.err) {
 			continue
 		} else if err != nil {
 			t.Log(err)

--- a/process/math_test.go
+++ b/process/math_test.go
@@ -3,86 +3,55 @@ package process
 import (
 	"bytes"
 	"context"
+	"errors"
 	"testing"
 )
 
 var mathTests = []struct {
 	name     string
 	proc     Math
+	err      error
 	test     []byte
 	expected []byte
 }{
 	{
 		"add",
 		Math{
-			InputKey:  "math",
-			OutputKey: "math",
 			Options: MathOptions{
 				Operation: "add",
 			},
+			InputKey:  "math",
+			OutputKey: "math",
 		},
+		nil,
 		[]byte(`{"math":[1,3]}`),
 		[]byte(`{"math":4}`),
 	},
 	{
 		"subtract",
 		Math{
-			InputKey:  "math",
-			OutputKey: "math",
 			Options: MathOptions{
 				Operation: "subtract",
 			},
+			InputKey:  "math",
+			OutputKey: "math",
 		},
+		nil,
 		[]byte(`{"math":[5,2]}`),
 		[]byte(`{"math":3}`),
 	},
 	{
 		"divide",
 		Math{
-			InputKey:  "math",
-			OutputKey: "math",
 			Options: MathOptions{
 				Operation: "divide",
 			},
+			InputKey:  "math",
+			OutputKey: "math",
 		},
+		nil,
 		[]byte(`{"math":[10,2]}`),
 		[]byte(`{"math":5}`),
-	},
-	{
-		"add array",
-		Math{
-			InputKey:  "math",
-			OutputKey: "math",
-			Options: MathOptions{
-				Operation: "add",
-			},
-		},
-		[]byte(`{"math":[[1,2],[3,4]]}`),
-		[]byte(`{"math":[4,6]}`),
-	},
-	{
-		"subtract array",
-		Math{
-			InputKey:  "math",
-			OutputKey: "math",
-			Options: MathOptions{
-				Operation: "subtract",
-			},
-		},
-		[]byte(`{"math":[[10,5],[4,1]]}`),
-		[]byte(`{"math":[6,4]}`),
-	},
-	{
-		"divide array",
-		Math{
-			InputKey:  "math",
-			OutputKey: "math",
-			Options: MathOptions{
-				Operation: "divide",
-			},
-		},
-		[]byte(`{"math":[[10,5],[5,1]]}`),
-		[]byte(`{"math":[2,5]}`),
 	},
 }
 
@@ -90,8 +59,10 @@ func TestMath(t *testing.T) {
 	for _, test := range mathTests {
 		ctx := context.TODO()
 		res, err := test.proc.Byte(ctx, test.test)
-		if err != nil {
-			t.Logf("%v", err)
+		if err != nil && errors.As(err, &test.err) {
+			continue
+		} else if err != nil {
+			t.Log(err)
 			t.Fail()
 		}
 

--- a/process/math_test.go
+++ b/process/math_test.go
@@ -10,9 +10,9 @@ import (
 var mathTests = []struct {
 	name     string
 	proc     Math
-	err      error
 	test     []byte
 	expected []byte
+	err      error
 }{
 	{
 		"add",
@@ -20,12 +20,12 @@ var mathTests = []struct {
 			Options: MathOptions{
 				Operation: "add",
 			},
-			InputKey:  "math",
-			OutputKey: "math",
+			InputKey:  "foo",
+			OutputKey: "foo",
 		},
+		[]byte(`{"foo":[1,3]}`),
+		[]byte(`{"foo":4}`),
 		nil,
-		[]byte(`{"math":[1,3]}`),
-		[]byte(`{"math":4}`),
 	},
 	{
 		"subtract",
@@ -33,12 +33,25 @@ var mathTests = []struct {
 			Options: MathOptions{
 				Operation: "subtract",
 			},
-			InputKey:  "math",
-			OutputKey: "math",
+			InputKey:  "foo",
+			OutputKey: "foo",
 		},
+		[]byte(`{"foo":[5,2]}`),
+		[]byte(`{"foo":3}`),
 		nil,
-		[]byte(`{"math":[5,2]}`),
-		[]byte(`{"math":3}`),
+	},
+	{
+		"multiply",
+		Math{
+			Options: MathOptions{
+				Operation: "multiply",
+			},
+			InputKey:  "foo",
+			OutputKey: "foo",
+		},
+		[]byte(`{"foo":[10,2]}`),
+		[]byte(`{"foo":20}`),
+		nil,
 	},
 	{
 		"divide",
@@ -46,21 +59,19 @@ var mathTests = []struct {
 			Options: MathOptions{
 				Operation: "divide",
 			},
-			InputKey:  "math",
-			OutputKey: "math",
+			InputKey:  "foo",
+			OutputKey: "foo",
 		},
+		[]byte(`{"foo":[10,2]}`),
+		[]byte(`{"foo":5}`),
 		nil,
-		[]byte(`{"math":[10,2]}`),
-		[]byte(`{"math":5}`),
 	},
 	{
-		"missing required options",
-		Math{
-			Options: MathOptions{},
-		},
+		"invalid settings",
+		Math{},
+		[]byte{},
+		[]byte{},
 		ProcessorInvalidSettings,
-		[]byte{},
-		[]byte{},
 	},
 }
 
@@ -68,7 +79,7 @@ func TestMath(t *testing.T) {
 	for _, test := range mathTests {
 		ctx := context.TODO()
 		res, err := test.proc.Byte(ctx, test.test)
-		if err != nil && errors.As(err, &test.err) {
+		if err != nil && errors.Is(err, test.err) {
 			continue
 		} else if err != nil {
 			t.Log(err)

--- a/process/math_test.go
+++ b/process/math_test.go
@@ -53,6 +53,15 @@ var mathTests = []struct {
 		[]byte(`{"math":[10,2]}`),
 		[]byte(`{"math":5}`),
 	},
+	{
+		"missing required options",
+		Math{
+			Options: MathOptions{},
+		},
+		ProcessorInvalidSettings,
+		[]byte{},
+		[]byte{},
+	},
 }
 
 func TestMath(t *testing.T) {

--- a/process/pipeline.go
+++ b/process/pipeline.go
@@ -1,0 +1,141 @@
+package process
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/brexhq/substation/condition"
+	"github.com/brexhq/substation/internal/config"
+	"github.com/brexhq/substation/internal/errors"
+	"github.com/brexhq/substation/internal/json"
+)
+
+// PipelineArrayInput is returned when the Pipeline processor is configured to process JSON, but the input is an array. Array values are not supported by this processor, instead the input should be run through the ForEach processor (which can encapsulate the Pipeline processor).
+const PipelineArrayInput = errors.Error("PipelineArrayInput")
+
+/*
+PipelineOptions contains custom options for the Pipeline processor:
+	Processors:
+		array of processors to apply to the data
+*/
+type PipelineOptions struct {
+	Processors []config.Config
+}
+
+/*
+Pipeline processes data by applying a series of processors. This processor should be used when data requires complex processing outside of the boundaries of any data structures (see tests for examples). The processor supports these patterns:
+	json:
+		{"pipeline":"H4sIAMpcy2IA/wXAIQ0AAACAsLbY93csBiFlc4wDAAAA"} >>> {"pipeline":"foo"}
+	data:
+		H4sIAMpcy2IA/wXAIQ0AAACAsLbY93csBiFlc4wDAAAA >> foo
+
+The processor uses this Jsonnet configuration:
+	{
+		type: 'pipeline',
+		settings: {
+			input_key: 'pipeline',
+			output_key: 'pipeline',
+			options: {
+				processors: [
+					{
+						type: 'base64',
+						settings: {
+							options: {
+								direction: 'from',
+							}
+						}
+					},
+					{
+						type: 'gzip',
+						settings: {
+							options: {
+								direction: 'from',
+							}
+						}
+					},
+				]
+			}
+		},
+	}
+*/
+type Pipeline struct {
+	Condition condition.OperatorConfig `json:"condition"`
+	Options   PipelineOptions          `json:"options"`
+	InputKey  string                   `json:"input_key"`
+	OutputKey string                   `json:"output_key"`
+}
+
+// Slice processes a slice of bytes with the Pipeline processor. Conditions are optionally applied on the bytes to enable processing.
+func (p Pipeline) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
+	op, err := condition.OperatorFactory(p.Condition)
+	if err != nil {
+		return nil, fmt.Errorf("slicer settings %v: %v", p, err)
+	}
+
+	slice := NewSlice(&s)
+	for _, data := range s {
+		ok, err := op.Operate(data)
+		if err != nil {
+			return nil, fmt.Errorf("slicer settings %v: %v", p, err)
+		}
+
+		if !ok {
+			slice = append(slice, data)
+			continue
+		}
+
+		processed, err := p.Byte(ctx, data)
+		if err != nil {
+			return nil, fmt.Errorf("slicer: %v", err)
+		}
+		slice = append(slice, processed)
+	}
+
+	return slice, nil
+}
+
+/*
+Byte processes bytes with the Pipeline processor.
+
+Process Byters only accept bytes, so when processing
+JSON the input value is converted from Result to its
+string representation to bytes. The conversion from
+Result to string is safe for strings and objects, but
+not arrays (e.g., ["foo","bar"]).
+
+If the input is an array, then an error is raised; the
+input should be run through the ForEach processor (which
+can encapsulate the Pipeline processor).
+*/
+func (p Pipeline) Byte(ctx context.Context, data []byte) ([]byte, error) {
+	byters, err := MakeAllByters(p.Options.Processors)
+	if err != nil {
+		return nil, fmt.Errorf("byter settings %v: %v", p, err)
+	}
+
+	if p.InputKey != "" && p.OutputKey != "" {
+		value := json.Get(data, p.InputKey)
+		if value.IsArray() {
+			return nil, fmt.Errorf("byter settings %v: %v", p, PipelineArrayInput)
+		}
+
+		tmp, err := Byte(ctx, byters, []byte(value.String()))
+		if err != nil {
+			return nil, fmt.Errorf("byter settings %v: %v", p, err)
+		}
+
+		return json.Set(data, p.OutputKey, tmp)
+	}
+
+	// data processing
+	if p.InputKey == "" && p.OutputKey == "" {
+		tmp, err := Byte(ctx, byters, data)
+		if err != nil {
+			return nil, fmt.Errorf("byter settings %v: %v", p, err)
+		}
+
+		return tmp, nil
+	}
+
+	return nil, fmt.Errorf("byter settings %v: %v", p, ProcessorInvalidSettings)
+}

--- a/process/pipeline_test.go
+++ b/process/pipeline_test.go
@@ -1,0 +1,142 @@
+package process
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/brexhq/substation/internal/config"
+)
+
+var PipelineTests = []struct {
+	name     string
+	proc     Pipeline
+	err      error
+	test     []byte
+	expected []byte
+}{
+	{
+		"json",
+		Pipeline{
+			InputKey:  "pipeline",
+			OutputKey: "pipeline",
+			Options: PipelineOptions{
+				Processors: []config.Config{
+					{
+						Type: "base64",
+						Settings: map[string]interface{}{
+							"options": map[string]interface{}{
+								"direction": "from",
+							},
+						},
+					},
+					{
+						Type: "gzip",
+						Settings: map[string]interface{}{
+							"options": map[string]interface{}{
+								"direction": "from",
+							},
+						},
+					},
+				},
+			},
+		},
+		nil,
+		[]byte(`{"pipeline":"H4sIAMpcy2IA/wXAIQ0AAACAsLbY93csBiFlc4wDAAAA"}`),
+		[]byte(`{"pipeline":"foo"}`),
+	},
+	{
+		"data",
+		Pipeline{
+			Options: PipelineOptions{
+				Processors: []config.Config{
+					{
+						Type: "base64",
+						Settings: map[string]interface{}{
+							"options": map[string]interface{}{
+								"direction": "from",
+							},
+						},
+					},
+					{
+						Type: "gzip",
+						Settings: map[string]interface{}{
+							"options": map[string]interface{}{
+								"direction": "from",
+							},
+						},
+					},
+				},
+			},
+		},
+		nil,
+		[]byte(`{"pipeline":"H4sIAMpcy2IA/wXAIQ0AAACAsLbY93csBiFlc4wDAAAA"}`),
+		[]byte(`foo`),
+	},
+	{
+		"array",
+		Pipeline{
+			InputKey:  "pipeline",
+			OutputKey: "pipeline",
+			Options: PipelineOptions{
+				Processors: []config.Config{
+					{
+						Type: "base64",
+						Settings: map[string]interface{}{
+							"options": map[string]interface{}{
+								"direction": "from",
+							},
+						},
+					},
+					{
+						Type: "gzip",
+						Settings: map[string]interface{}{
+							"options": map[string]interface{}{
+								"direction": "from",
+							},
+						},
+					},
+				},
+			},
+		},
+		PipelineArrayInput,
+		[]byte(`{"pipeline":["H4sIAMpcy2IA/wXAIQ0AAACAsLbY93csBiFlc4wDAAAA"]}`),
+		[]byte{},
+	},
+}
+
+func TestPipeline(t *testing.T) {
+	for _, test := range PipelineTests {
+		ctx := context.TODO()
+		res, err := test.proc.Byte(ctx, test.test)
+		if err != nil && errors.As(err, &test.err) {
+			continue
+		} else if err != nil {
+			t.Log(err)
+			t.Fail()
+		}
+
+		if c := bytes.Compare(res, test.expected); c != 0 {
+			t.Logf("expected %s, got %s", test.expected, res)
+			t.Fail()
+		}
+	}
+}
+
+func benchmarkPipelineByte(b *testing.B, byter Pipeline, test []byte) {
+	ctx := context.TODO()
+	for i := 0; i < b.N; i++ {
+		byter.Byte(ctx, test)
+	}
+}
+
+func BenchmarkPipelineByte(b *testing.B) {
+	for _, test := range PipelineTests {
+		b.Run(string(test.name),
+			func(b *testing.B) {
+				benchmarkPipelineByte(b, test.proc, test.test)
+			},
+		)
+	}
+}

--- a/process/pipeline_test.go
+++ b/process/pipeline_test.go
@@ -12,15 +12,13 @@ import (
 var PipelineTests = []struct {
 	name     string
 	proc     Pipeline
-	err      error
 	test     []byte
 	expected []byte
+	err      error
 }{
 	{
 		"json",
 		Pipeline{
-			InputKey:  "pipeline",
-			OutputKey: "pipeline",
 			Options: PipelineOptions{
 				Processors: []config.Config{
 					{
@@ -41,10 +39,12 @@ var PipelineTests = []struct {
 					},
 				},
 			},
+			InputKey:  "foo",
+			OutputKey: "foo",
 		},
+		[]byte(`{"foo":"H4sIAKi91GIA/wXAMQ0AAADCMK1MAv6Pph2qjP92AwAAAA=="}`),
+		[]byte(`{"foo":"bar"}`),
 		nil,
-		[]byte(`{"pipeline":"H4sIAMpcy2IA/wXAIQ0AAACAsLbY93csBiFlc4wDAAAA"}`),
-		[]byte(`{"pipeline":"foo"}`),
 	},
 	{
 		"data",
@@ -70,15 +70,20 @@ var PipelineTests = []struct {
 				},
 			},
 		},
-		nil,
-		[]byte(`{"pipeline":"H4sIAMpcy2IA/wXAIQ0AAACAsLbY93csBiFlc4wDAAAA"}`),
+		[]byte(`H4sIAO291GIA/wXAIQ0AAACAsLbY93csBiFlc4wDAAAA`),
 		[]byte(`foo`),
+		nil,
 	},
 	{
-		"array",
+		"invalid settings",
+		Pipeline{},
+		[]byte{},
+		[]byte{},
+		ProcessorInvalidSettings,
+	},
+	{
+		"invalid array input",
 		Pipeline{
-			InputKey:  "pipeline",
-			OutputKey: "pipeline",
 			Options: PipelineOptions{
 				Processors: []config.Config{
 					{
@@ -99,10 +104,12 @@ var PipelineTests = []struct {
 					},
 				},
 			},
+			InputKey:  "foo",
+			OutputKey: "foo",
 		},
-		PipelineArrayInput,
-		[]byte(`{"pipeline":["H4sIAMpcy2IA/wXAIQ0AAACAsLbY93csBiFlc4wDAAAA"]}`),
+		[]byte(`{"foo":["H4sIAMpcy2IA/wXAIQ0AAACAsLbY93csBiFlc4wDAAAA"]}`),
 		[]byte{},
+		PipelineArrayInput,
 	},
 }
 
@@ -110,7 +117,7 @@ func TestPipeline(t *testing.T) {
 	for _, test := range PipelineTests {
 		ctx := context.TODO()
 		res, err := test.proc.Byte(ctx, test.test)
-		if err != nil && errors.As(err, &test.err) {
+		if err != nil && errors.Is(err, test.err) {
 			continue
 		} else if err != nil {
 			t.Log(err)

--- a/process/process.go
+++ b/process/process.go
@@ -11,13 +11,10 @@ import (
 // ProcessorInvalidSettings is returned when a processor is configured with invalid settings. Common causes include improper input and output settings (e.g., missing keys) and missing required options.
 const ProcessorInvalidSettings = errors.Error("ProcessorInvalidSettings")
 
-// ProcessorInvalidDirection is returned when an invalid direction option is configured on a processor.
-const ProcessorInvalidDirection = errors.Error("ProcessorInvalidDirection")
-
-// ByteInvalidFactoryConfig is used when an unsupported Byte is referenced in ByteFactory.
+// ByteInvalidFactoryConfig is returned when an unsupported Byte is referenced in ByteFactory.
 const ByteInvalidFactoryConfig = errors.Error("ByteInvalidFactoryConfig")
 
-// SliceInvalidFactoryConfig is used when an unsupported Slice is referenced in SliceFactory.
+// SliceInvalidFactoryConfig is returned when an unsupported Slice is referenced in SliceFactory.
 const SliceInvalidFactoryConfig = errors.Error("SliceInvalidFactoryConfig")
 
 // Slicer is an interface for applying processors to slices of bytes.
@@ -142,7 +139,7 @@ func ByterFactory(cfg config.Config) (Byter, error) {
 		config.Decode(cfg.Settings, &p)
 		return p, nil
 	default:
-		return nil, fmt.Errorf("process settings %v: %v", cfg.Settings, ByteInvalidFactoryConfig)
+		return nil, fmt.Errorf("process settings %+v: %w", cfg.Settings, ByteInvalidFactoryConfig)
 	}
 }
 
@@ -242,7 +239,7 @@ func SlicerFactory(cfg config.Config) (Slicer, error) {
 		config.Decode(cfg.Settings, &p)
 		return p, nil
 	default:
-		return nil, fmt.Errorf("process settings %v: %v", cfg.Settings, SliceInvalidFactoryConfig)
+		return nil, fmt.Errorf("process settings %+v: %w", cfg.Settings, SliceInvalidFactoryConfig)
 	}
 }
 

--- a/process/process.go
+++ b/process/process.go
@@ -11,6 +11,9 @@ import (
 // ProcessorInvalidSettings is returned when a processor is configured with invalid settings. Common causes include improper input and output settings (e.g., missing keys) and missing required options.
 const ProcessorInvalidSettings = errors.Error("ProcessorInvalidSettings")
 
+// ProcessorInvalidDirection is returned when an invalid direction option is configured on a processor.
+const ProcessorInvalidDirection = errors.Error("ProcessorInvalidDirection")
+
 // ByteInvalidFactoryConfig is used when an unsupported Byte is referenced in ByteFactory.
 const ByteInvalidFactoryConfig = errors.Error("ByteInvalidFactoryConfig")
 

--- a/process/process.go
+++ b/process/process.go
@@ -8,6 +8,9 @@ import (
 	"github.com/brexhq/substation/internal/errors"
 )
 
+// ProcessorInvalidSettings is returned when a processor is configured with invalid settings. Common causes include improper input and output settings (e.g., missing keys) and missing required options.
+const ProcessorInvalidSettings = errors.Error("ProcessorInvalidSettings")
+
 // ByteInvalidFactoryConfig is used when an unsupported Byte is referenced in ByteFactory.
 const ByteInvalidFactoryConfig = errors.Error("ByteInvalidFactoryConfig")
 
@@ -95,6 +98,10 @@ func ByterFactory(cfg config.Config) (Byter, error) {
 		var p Flatten
 		config.Decode(cfg.Settings, &p)
 		return p, nil
+	case "for_each":
+		var p ForEach
+		config.Decode(cfg.Settings, &p)
+		return p, nil
 	case "group":
 		var p Group
 		config.Decode(cfg.Settings, &p)
@@ -117,6 +124,10 @@ func ByterFactory(cfg config.Config) (Byter, error) {
 		return p, nil
 	case "math":
 		var p Math
+		config.Decode(cfg.Settings, &p)
+		return p, nil
+	case "pipeline":
+		var p Pipeline
 		config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "replace":
@@ -187,6 +198,10 @@ func SlicerFactory(cfg config.Config) (Slicer, error) {
 		var p Flatten
 		config.Decode(cfg.Settings, &p)
 		return p, nil
+	case "for_each":
+		var p ForEach
+		config.Decode(cfg.Settings, &p)
+		return p, nil
 	case "group":
 		var p Group
 		config.Decode(cfg.Settings, &p)
@@ -209,6 +224,10 @@ func SlicerFactory(cfg config.Config) (Slicer, error) {
 		return p, nil
 	case "math":
 		var p Math
+		config.Decode(cfg.Settings, &p)
+		return p, nil
+	case "pipeline":
+		var p Pipeline
 		config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "replace":

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -16,19 +16,24 @@ var processTests = []struct {
 	{
 		[]config.Config{
 			{
+				Type: "copy",
+				Settings: map[string]interface{}{
+					"output_key": "foo",
+				},
+			},
+		},
+		[]byte(`bar`),
+		[]byte(`{"foo":"bar"}`),
+	},
+	{
+		[]config.Config{
+			{
 				Type: "insert",
 				Settings: map[string]interface{}{
-					"condition": struct {
-						Operator string
-					}{
-						Operator: "all",
-					},
-					"options": struct {
-						Value interface{}
-					}{
-						Value: "bar",
-					},
 					"output_key": "foo",
+					"options": map[string]interface{}{
+						"value": "bar",
+					},
 				},
 			},
 		},
@@ -40,15 +45,8 @@ var processTests = []struct {
 			{
 				Type: "gzip",
 				Settings: map[string]interface{}{
-					"condition": struct {
-						Operator string
-					}{
-						Operator: "all",
-					},
-					"options": struct {
-						Direction string
-					}{
-						Direction: "from",
+					"options": map[string]interface{}{
+						"direction": "from",
 					},
 				},
 			},
@@ -61,23 +59,31 @@ var processTests = []struct {
 			{
 				Type: "base64",
 				Settings: map[string]interface{}{
-					"condition": struct {
-						Operator string
-					}{
-						Operator: "all",
-					},
-					"options": struct {
-						Direction string
-						Alphabet  string
-					}{
-						Direction: "from",
-						Alphabet:  "std",
+					"options": map[string]interface{}{
+						"direction": "from",
 					},
 				},
 			},
 		},
 		[]byte(`eyJoZWxsbyI6IndvcmxkIn0=`),
 		[]byte(`{"hello":"world"}`),
+	},
+	{
+		[]config.Config{
+			{
+				Type: "time",
+				Settings: map[string]interface{}{
+					"input_key":  "foo",
+					"output_key": "foo",
+					"options": map[string]interface{}{
+						"input_format":  "unix",
+						"output_format": "2006-01-02T15:04:05.000000Z",
+					},
+				},
+			},
+		},
+		[]byte(`{"foo":1639877490}`),
+		[]byte(`{"foo":"2021-12-19T01:31:30.000000Z"}`),
 	},
 }
 

--- a/process/replace.go
+++ b/process/replace.go
@@ -7,12 +7,8 @@ import (
 	"strings"
 
 	"github.com/brexhq/substation/condition"
-	"github.com/brexhq/substation/internal/errors"
 	"github.com/brexhq/substation/internal/json"
 )
-
-// ReplaceInvalidSettings is returned when the Replace processor is configured with invalid Input and Output settings.
-const ReplaceInvalidSettings = errors.Error("ReplaceInvalidSettings")
 
 /*
 ReplaceOptions contains custom options for the Replace processor:
@@ -34,8 +30,6 @@ type ReplaceOptions struct {
 Replace processes data by replacing characters. The processor supports these patterns:
 	json:
 		{"replace":"bar"} >>> {"replace":"baz"}
-	json array:
-		{"replace":["bar","bard"]} >>> {"replace":["baz","bazd"]}
 	data:
 		bar >>> baz
 
@@ -53,10 +47,10 @@ The processor uses this Jsonnet configuration:
 	}
 */
 type Replace struct {
+	Options   ReplaceOptions           `json:"options"`
 	Condition condition.OperatorConfig `json:"condition"`
 	InputKey  string                   `json:"input_key"`
 	OutputKey string                   `json:"output_key"`
-	Options   ReplaceOptions           `json:"options"`
 }
 
 // Slice processes a slice of bytes with the Replace processor. Conditions are optionally applied on the bytes to enable processing.
@@ -90,6 +84,11 @@ func (p Replace) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
 
 // Byte processes bytes with the Replace processor.
 func (p Replace) Byte(ctx context.Context, data []byte) ([]byte, error) {
+	// error early if required options are missing
+	if p.Options.Old == "" || p.Options.New == "" {
+		return nil, fmt.Errorf("byter settings %+v: %v", p, ProcessorInvalidSettings)
+	}
+
 	// default to replace all
 	if p.Options.Count == 0 {
 		p.Options.Count = -1
@@ -98,19 +97,8 @@ func (p Replace) Byte(ctx context.Context, data []byte) ([]byte, error) {
 	// json processing
 	if p.InputKey != "" && p.OutputKey != "" {
 		value := json.Get(data, p.InputKey)
-		if !value.IsArray() {
-			r := p.stringsReplace(value.String())
-			return json.Set(data, p.OutputKey, r)
-		}
-
-		// json array processing
-		var array []string
-		for _, v := range value.Array() {
-			r := p.stringsReplace(v.String())
-			array = append(array, r)
-		}
-
-		return json.Set(data, p.OutputKey, array)
+		r := p.stringsReplace(value.String())
+		return json.Set(data, p.OutputKey, r)
 	}
 
 	// data processing
@@ -118,7 +106,7 @@ func (p Replace) Byte(ctx context.Context, data []byte) ([]byte, error) {
 		return p.bytesReplace(data), nil
 	}
 
-	return nil, fmt.Errorf("byter settings %v: %v", p, ReplaceInvalidSettings)
+	return nil, fmt.Errorf("byter settings %+v: %v", p, ProcessorInvalidSettings)
 }
 
 func (p Replace) stringsReplace(s string) string {

--- a/process/replace_test.go
+++ b/process/replace_test.go
@@ -10,9 +10,9 @@ import (
 var replaceTests = []struct {
 	name     string
 	proc     Replace
-	err      error
 	test     []byte
 	expected []byte
+	err      error
 }{
 	{
 		"json",
@@ -21,12 +21,12 @@ var replaceTests = []struct {
 				Old: "r",
 				New: "z",
 			},
-			InputKey:  "replace",
-			OutputKey: "replace",
+			InputKey:  "foo",
+			OutputKey: "foo",
 		},
+		[]byte(`{"foo":"bar"}`),
+		[]byte(`{"foo":"baz"}`),
 		nil,
-		[]byte(`{"replace":"bar"}`),
-		[]byte(`{"replace":"baz"}`),
 	},
 	{
 		"data",
@@ -36,18 +36,16 @@ var replaceTests = []struct {
 				New: "z",
 			},
 		},
-		nil,
 		[]byte(`bar`),
 		[]byte(`baz`),
+		nil,
 	},
 	{
-		"missing required options",
-		Replace{
-			Options: ReplaceOptions{},
-		},
-		nil,
+		"invalid settings",
+		Replace{},
 		[]byte{},
 		[]byte{},
+		ProcessorInvalidSettings,
 	},
 }
 
@@ -55,7 +53,7 @@ func TestReplace(t *testing.T) {
 	ctx := context.TODO()
 	for _, test := range replaceTests {
 		res, err := test.proc.Byte(ctx, test.test)
-		if err != nil && errors.As(err, &test.err) {
+		if err != nil && errors.Is(err, test.err) {
 			continue
 		} else if err != nil {
 			t.Log(err)

--- a/process/time.go
+++ b/process/time.go
@@ -42,7 +42,7 @@ type TimeOptions struct {
 
 /*
 Time processes data by converting time values between formats. The processor supports these patterns:
-	json:
+	JSON:
 		{"time":1639877490.061} >>> {"time":"2021-12-19T01:31:30.061000Z"}
 	data:
 		1639877490.061 >>> 2021-12-19T01:31:30.061000Z
@@ -51,12 +51,12 @@ The processor uses this Jsonnet configuration:
 	{
 		type: 'time',
 		settings: {
-			input_key: 'time',
-			output_key: 'time',
 			options: {
 				input_format: 'unix',
 				output_format: '2006-01-02T15:04:05.000000Z',
-			}
+			},
+			input_key: 'time',
+			output_key: 'time',
 		},
 	}
 */
@@ -71,14 +71,14 @@ type Time struct {
 func (p Time) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
 	op, err := condition.OperatorFactory(p.Condition)
 	if err != nil {
-		return nil, fmt.Errorf("slicer settings %v: %v", p, err)
+		return nil, fmt.Errorf("slicer settings %+v: %w", p, err)
 	}
 
 	slice := NewSlice(&s)
 	for _, data := range s {
 		ok, err := op.Operate(data)
 		if err != nil {
-			return nil, fmt.Errorf("slicer settings %v: %v", p, err)
+			return nil, fmt.Errorf("slicer settings %+v: %w", p, err)
 		}
 
 		if !ok {
@@ -100,7 +100,7 @@ func (p Time) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
 func (p Time) Byte(ctx context.Context, data []byte) ([]byte, error) {
 	// error early if required options are missing
 	if p.Options.InputFormat == "" || p.Options.OutputFormat == "" {
-		return nil, fmt.Errorf("byter settings %+v: %v", p, ProcessorInvalidSettings)
+		return nil, fmt.Errorf("byter settings %+v: %w", p, ProcessorInvalidSettings)
 	}
 
 	// "now" processing, supports json and data
@@ -140,7 +140,7 @@ func (p Time) Byte(ctx context.Context, data []byte) ([]byte, error) {
 
 		ts, err := p.time(value)
 		if err != nil {
-			return nil, fmt.Errorf("byter settings %+v: %v", p, err)
+			return nil, fmt.Errorf("byter settings %+v: %w", p, err)
 		}
 		return json.Set(data, p.OutputKey, ts)
 	}
@@ -149,13 +149,13 @@ func (p Time) Byte(ctx context.Context, data []byte) ([]byte, error) {
 	if p.InputKey == "" && p.OutputKey == "" {
 		tmp, err := json.Set([]byte{}, "_tmp", data)
 		if err != nil {
-			return nil, fmt.Errorf("byter settings %+v: %v", p, err)
+			return nil, fmt.Errorf("byter settings %+v: %w", p, err)
 		}
 
 		value := json.Get(tmp, "_tmp")
 		ts, err := p.time(value)
 		if err != nil {
-			return nil, fmt.Errorf("byter settings %+v: %v", p, err)
+			return nil, fmt.Errorf("byter settings %+v: %w", p, err)
 		}
 
 		switch v := ts.(type) {
@@ -166,7 +166,7 @@ func (p Time) Byte(ctx context.Context, data []byte) ([]byte, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("byter settings %+v: %v", p, ProcessorInvalidSettings)
+	return nil, fmt.Errorf("byter settings %+v: %w", p, ProcessorInvalidSettings)
 }
 
 func (p Time) time(v json.Result) (interface{}, error) {

--- a/process/time_test.go
+++ b/process/time_test.go
@@ -3,6 +3,7 @@ package process
 import (
 	"bytes"
 	"context"
+	"errors"
 	"testing"
 )
 
@@ -11,98 +12,156 @@ var outputFmt = "2006-01-02T15:04:05.000000Z"
 var timeTests = []struct {
 	name     string
 	proc     Time
+	err      error
 	test     []byte
 	expected []byte
 }{
 	{
-		"string",
+		"data string",
 		Time{
-			InputKey:  "time",
-			OutputKey: "time",
 			Options: TimeOptions{
 				InputFormat:  "2006-01-02T15:04:05Z",
 				OutputFormat: outputFmt,
 			},
 		},
+		nil,
+		[]byte(`2021-03-06T00:02:57Z`),
+		[]byte(`2021-03-06T00:02:57.000000Z`),
+	},
+	{
+		"data unix",
+		Time{
+			Options: TimeOptions{
+				InputFormat:  "unix",
+				OutputFormat: outputFmt,
+			},
+		},
+		nil,
+		[]byte(`1639877490.061`),
+		[]byte(`2021-12-19T01:31:30.061000Z`),
+	},
+	{
+		"data unix to unix_milli",
+		Time{
+			Options: TimeOptions{
+				InputFormat:  "unix",
+				OutputFormat: "unix_milli",
+			},
+		},
+		nil,
+		[]byte(`1639877490.061`),
+		[]byte(`1639877490061`),
+	},
+	{
+		"string",
+		Time{
+			Options: TimeOptions{
+				InputFormat:  "2006-01-02T15:04:05Z",
+				OutputFormat: outputFmt,
+			},
+			InputKey:  "time",
+			OutputKey: "time",
+		},
+		nil,
 		[]byte(`{"time":"2021-03-06T00:02:57Z"}`),
 		[]byte(`{"time":"2021-03-06T00:02:57.000000Z"}`),
 	},
 	{
 		"from unix",
 		Time{
-			InputKey:  "time",
-			OutputKey: "time",
 			Options: TimeOptions{
 				InputFormat:  "unix",
 				OutputFormat: outputFmt,
 			},
+			InputKey:  "time",
+			OutputKey: "time",
 		},
+		nil,
 		[]byte(`{"time":1639877490}`),
 		[]byte(`{"time":"2021-12-19T01:31:30.000000Z"}`),
 	},
 	{
 		"to unix",
 		Time{
-			InputKey:  "time",
-			OutputKey: "time",
 			Options: TimeOptions{
 				InputFormat:  outputFmt,
 				OutputFormat: "unix",
 			},
+			InputKey:  "time",
+			OutputKey: "time",
 		},
+		nil,
 		[]byte(`{"time":"2021-12-19T01:31:30.000000Z"}`),
 		[]byte(`{"time":1639877490}`),
 	},
 	{
 		"from unix_milli",
 		Time{
-			InputKey:  "time",
-			OutputKey: "time",
 			Options: TimeOptions{
 				InputFormat:  "unix_milli",
 				OutputFormat: outputFmt,
 			},
+			InputKey:  "time",
+			OutputKey: "time",
 		},
+		nil,
 		[]byte(`{"time":1654459632263}`),
 		[]byte(`{"time":"2022-06-05T20:07:12.263000Z"}`),
 	},
 	{
 		"to unix_milli",
 		Time{
-			InputKey:  "time",
-			OutputKey: "time",
 			Options: TimeOptions{
 				InputFormat:  outputFmt,
 				OutputFormat: "unix_milli",
 			},
+			InputKey:  "time",
+			OutputKey: "time",
 		},
+		nil,
 		[]byte(`{"time":"2022-06-05T20:07:12.263000Z"}`),
 		[]byte(`{"time":1654459632263}`),
 	},
 	{
-		"offset conversion",
+		"unix to unix_milli",
 		Time{
+			Options: TimeOptions{
+				InputFormat:  "unix",
+				OutputFormat: "unix_milli",
+			},
 			InputKey:  "time",
 			OutputKey: "time",
+		},
+		nil,
+		[]byte(`{"time":1639877490}`),
+		[]byte(`{"time":1639877490000}`),
+	},
+	{
+		"offset conversion",
+		Time{
 			Options: TimeOptions{
 				InputFormat:  "2006-Jan-02 Monday 03:04:05 -0700",
 				OutputFormat: "2006-Jan-02 Monday 03:04:05 -0700",
 			},
+			InputKey:  "time",
+			OutputKey: "time",
 		},
+		nil,
 		[]byte(`{"time":"2020-Jan-29 Wednesday 12:19:25 -0500"}`),
 		[]byte(`{"time":"2020-Jan-29 Wednesday 05:19:25 +0000"}`),
 	},
 	{
 		"offset to local conversion",
 		Time{
-			InputKey:  "time",
-			OutputKey: "time",
 			Options: TimeOptions{
 				InputFormat:    "2006-Jan-02 Monday 03:04:05 -0700",
 				OutputFormat:   "2006-Jan-02 Monday 03:04:05 PM",
 				OutputLocation: "America/New_York",
 			},
+			InputKey:  "time",
+			OutputKey: "time",
 		},
+		nil,
 		// 12:19:25 AM in Pacific Standard Time
 		[]byte(`{"time":"2020-Jan-29 Wednesday 00:19:25 -0800"}`),
 		// 03:19:25 AM in Eastern Standard Time
@@ -111,45 +170,29 @@ var timeTests = []struct {
 	{
 		"local to local conversion",
 		Time{
-			InputKey:  "time",
-			OutputKey: "time",
 			Options: TimeOptions{
 				InputFormat:    "2006-Jan-02 Monday 03:04:05",
-				InputLocation:  "America/Los_Angeles",
 				OutputFormat:   "2006-Jan-02 Monday 03:04:05",
+				InputLocation:  "America/Los_Angeles",
 				OutputLocation: "America/New_York",
 			},
+			InputKey:  "time",
+			OutputKey: "time",
 		},
+		nil,
 		// 12:19:25 AM in Pacific Standard Time
 		[]byte(`{"time":"2020-Jan-29 Wednesday 00:19:25"}`),
 		// 03:19:25 AM in Eastern Standard Time
 		[]byte(`{"time":"2020-Jan-29 Wednesday 03:19:25"}`),
 	},
 	{
-		"array",
+		"missing required options",
 		Time{
-			InputKey:  "time",
-			OutputKey: "time",
-			Options: TimeOptions{
-				InputFormat:  "2006-01-02T15:04:05Z",
-				OutputFormat: outputFmt,
-			},
+			Options: TimeOptions{},
 		},
-		[]byte(`{"time":["2021-03-06T00:02:57Z","2021-03-06T00:03:57Z"]}`),
-		[]byte(`{"time":["2021-03-06T00:02:57.000000Z","2021-03-06T00:03:57.000000Z"]}`),
-	},
-	{
-		"array",
-		Time{
-			InputKey:  "time",
-			OutputKey: "time",
-			Options: TimeOptions{
-				InputFormat:  "unix",
-				OutputFormat: outputFmt,
-			},
-		},
-		[]byte(`{"time":[1639877490.061,1651705967]}`),
-		[]byte(`{"time":["2021-12-19T01:31:30.000000Z","2022-05-04T23:12:47.000000Z"]}`),
+		ProcessorInvalidSettings,
+		[]byte{},
+		[]byte{},
 	},
 }
 
@@ -157,8 +200,10 @@ func TestTime(t *testing.T) {
 	ctx := context.TODO()
 	for _, test := range timeTests {
 		res, err := test.proc.Byte(ctx, test.test)
-		if err != nil {
-			t.Logf("%v", err)
+		if err != nil && errors.As(err, &test.err) {
+			continue
+		} else if err != nil {
+			t.Log(err)
 			t.Fail()
 		}
 

--- a/process/time_test.go
+++ b/process/time_test.go
@@ -12,9 +12,9 @@ var outputFmt = "2006-01-02T15:04:05.000000Z"
 var timeTests = []struct {
 	name     string
 	proc     Time
-	err      error
 	test     []byte
 	expected []byte
+	err      error
 }{
 	{
 		"data string",
@@ -24,9 +24,9 @@ var timeTests = []struct {
 				OutputFormat: outputFmt,
 			},
 		},
-		nil,
 		[]byte(`2021-03-06T00:02:57Z`),
 		[]byte(`2021-03-06T00:02:57.000000Z`),
+		nil,
 	},
 	{
 		"data unix",
@@ -36,9 +36,9 @@ var timeTests = []struct {
 				OutputFormat: outputFmt,
 			},
 		},
-		nil,
 		[]byte(`1639877490.061`),
 		[]byte(`2021-12-19T01:31:30.061000Z`),
+		nil,
 	},
 	{
 		"data unix to unix_milli",
@@ -48,12 +48,12 @@ var timeTests = []struct {
 				OutputFormat: "unix_milli",
 			},
 		},
-		nil,
 		[]byte(`1639877490.061`),
 		[]byte(`1639877490061`),
+		nil,
 	},
 	{
-		"string",
+		"JSON",
 		Time{
 			Options: TimeOptions{
 				InputFormat:  "2006-01-02T15:04:05Z",
@@ -62,12 +62,12 @@ var timeTests = []struct {
 			InputKey:  "time",
 			OutputKey: "time",
 		},
-		nil,
 		[]byte(`{"time":"2021-03-06T00:02:57Z"}`),
 		[]byte(`{"time":"2021-03-06T00:02:57.000000Z"}`),
+		nil,
 	},
 	{
-		"from unix",
+		"JSON from unix",
 		Time{
 			Options: TimeOptions{
 				InputFormat:  "unix",
@@ -76,12 +76,12 @@ var timeTests = []struct {
 			InputKey:  "time",
 			OutputKey: "time",
 		},
-		nil,
 		[]byte(`{"time":1639877490}`),
 		[]byte(`{"time":"2021-12-19T01:31:30.000000Z"}`),
+		nil,
 	},
 	{
-		"to unix",
+		"JSON to unix",
 		Time{
 			Options: TimeOptions{
 				InputFormat:  outputFmt,
@@ -90,12 +90,12 @@ var timeTests = []struct {
 			InputKey:  "time",
 			OutputKey: "time",
 		},
-		nil,
 		[]byte(`{"time":"2021-12-19T01:31:30.000000Z"}`),
 		[]byte(`{"time":1639877490}`),
+		nil,
 	},
 	{
-		"from unix_milli",
+		"JSON from unix_milli",
 		Time{
 			Options: TimeOptions{
 				InputFormat:  "unix_milli",
@@ -104,12 +104,12 @@ var timeTests = []struct {
 			InputKey:  "time",
 			OutputKey: "time",
 		},
-		nil,
 		[]byte(`{"time":1654459632263}`),
 		[]byte(`{"time":"2022-06-05T20:07:12.263000Z"}`),
+		nil,
 	},
 	{
-		"to unix_milli",
+		"JSON to unix_milli",
 		Time{
 			Options: TimeOptions{
 				InputFormat:  outputFmt,
@@ -118,12 +118,12 @@ var timeTests = []struct {
 			InputKey:  "time",
 			OutputKey: "time",
 		},
-		nil,
 		[]byte(`{"time":"2022-06-05T20:07:12.263000Z"}`),
 		[]byte(`{"time":1654459632263}`),
+		nil,
 	},
 	{
-		"unix to unix_milli",
+		"JSON unix to unix_milli",
 		Time{
 			Options: TimeOptions{
 				InputFormat:  "unix",
@@ -132,12 +132,12 @@ var timeTests = []struct {
 			InputKey:  "time",
 			OutputKey: "time",
 		},
-		nil,
 		[]byte(`{"time":1639877490}`),
 		[]byte(`{"time":1639877490000}`),
+		nil,
 	},
 	{
-		"offset conversion",
+		"JSON offset conversion",
 		Time{
 			Options: TimeOptions{
 				InputFormat:  "2006-Jan-02 Monday 03:04:05 -0700",
@@ -146,12 +146,12 @@ var timeTests = []struct {
 			InputKey:  "time",
 			OutputKey: "time",
 		},
-		nil,
 		[]byte(`{"time":"2020-Jan-29 Wednesday 12:19:25 -0500"}`),
 		[]byte(`{"time":"2020-Jan-29 Wednesday 05:19:25 +0000"}`),
+		nil,
 	},
 	{
-		"offset to local conversion",
+		"JSON offset to local conversion",
 		Time{
 			Options: TimeOptions{
 				InputFormat:    "2006-Jan-02 Monday 03:04:05 -0700",
@@ -161,14 +161,14 @@ var timeTests = []struct {
 			InputKey:  "time",
 			OutputKey: "time",
 		},
-		nil,
 		// 12:19:25 AM in Pacific Standard Time
 		[]byte(`{"time":"2020-Jan-29 Wednesday 00:19:25 -0800"}`),
 		// 03:19:25 AM in Eastern Standard Time
 		[]byte(`{"time":"2020-Jan-29 Wednesday 03:19:25 AM"}`),
+		nil,
 	},
 	{
-		"local to local conversion",
+		"JSON local to local conversion",
 		Time{
 			Options: TimeOptions{
 				InputFormat:    "2006-Jan-02 Monday 03:04:05",
@@ -179,20 +179,18 @@ var timeTests = []struct {
 			InputKey:  "time",
 			OutputKey: "time",
 		},
-		nil,
 		// 12:19:25 AM in Pacific Standard Time
 		[]byte(`{"time":"2020-Jan-29 Wednesday 00:19:25"}`),
 		// 03:19:25 AM in Eastern Standard Time
 		[]byte(`{"time":"2020-Jan-29 Wednesday 03:19:25"}`),
+		nil,
 	},
 	{
-		"missing required options",
-		Time{
-			Options: TimeOptions{},
-		},
+		"invalid settings",
+		Time{},
+		[]byte{},
+		[]byte{},
 		ProcessorInvalidSettings,
-		[]byte{},
-		[]byte{},
 	},
 }
 
@@ -200,7 +198,7 @@ func TestTime(t *testing.T) {
 	ctx := context.TODO()
 	for _, test := range timeTests {
 		res, err := test.proc.Byte(ctx, test.test)
-		if err != nil && errors.As(err, &test.err) {
+		if err != nil && errors.Is(err, test.err) {
 			continue
 		} else if err != nil {
 			t.Log(err)


### PR DESCRIPTION
## Description
This PR introduces meta-processing and migrates all processors to the meta-processing technique. "Meta processors" are any processors that execute other processors; this PR adds two:
- for_each: accepts JSON array as input and executes the configured processor on each element in the array
- pipeline: executes a series of processors on JSON or unstructured data

The for_each processor replaces JSON array support in other processors, making this PR a breaking change that requires a new release.

This PR also includes these changes:
- internal/base64: adds decoding and encoding base64 strings as its own internal package
- internal/json: Set supports encoding non-UTF8 bytes into base64 encoded strings
- process/expand: additional keys found in the JSON object are always copied into the expanded JSON objects
- process/process: adds ProcessorInvalidSettings error, used across all processors

## Motivation and Context
Meta-processing reduces complexity in other processors by removing direct JSON array support and opens up some new use cases. For example, it's now possible to decode complex binary structures entirely within JSON objects (e.g., a key-value that is base64 encoded gzipped data) and execute complex processors (e.g., DynamoDB, Lambda) on arrays of values.

## How Has This Been Tested?
The two new processors have unit tests (and for_each has unit tests that execute every processor that used to support arrays).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
