### PR TITLE
refactor(aws): Update internal/aws Functions

### DIFF
--- a/internal/aws/README.md
+++ b/internal/aws/README.md
@@ -1,5 +1,5 @@
 # aws
 Contains functions for managing AWS API calls. Substation follows these rules across every application:
-* AWS clients are always X-Ray enabled for tracing
-* AWS clients are configured using environment variables (https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html)
-* AWS clients always use the service's interface API (e.g., s3iface, kinesisiface, etc.)
+* AWS clients are configured using [environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html)
+* AWS clients use service interface APIs (e.g., s3iface, kinesisiface, etc.)
+* AWS clients enable [X-Ray](https://aws.amazon.com/xray/) for tracing if a [daemon address](https://docs.aws.amazon.com/xray/latest/devguide/xray-sdk-go-configuration.html#xray-sdk-go-configuration-envvars) is found

--- a/internal/aws/dynamodb/dynamodb.go
+++ b/internal/aws/dynamodb/dynamodb.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aws/aws-xray-sdk-go/xray"
 )
 
-//New creates and returns a new session connection to DynamoDB
+// New returns a configured DynamoDB client.
 func New() *dynamodb.DynamoDB {
 	conf := aws.NewConfig()
 
@@ -40,22 +40,22 @@ func New() *dynamodb.DynamoDB {
 	return c
 }
 
-// API wraps a DynamoDB client interface
+// API wraps the DynamoDB API interface.
 type API struct {
 	Client dynamodbiface.DynamoDBAPI
 }
 
-// Setup creates a DynamoDB client and sets the DynamoDB.stream
+// Setup creates a new DynamoDB client.
 func (a *API) Setup() {
 	a.Client = New()
 }
 
-// IsEnabled checks whether a new client has been set
+// IsEnabled returns true if the client is enabled and ready for use.
 func (a *API) IsEnabled() bool {
 	return a.Client != nil
 }
 
-// PutItem is a convenience wrapper for executing the PutItem API on DynamoDB.table
+// PutItem is a convenience wrapper for putting items into a DynamoDB table.
 func (a *API) PutItem(ctx aws.Context, table string, item map[string]*dynamodb.AttributeValue) (resp *dynamodb.PutItemOutput, err error) {
 	resp, err = a.Client.PutItemWithContext(
 		ctx,
@@ -71,7 +71,7 @@ func (a *API) PutItem(ctx aws.Context, table string, item map[string]*dynamodb.A
 	return resp, nil
 }
 
-// Query is a convenience wrapper for querying a DynamoDB table
+// Query is a convenience wrapper for querying a DynamoDB table.
 func (a *API) Query(ctx aws.Context, table, partitionKey, sortKey, keyConditionExpression string, limit int64, scanIndexForward bool) (resp *dynamodb.QueryOutput, err error) {
 	var expression map[string]*dynamodb.AttributeValue
 

--- a/internal/aws/kinesis/kinesis.go
+++ b/internal/aws/kinesis/kinesis.go
@@ -164,7 +164,7 @@ func ConvertEventsRecords(records []events.KinesisEventRecord) []*kinesis.Record
 	return output
 }
 
-// New creates a new session connection to Kinesis
+// New returns a configured Kinesis client.
 func New() *kinesis.Kinesis {
 	conf := aws.NewConfig()
 
@@ -192,22 +192,22 @@ func New() *kinesis.Kinesis {
 	return c
 }
 
-// API wraps a Kinesis client interface
+// API wraps the Kinesis API interface.
 type API struct {
 	Client kinesisiface.KinesisAPI
 }
 
-// IsEnabled cheks if a client is initiated and connected to Kensis
-func (a *API) IsEnabled() bool {
-	return a.Client != nil
-}
-
-// Setup creates a Kinesis client and sets the Kinesis.stream
+// Setup creates a new Kinesis client.
 func (a *API) Setup() {
 	a.Client = New()
 }
 
-// PutRecord is a convenience wrapper for executing the PutRecord API on Kinesis.stream
+// IsEnabled returns true if the client is enabled and ready for use.
+func (a *API) IsEnabled() bool {
+	return a.Client != nil
+}
+
+// PutRecord is a convenience wrapper for putting a record into a Kinesis stream.
 func (a *API) PutRecord(ctx aws.Context, data []byte, stream, partitionKey string) (*kinesis.PutRecordOutput, error) {
 	resp, err := a.Client.PutRecordWithContext(
 		ctx,
@@ -224,7 +224,7 @@ func (a *API) PutRecord(ctx aws.Context, data []byte, stream, partitionKey strin
 	return resp, nil
 }
 
-// ActiveShards returns the number of in-use shards for a Kinesis stream
+// ActiveShards returns the number of in-use shards for a Kinesis stream.
 func (a *API) ActiveShards(ctx aws.Context, stream string) (int64, error) {
 	var shards int64
 	params := &kinesis.ListShardsInput{
@@ -257,7 +257,7 @@ LOOP:
 	return shards, nil
 }
 
-// UpdateShards uniformly updates a Kinesis stream's shard count and returns when the update is complete
+// UpdateShards uniformly updates a Kinesis stream's shard count and returns when the update is complete.
 func (a *API) UpdateShards(ctx aws.Context, stream string, shards int64) error {
 	params := &kinesis.UpdateShardCountInput{
 		StreamName:       aws.String(stream),

--- a/internal/aws/lambda/lambda.go
+++ b/internal/aws/lambda/lambda.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aws/aws-xray-sdk-go/xray"
 )
 
-//New creates a new session connection to Lambda
+// New returns a configured Lambda client.
 func New() *lambda.Lambda {
 	conf := aws.NewConfig()
 
@@ -40,22 +40,22 @@ func New() *lambda.Lambda {
 	return c
 }
 
-// API wraps a lambda client interface
+// API wraps the Lambda API interface.
 type API struct {
 	Client lambdaiface.LambdaAPI
 }
 
-// Setup creates and sets a lambda client
+// Setup creates a new Lambda client.
 func (a *API) Setup() {
 	a.Client = New()
 }
 
-//IsEnabled returns the boolean on whether the client is enabled
+// IsEnabled returns true if the client is enabled and ready for use.
 func (a *API) IsEnabled() bool {
 	return a.Client != nil
 }
 
-//Invoke is a convenience wrapper around the AWS Lambda Invoke call with triggers a lambda
+// Invoke is a convenience wrapper for synchronously invoking a Lambda function.
 func (a *API) Invoke(ctx aws.Context, function string, payload []byte) (resp *lambda.InvokeOutput, err error) {
 	resp, err = a.Client.InvokeWithContext(
 		ctx,

--- a/internal/aws/secretsmanager/secretsmanager.go
+++ b/internal/aws/secretsmanager/secretsmanager.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aws/aws-xray-sdk-go/xray"
 )
 
-//New creates and returns a new session connection to Secrets manager
+// New returns a configured Secrets Manager client.
 func New() *secretsmanager.SecretsManager {
 	conf := aws.NewConfig()
 
@@ -40,22 +40,22 @@ func New() *secretsmanager.SecretsManager {
 	return c
 }
 
-// API wraps a secrets manager client interface
+// API wraps the Secrets Manager API interface.
 type API struct {
 	Client secretsmanageriface.SecretsManagerAPI
 }
 
-// Setup creates a secrets manager client
+// Setup creates a new Secrets Manager client.
 func (a *API) Setup() {
 	a.Client = New()
 }
 
-// IsEnabled checks if the client is set
+// IsEnabled returns true if the client is enabled and ready for use.
 func (a *API) IsEnabled() bool {
 	return a.Client != nil
 }
 
-// GetSecret wraps AWS SecretsManager GetSecretValue API
+// GetSecret is a convenience wrapper for getting a secret from Secrets Manager.
 func (a *API) GetSecret(ctx aws.Context, secretName string) (secret string, err error) {
 	input := &secretsmanager.GetSecretValueInput{
 		SecretId:     aws.String(secretName),

--- a/internal/aws/ssm/ssm.go
+++ b/internal/aws/ssm/ssm.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aws/aws-xray-sdk-go/xray"
 )
 
-//New creates and returns a new session connection to ssm
+// New returns a configured Systems Manager client.
 func New() *ssm.SSM {
 	conf := aws.NewConfig()
 
@@ -40,22 +40,22 @@ func New() *ssm.SSM {
 	return c
 }
 
-// API wraps a ssm interface
+// API wraps the Systems Manager API interface.
 type API struct {
 	Client ssmiface.SSMAPI
 }
 
-// Setup creates a ssm client
+// Setup creates a new Systems Manager client.
 func (a *API) Setup() {
 	a.Client = New()
 }
 
-// IsEnabled checks if the client is set
+// IsEnabled returns true if the client is enabled and ready for use.
 func (a *API) IsEnabled() bool {
 	return a.Client != nil
 }
 
-// GetParameter is a convinience wrapper around ssm's GetParameter which returns the value for a given parameter
+// GetParameter is a convenience wrapper for getting a parameter from Systems Manager.
 func (a *API) GetParameter(ctx aws.Context, param string) (val string, err error) {
 	input := &ssm.GetParameterInput{
 		Name:           aws.String(param),


### PR DESCRIPTION
## Description
- Refactors Kinesis autoscaling thresholds to match the solution [described here](https://aws.amazon.com/blogs/big-data/auto-scaling-amazon-kinesis-data-streams-using-amazon-cloudwatch-and-aws-lambda/)
- Refactors CloudWatch Kinesis alarms to repeat the most recent metric value instead of filling it with a zero value (see [fill repeat here](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/using-metric-math.html))
- Updates documentation

## Motivation and Context
These changes can reduce the cost of Kinesis for all pipelines (reduces unnecessary scale up events by increasing stream capacity if the write volume exceeds the threshold for 5 minutes instead of 1 minute) and increase the reliability of autoscaling for streams that have bursty traffic (by using the most recent metric value).

## How Has This Been Tested?
We've run the autoscaling changes for a few weeks on large scale and bursty pipelines, no problems observed.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
