### PR TITLE
feat: Data Aggregation

### DIFF
--- a/condition/condition.go
+++ b/condition/condition.go
@@ -7,6 +7,9 @@ import (
 	"github.com/brexhq/substation/internal/errors"
 )
 
+// InspectorInvalidSettings is returned when an inspector is configured with invalid settings.
+const InspectorInvalidSettings = errors.Error("InspectorInvalidSettings")
+
 // InspectorInvalidFactoryConfig is returned when an unsupported Inspector is referenced in InspectorFactory.
 const InspectorInvalidFactoryConfig = errors.Error("InspectorInvalidFactoryConfig")
 
@@ -39,17 +42,17 @@ func (o AND) Operate(data []byte) (bool, error) {
 
 	for _, i := range o.Inspectors {
 		ok, err := i.Inspect(data)
-
 		if err != nil {
 			return false, err
 		}
-		// return false if any Check fails
+
+		// return false if any check fails
 		if !ok {
 			return false, nil
 		}
 	}
 
-	// return tue if all Checks pass
+	// return tue if all checks pass
 	return true, nil
 }
 
@@ -69,13 +72,14 @@ func (o OR) Operate(data []byte) (bool, error) {
 		if err != nil {
 			return false, err
 		}
-		// return true if any Check passes
+
+		// return true if any check passes
 		if ok {
 			return true, nil
 		}
 	}
 
-	// return false if all Checks fail
+	// return false if all checks fail
 	return false, nil
 }
 
@@ -84,7 +88,7 @@ type NAND struct {
 	Inspectors []Inspector
 }
 
-// Operate returns true if all Inspectors return false, otherwise it returns true.
+// Operate returns true if any Inspectors return false, otherwise it returns true.
 func (o NAND) Operate(data []byte) (bool, error) {
 	if len(o.Inspectors) == 0 {
 		return false, fmt.Errorf("operator settings %v: %v", o, OperatorMissingInspectors)
@@ -95,13 +99,14 @@ func (o NAND) Operate(data []byte) (bool, error) {
 		if err != nil {
 			return false, err
 		}
-		// return true if any Check fails
+
+		// return true if any check fails
 		if !ok {
 			return true, nil
 		}
 	}
 
-	// return false if all Checks pass
+	// return false if all checks pass
 	return false, nil
 }
 
@@ -121,20 +126,21 @@ func (o NOR) Operate(data []byte) (bool, error) {
 		if err != nil {
 			return false, err
 		}
-		// return false if any Check passes
+
+		// return false if any check passes
 		if ok {
 			return false, nil
 		}
 	}
 
-	// return true if all Checks fail
+	// return true if all checks fail
 	return true, nil
 }
 
 // Default implements the Operator interface.
 type Default struct{}
 
-// Operate always returns true. This is the default operator returned by  OperatorFactory.
+// Operate always returns true. This is the default operator returned by OperatorFactory.
 func (o Default) Operate(data []byte) (bool, error) {
 	return true, nil
 }
@@ -185,6 +191,10 @@ func InspectorFactory(cfg config.Config) (Inspector, error) {
 		var i JSONValid
 		config.Decode(cfg.Settings, &i)
 		return i, nil
+	case "length":
+		var i Length
+		config.Decode(cfg.Settings, &i)
+		return i, nil
 	case "regexp":
 		var i RegExp
 		config.Decode(cfg.Settings, &i)
@@ -198,7 +208,7 @@ func InspectorFactory(cfg config.Config) (Inspector, error) {
 	}
 }
 
-// MakeInspectors is a convenience function for creating several Inspectors.
+// MakeInspectors is a convenience function for creating mulitple Inspectors.
 func MakeInspectors(cfg []config.Config) ([]Inspector, error) {
 	var inspectors []Inspector
 	for _, c := range cfg {

--- a/condition/condition_test.go
+++ b/condition/condition_test.go
@@ -6,65 +6,42 @@ import (
 	"github.com/brexhq/substation/internal/config"
 )
 
-var configTests = []struct {
+// all inspectors must return true for AND to return true
+var conditionANDTests = []struct {
+	name     string
 	conf     []config.Config
 	test     []byte
 	expected bool
 }{
 	{
-		[]config.Config{
-			{
-				Type: "strings",
-				Settings: map[string]interface{}{
-					"function":   "startswith",
-					"expression": "Test",
-				},
-			},
-			{
-				Type: "regexp",
-				Settings: map[string]interface{}{
-					"expression": "^Test$",
-				},
-			},
-		},
-		[]byte("Test"),
-		true,
-	},
-	{
-		[]config.Config{
-			{
-				Type: "regexp",
-				Settings: map[string]interface{}{
-					"expression": "^Tester",
-				},
-			},
-			{
-				Type: "strings",
-				Settings: map[string]interface{}{
-					"function":   "startswith",
-					"expression": "Test",
-				},
-			},
-		},
-		[]byte("Test"),
-		false,
-	},
-	{
+		"strings",
 		[]config.Config{
 			{
 				Type: "strings",
 				Settings: map[string]interface{}{
 					"function":   "equals",
-					"expression": "",
-					"key":        "baz",
-					"negate":     true,
+					"expression": "foo",
 				},
 			},
 		},
-		[]byte(`{"foo":"bar","baz":"hello"`),
+		[]byte("foo"),
 		true,
 	},
 	{
+		"regexp",
+		[]config.Config{
+			{
+				Type: "regexp",
+				Settings: map[string]interface{}{
+					"expression": "^foo$",
+				},
+			},
+		},
+		[]byte("foo"),
+		true,
+	},
+	{
+		"content",
 		[]config.Config{
 			{
 				Type: "content",
@@ -76,10 +53,45 @@ var configTests = []struct {
 		[]byte{80, 75, 03, 04},
 		false,
 	},
+	{
+		"length",
+		[]config.Config{
+			{
+				Type: "length",
+				Settings: map[string]interface{}{
+					"value":    3,
+					"function": "equals",
+				},
+			},
+		},
+		[]byte("foo"),
+		true,
+	},
+	{
+		"string length",
+		[]config.Config{
+			{
+				Type: "strings",
+				Settings: map[string]interface{}{
+					"function":   "equals",
+					"expression": "foo",
+				},
+			},
+			{
+				Type: "length",
+				Settings: map[string]interface{}{
+					"value":    3,
+					"function": "equals",
+				},
+			},
+		},
+		[]byte("foo"),
+		true,
+	},
 }
 
 func TestAND(t *testing.T) {
-	for _, test := range configTests {
+	for _, test := range conditionANDTests {
 		cfg := OperatorConfig{
 			Operator:   "and",
 			Inspectors: test.conf,
@@ -104,75 +116,105 @@ func TestAND(t *testing.T) {
 	}
 }
 
-func TestFactory(t *testing.T) {
-	for _, test := range configTests {
-		conf := test.conf[0]
-		c, err := InspectorFactory(conf)
-		if err != nil {
-			t.Log(err)
-			t.Fail()
-		}
-
-		check, err := c.Inspect(test.test)
-		if err != nil {
-			t.Log(err)
-			t.Fail()
-		}
-
-		if check != test.expected {
-			t.Logf("expected %v, got %v", test.expected, check)
-			t.Fail()
-		}
+func benchmarkAND(b *testing.B, conf []config.Config, data []byte) {
+	for i := 0; i < b.N; i++ {
+		inspectors, _ := MakeInspectors(conf)
+		op := AND{inspectors}
+		op.Operate(data)
 	}
 }
 
-func TestOR(t *testing.T) {
-	var tests = []struct {
-		conf     []config.Config
-		test     []byte
-		expected bool
-	}{
-		{
-			[]config.Config{
-				{
-					Type: "strings",
-					Settings: map[string]interface{}{
-						"function":   "startswith",
-						"expression": "Test",
-					},
-				},
-				{
-					Type: "regexp",
-					Settings: map[string]interface{}{
-						"expression": "^Test$",
-					},
-				},
+func BenchmarkAND(b *testing.B) {
+	for _, test := range conditionANDTests {
+		b.Run(string(test.name),
+			func(b *testing.B) {
+				benchmarkAND(b, test.conf, test.test)
 			},
-			[]byte("Test"),
-			true,
-		},
-		{
-			[]config.Config{
-				{
-					Type: "regexp",
-					Settings: map[string]interface{}{
-						"expression": "^Tester",
-					},
-				},
-				{
-					Type: "strings",
-					Settings: map[string]interface{}{
-						"function":   "startswith",
-						"expression": "Test",
-					},
-				},
-			},
-			[]byte("Test"),
-			true,
-		},
+		)
 	}
+}
 
-	for _, test := range tests {
+// any inspector must return true for OR to return true
+var conditionORTests = []struct {
+	name     string
+	conf     []config.Config
+	test     []byte
+	expected bool
+}{
+	{
+		"strings",
+		[]config.Config{
+			{
+				Type: "strings",
+				Settings: map[string]interface{}{
+					"function":   "equals",
+					"expression": "foo",
+				},
+			},
+			{
+				Type: "strings",
+				Settings: map[string]interface{}{
+					"function":   "equals",
+					"expression": "baz",
+				},
+			},
+		},
+		[]byte("foo"),
+		true,
+	},
+	{
+		"length",
+		[]config.Config{
+			{
+				Type: "length",
+				Settings: map[string]interface{}{
+					"value":    3,
+					"function": "equals",
+				},
+			},
+			{
+				Type: "length",
+				Settings: map[string]interface{}{
+					"value":    4,
+					"function": "equals",
+				},
+			},
+			{
+				Type: "length",
+				Settings: map[string]interface{}{
+					"value":    5,
+					"function": "equals",
+				},
+			},
+		},
+		[]byte("foo"),
+		true,
+	},
+	{
+		"string length",
+		[]config.Config{
+			{
+				Type: "strings",
+				Settings: map[string]interface{}{
+					"function":   "equals",
+					"expression": "foo",
+				},
+			},
+			{
+				Type: "length",
+				Settings: map[string]interface{}{
+					"value":    4,
+					"function": "equals",
+				},
+			},
+		},
+		[]byte("foo"),
+		true,
+	},
+}
+
+func TestOR(t *testing.T) {
+	for _, test := range conditionORTests {
 		cfg := OperatorConfig{
 			Operator:   "or",
 			Inspectors: test.conf,
@@ -197,53 +239,172 @@ func TestOR(t *testing.T) {
 	}
 }
 
-func TestNOR(t *testing.T) {
-	var tests = []struct {
-		conf     []config.Config
-		test     []byte
-		expected bool
-	}{
-		{
-			[]config.Config{
-				{
-					Type: "strings",
-					Settings: map[string]interface{}{
-						"function":   "startswith",
-						"expression": "Test",
-					},
-				},
-				{
-					Type: "regexp",
-					Settings: map[string]interface{}{
-						"expression": "^Test$",
-					},
-				},
-			},
-			[]byte("Test"),
-			false,
-		},
-		{
-			[]config.Config{
-				{
-					Type: "regexp",
-					Settings: map[string]interface{}{
-						"expression": "^Tester",
-					},
-				},
-				{
-					Type: "strings",
-					Settings: map[string]interface{}{
-						"function":   "startswith",
-						"expression": "Test",
-					},
-				},
-			},
-			[]byte("Test"),
-			false,
-		},
+func benchmarkOR(b *testing.B, conf []config.Config, data []byte) {
+	for i := 0; i < b.N; i++ {
+		inspectors, _ := MakeInspectors(conf)
+		op := OR{inspectors}
+		op.Operate(data)
 	}
+}
 
-	for _, test := range tests {
+func BenchmarkOR(b *testing.B) {
+	for _, test := range conditionORTests {
+		b.Run(string(test.name),
+			func(b *testing.B) {
+				benchmarkOR(b, test.conf, test.test)
+			},
+		)
+	}
+}
+
+// all inspectors must return true for NAND to return false
+var conditionNANDTests = []struct {
+	name     string
+	conf     []config.Config
+	test     []byte
+	expected bool
+}{
+	{
+		"strings",
+		[]config.Config{
+			{
+				Type: "strings",
+				Settings: map[string]interface{}{
+					"function":   "equals",
+					"expression": "baz",
+				},
+			},
+			{
+				Type: "strings",
+				Settings: map[string]interface{}{
+					"function":   "equals",
+					"expression": "qux",
+				},
+			},
+		},
+		[]byte("foo"),
+		true,
+	},
+	{
+		"strings",
+		[]config.Config{
+			{
+				Type: "strings",
+				Settings: map[string]interface{}{
+					"function":   "equals",
+					"expression": "foo",
+				},
+			},
+			{
+				Type: "strings",
+				Settings: map[string]interface{}{
+					"function":   "startswith",
+					"expression": "f",
+				},
+			},
+		},
+		[]byte("foo"),
+		false,
+	},
+}
+
+func TestNAND(t *testing.T) {
+	for _, test := range conditionNANDTests {
+		cfg := OperatorConfig{
+			Operator:   "nand",
+			Inspectors: test.conf,
+		}
+
+		op, err := OperatorFactory(cfg)
+		if err != nil {
+			t.Log(err)
+			t.Fail()
+		}
+
+		ok, err := op.Operate(test.test)
+		if err != nil {
+			t.Log(err)
+			t.Fail()
+		}
+
+		if ok != test.expected {
+			t.Logf("expected %v, got %v", test.expected, ok)
+			t.Fail()
+		}
+	}
+}
+
+func benchmarkNAND(b *testing.B, conf []config.Config, data []byte) {
+	for i := 0; i < b.N; i++ {
+		inspectors, _ := MakeInspectors(conf)
+		op := NAND{inspectors}
+		op.Operate(data)
+	}
+}
+
+func BenchmarkNAND(b *testing.B) {
+	for _, test := range conditionNORTests {
+		b.Run(string(test.name),
+			func(b *testing.B) {
+				benchmarkNAND(b, test.conf, test.test)
+			},
+		)
+	}
+}
+
+// any inspector must return true for NOR to return false
+var conditionNORTests = []struct {
+	name     string
+	conf     []config.Config
+	test     []byte
+	expected bool
+}{
+	{
+		"strings",
+		[]config.Config{
+			{
+				Type: "strings",
+				Settings: map[string]interface{}{
+					"function":   "equals",
+					"expression": "baz",
+				},
+			},
+			{
+				Type: "strings",
+				Settings: map[string]interface{}{
+					"function":   "startswith",
+					"expression": "b",
+				},
+			},
+		},
+		[]byte("foo"),
+		true,
+	},
+	{
+		"strings",
+		[]config.Config{
+			{
+				Type: "strings",
+				Settings: map[string]interface{}{
+					"function":   "equals",
+					"expression": "foo",
+				},
+			},
+			{
+				Type: "strings",
+				Settings: map[string]interface{}{
+					"function":   "startswith",
+					"expression": "b",
+				},
+			},
+		},
+		[]byte("foo"),
+		false,
+	},
+}
+
+func TestNOR(t *testing.T) {
+	for _, test := range conditionNORTests {
 		cfg := OperatorConfig{
 			Operator:   "nor",
 			Inspectors: test.conf,
@@ -268,27 +429,46 @@ func TestNOR(t *testing.T) {
 	}
 }
 
-var BenchmarkCfg = OperatorConfig{
-	Operator:   "and",
-	Inspectors: configTests[0].conf,
-}
-
-func BenchmarkOperatorFactory(b *testing.B) {
+func benchmarkNOR(b *testing.B, conf []config.Config, data []byte) {
 	for i := 0; i < b.N; i++ {
-		op, err := OperatorFactory(BenchmarkCfg)
-		if err != nil {
-			b.Log(err)
-			b.Fail()
-		}
-
-		op.Operate(configTests[0].test)
+		inspectors, _ := MakeInspectors(conf)
+		op := NOR{inspectors}
+		op.Operate(data)
 	}
 }
 
-var op, _ = OperatorFactory(BenchmarkCfg)
+func BenchmarkNOR(b *testing.B) {
+	for _, test := range conditionNORTests {
+		b.Run(string(test.name),
+			func(b *testing.B) {
+				benchmarkNOR(b, test.conf, test.test)
+			},
+		)
+	}
+}
 
-func BenchmarkOperate(b *testing.B) {
+func TestFactory(t *testing.T) {
+	for _, test := range conditionANDTests {
+		_, err := InspectorFactory(test.conf[0])
+		if err != nil {
+			t.Log(err)
+			t.Fail()
+		}
+	}
+}
+
+func benchmarkFactory(b *testing.B, conf config.Config) {
 	for i := 0; i < b.N; i++ {
-		op.Operate(configTests[0].test)
+		InspectorFactory(conf)
+	}
+}
+
+func BenchmarkFactory(b *testing.B) {
+	for _, test := range conditionANDTests {
+		b.Run(string(test.name),
+			func(b *testing.B) {
+				benchmarkFactory(b, test.conf[0])
+			},
+		)
 	}
 }

--- a/condition/length.go
+++ b/condition/length.go
@@ -20,14 +20,13 @@ The inspector has these settings:
 		must be one of:
 			byte (number of bytes)
 			rune (number of characters)
+		defaults to byte
 	Function:
 		the length evaluation function used during inspection
 		must be one of:
-			equals (equals)
-			greaterthan (greater than)
-			greaterthaneq (greater than equal to)
-			lessthan (less than)
-			lessthaneq (less than equal to)
+			equals
+			greaterthan
+			lessthan
 	Negate (optional):
 		if set to true, then the inspection is negated (i.e., true becomes false, false becomes true)
 		defaults to false
@@ -45,7 +44,7 @@ The inspector uses this Jsonnet configuration:
 		settings: {
 			key: 'foo',
 			value: 3,
-			_function: 'lessthaneq',
+			'function': 'equals',
 		},
 	}
 */
@@ -78,7 +77,7 @@ func (c Length) Inspect(data []byte) (output bool, err error) {
 	case "rune":
 		length = utf8.RuneCountInString(check)
 	default:
-		return false, fmt.Errorf("inspector settings %+v: %w", c, InspectorInvalidSettings)
+		length = len(check)
 	}
 
 	return c.match(length)
@@ -95,16 +94,8 @@ func (c Length) match(length int) (bool, error) {
 		if length > c.Value {
 			matched = true
 		}
-	case "greaterthaneq":
-		if length >= c.Value {
-			matched = true
-		}
 	case "lessthan":
 		if length < c.Value {
-			matched = true
-		}
-	case "lessthaneq":
-		if length <= c.Value {
 			matched = true
 		}
 	default:

--- a/condition/length.go
+++ b/condition/length.go
@@ -1,0 +1,119 @@
+package condition
+
+import (
+	"fmt"
+	"unicode/utf8"
+
+	"github.com/brexhq/substation/internal/json"
+)
+
+/*
+Length evaluates data using len functions. This inspector supports evaluating byte and rune (character) length of strings. If a JSON array is input, then the length is evaluated against the number of elements in the array.
+
+The inspector has these settings:
+	Key (optional):
+		the JSON key-value to retrieve for inspection
+	Value:
+		the length value used during inspection
+	Type:
+		the length type used during inpsection
+		must be one of:
+			byte (number of bytes)
+			rune (number of characters)
+	Function:
+		the length evaluation function used during inspection
+		must be one of:
+			equals (equals)
+			greaterthan (greater than)
+			greaterthaneq (greater than equal to)
+			lessthan (less than)
+			lessthaneq (less than equal to)
+	Negate (optional):
+		if set to true, then the inspection is negated (i.e., true becomes false, false becomes true)
+		defaults to false
+
+The inspector supports these patterns:
+	JSON:
+		{"foo":"bar"} == 3
+		{"foo":["bar","baz","qux"]} == 3
+	data:
+		bar == 3
+
+The inspector uses this Jsonnet configuration:
+	{
+		type: 'length',
+		settings: {
+			key: 'foo',
+			value: 3,
+			_function: 'lessthaneq',
+		},
+	}
+*/
+type Length struct {
+	Key      string `json:"key"`
+	Value    int    `json:"value"`
+	Type     string `json:"type"`
+	Function string `json:"function"`
+	Negate   bool   `json:"negate"`
+}
+
+// Inspect evaluates data with the Length inspector.
+func (c Length) Inspect(data []byte) (output bool, err error) {
+	var check string
+	if c.Key == "" {
+		check = string(data)
+	} else {
+		v := json.Get(data, c.Key)
+		if v.IsArray() {
+			return c.match(len(v.Array()))
+		}
+
+		check = string(v.String())
+	}
+
+	var length int
+	switch c.Type {
+	case "byte":
+		length = len(check)
+	case "rune":
+		length = utf8.RuneCountInString(check)
+	default:
+		return false, fmt.Errorf("inspector settings %+v: %w", c, InspectorInvalidSettings)
+	}
+
+	return c.match(length)
+}
+
+func (c Length) match(length int) (bool, error) {
+	var matched bool
+	switch c.Function {
+	case "equals":
+		if length == c.Value {
+			matched = true
+		}
+	case "greaterthan":
+		if length > c.Value {
+			matched = true
+		}
+	case "greaterthaneq":
+		if length >= c.Value {
+			matched = true
+		}
+	case "lessthan":
+		if length < c.Value {
+			matched = true
+		}
+	case "lessthaneq":
+		if length <= c.Value {
+			matched = true
+		}
+	default:
+		return false, fmt.Errorf("inspector settings %+v: %w", c, InspectorInvalidSettings)
+	}
+
+	if c.Negate {
+		return !matched, nil
+	}
+
+	return matched, nil
+}

--- a/condition/length_test.go
+++ b/condition/length_test.go
@@ -90,44 +90,6 @@ var lengthTests = []struct {
 		"pass",
 		Length{
 			Key:      "foo",
-			Value:    3,
-			Function: "lessthaneq",
-		},
-		[]byte(`{"foo":"bar"}`),
-		true,
-	},
-	{
-		"pass",
-		Length{
-			Value:    3,
-			Function: "lessthaneq",
-		},
-		[]byte(`bar`),
-		true,
-	},
-	{
-		"fail",
-		Length{
-			Key:      "foo",
-			Value:    2,
-			Function: "lessthaneq",
-		},
-		[]byte(`{"foo":"bar"}`),
-		false,
-	},
-	{
-		"fail",
-		Length{
-			Value:    2,
-			Function: "lessthaneq",
-		},
-		[]byte(`bar`),
-		false,
-	},
-	{
-		"pass",
-		Length{
-			Key:      "foo",
 			Value:    2,
 			Function: "greaterthan",
 		},
@@ -158,44 +120,6 @@ var lengthTests = []struct {
 		Length{
 			Value:    3,
 			Function: "greaterthan",
-		},
-		[]byte(`bar`),
-		false,
-	},
-	{
-		"pass",
-		Length{
-			Key:      "foo",
-			Value:    3,
-			Function: "greaterthaneq",
-		},
-		[]byte(`{"foo":"bar"}`),
-		true,
-	},
-	{
-		"pass",
-		Length{
-			Value:    3,
-			Function: "greaterthaneq",
-		},
-		[]byte(`bar`),
-		true,
-	},
-	{
-		"fail",
-		Length{
-			Key:      "foo",
-			Value:    4,
-			Function: "greaterthaneq",
-		},
-		[]byte(`{"foo":"bar"}`),
-		false,
-	},
-	{
-		"fail",
-		Length{
-			Value:    4,
-			Function: "greaterthaneq",
 		},
 		[]byte(`bar`),
 		false,
@@ -246,27 +170,6 @@ var lengthTests = []struct {
 		"!pass",
 		Length{
 			Key:      "foo",
-			Value:    3,
-			Function: "lessthaneq",
-			Negate:   true,
-		},
-		[]byte(`{"foo":"bar"}`),
-		false,
-	},
-	{
-		"!pass",
-		Length{
-			Value:    3,
-			Function: "lessthaneq",
-			Negate:   true,
-		},
-		[]byte(`bar`),
-		false,
-	},
-	{
-		"!pass",
-		Length{
-			Key:      "foo",
 			Value:    2,
 			Function: "greaterthan",
 			Negate:   true,
@@ -279,27 +182,6 @@ var lengthTests = []struct {
 		Length{
 			Value:    2,
 			Function: "greaterthan",
-			Negate:   true,
-		},
-		[]byte(`bar`),
-		false,
-	},
-	{
-		"!pass",
-		Length{
-			Key:      "foo",
-			Value:    3,
-			Function: "greaterthaneq",
-			Negate:   true,
-		},
-		[]byte(`{"foo":"bar"}`),
-		false,
-	},
-	{
-		"!pass",
-		Length{
-			Value:    3,
-			Function: "greaterthaneq",
 			Negate:   true,
 		},
 		[]byte(`bar`),
@@ -329,11 +211,13 @@ var lengthTests = []struct {
 }
 
 func TestLength(t *testing.T) {
-	for _, testing := range lengthTests {
-		check, _ := testing.inspector.Inspect(testing.test)
+	for _, test := range lengthTests {
+		check, _ := test.inspector.Inspect(test.test)
 
-		if testing.expected != check {
-			t.Logf("expected %v, got %v", testing.expected, check)
+		if test.expected != check {
+			t.Logf("expected %v, got %v", test.expected, check)
+			t.Logf("settings: %+v", test.inspector)
+			t.Logf("test: %+v", string(test.test))
 			t.Fail()
 		}
 	}

--- a/condition/length_test.go
+++ b/condition/length_test.go
@@ -1,0 +1,356 @@
+package condition
+
+import (
+	"testing"
+)
+
+var lengthTests = []struct {
+	name      string
+	inspector Length
+	test      []byte
+	expected  bool
+}{
+	{
+		"pass",
+		Length{
+			Key:      "foo",
+			Value:    3,
+			Function: "equals",
+		},
+		[]byte(`{"foo":"bar"}`),
+		true,
+	},
+	{
+		"pass",
+		Length{
+			Value:    3,
+			Function: "equals",
+		},
+		[]byte(`bar`),
+		true,
+	},
+	{
+		"fail",
+		Length{
+			Key:      "foo",
+			Value:    4,
+			Function: "equals",
+		},
+		[]byte(`{"foo":"bar"}`),
+		false,
+	},
+	{
+		"fail",
+		Length{
+			Value:    4,
+			Function: "equals",
+		},
+		[]byte(`bar`),
+		false,
+	},
+	{
+		"pass",
+		Length{
+			Key:      "foo",
+			Value:    4,
+			Function: "lessthan",
+		},
+		[]byte(`{"foo":"bar"}`),
+		true,
+	},
+	{
+		"pass",
+		Length{
+			Value:    4,
+			Function: "lessthan",
+		},
+		[]byte(`bar`),
+		true,
+	},
+	{
+		"fail",
+		Length{
+			Key:      "foo",
+			Value:    3,
+			Function: "lessthan",
+		},
+		[]byte(`{"foo":"bar"}`),
+		false,
+	},
+	{
+		"fail",
+		Length{
+			Value:    3,
+			Function: "lessthan",
+		},
+		[]byte(`bar`),
+		false,
+	},
+	{
+		"pass",
+		Length{
+			Key:      "foo",
+			Value:    3,
+			Function: "lessthaneq",
+		},
+		[]byte(`{"foo":"bar"}`),
+		true,
+	},
+	{
+		"pass",
+		Length{
+			Value:    3,
+			Function: "lessthaneq",
+		},
+		[]byte(`bar`),
+		true,
+	},
+	{
+		"fail",
+		Length{
+			Key:      "foo",
+			Value:    2,
+			Function: "lessthaneq",
+		},
+		[]byte(`{"foo":"bar"}`),
+		false,
+	},
+	{
+		"fail",
+		Length{
+			Value:    2,
+			Function: "lessthaneq",
+		},
+		[]byte(`bar`),
+		false,
+	},
+	{
+		"pass",
+		Length{
+			Key:      "foo",
+			Value:    2,
+			Function: "greaterthan",
+		},
+		[]byte(`{"foo":"bar"}`),
+		true,
+	},
+	{
+		"pass",
+		Length{
+			Value:    2,
+			Function: "greaterthan",
+		},
+		[]byte(`bar`),
+		true,
+	},
+	{
+		"fail",
+		Length{
+			Key:      "foo",
+			Value:    3,
+			Function: "greaterthan",
+		},
+		[]byte(`{"foo":"bar"}`),
+		false,
+	},
+	{
+		"fail",
+		Length{
+			Value:    3,
+			Function: "greaterthan",
+		},
+		[]byte(`bar`),
+		false,
+	},
+	{
+		"pass",
+		Length{
+			Key:      "foo",
+			Value:    3,
+			Function: "greaterthaneq",
+		},
+		[]byte(`{"foo":"bar"}`),
+		true,
+	},
+	{
+		"pass",
+		Length{
+			Value:    3,
+			Function: "greaterthaneq",
+		},
+		[]byte(`bar`),
+		true,
+	},
+	{
+		"fail",
+		Length{
+			Key:      "foo",
+			Value:    4,
+			Function: "greaterthaneq",
+		},
+		[]byte(`{"foo":"bar"}`),
+		false,
+	},
+	{
+		"fail",
+		Length{
+			Value:    4,
+			Function: "greaterthaneq",
+		},
+		[]byte(`bar`),
+		false,
+	},
+	{
+		"!pass",
+		Length{
+			Key:      "foo",
+			Value:    3,
+			Function: "equals",
+			Negate:   true,
+		},
+		[]byte(`{"foo":"bar"}`),
+		false,
+	},
+	{
+		"!pass",
+		Length{
+			Value:    3,
+			Function: "equals",
+			Negate:   true,
+		},
+		[]byte(`bar`),
+		false,
+	},
+	{
+		"!pass",
+		Length{
+			Key:      "foo",
+			Value:    4,
+			Function: "lessthan",
+			Negate:   true,
+		},
+		[]byte(`{"foo":"bar"}`),
+		false,
+	},
+	{
+		"!pass",
+		Length{
+			Value:    4,
+			Function: "lessthan",
+			Negate:   true,
+		},
+		[]byte(`bar`),
+		false,
+	},
+	{
+		"!pass",
+		Length{
+			Key:      "foo",
+			Value:    3,
+			Function: "lessthaneq",
+			Negate:   true,
+		},
+		[]byte(`{"foo":"bar"}`),
+		false,
+	},
+	{
+		"!pass",
+		Length{
+			Value:    3,
+			Function: "lessthaneq",
+			Negate:   true,
+		},
+		[]byte(`bar`),
+		false,
+	},
+	{
+		"!pass",
+		Length{
+			Key:      "foo",
+			Value:    2,
+			Function: "greaterthan",
+			Negate:   true,
+		},
+		[]byte(`{"foo":"bar"}`),
+		false,
+	},
+	{
+		"!pass",
+		Length{
+			Value:    2,
+			Function: "greaterthan",
+			Negate:   true,
+		},
+		[]byte(`bar`),
+		false,
+	},
+	{
+		"!pass",
+		Length{
+			Key:      "foo",
+			Value:    3,
+			Function: "greaterthaneq",
+			Negate:   true,
+		},
+		[]byte(`{"foo":"bar"}`),
+		false,
+	},
+	{
+		"!pass",
+		Length{
+			Value:    3,
+			Function: "greaterthaneq",
+			Negate:   true,
+		},
+		[]byte(`bar`),
+		false,
+	},
+	{
+		"rune pass",
+		Length{
+			Type:     "rune",
+			Value:    3,
+			Function: "equals",
+		},
+		// 3 runes (characters), 4 bytes
+		[]byte("a£c"),
+		true,
+	},
+	{
+		"array pass",
+		Length{
+			Key:      "foo",
+			Value:    3,
+			Function: "equals",
+		},
+		[]byte(`{"foo":["bar",2,{"baz":"qux"}]}`),
+		true,
+	},
+}
+
+func TestLength(t *testing.T) {
+	for _, testing := range lengthTests {
+		check, _ := testing.inspector.Inspect(testing.test)
+
+		if testing.expected != check {
+			t.Logf("expected %v, got %v", testing.expected, check)
+			t.Fail()
+		}
+	}
+}
+
+func benchmarkLengthByte(b *testing.B, inspector Length, test []byte) {
+	for i := 0; i < b.N; i++ {
+		inspector.Inspect(test)
+	}
+}
+
+func BenchmarkLengthByte(b *testing.B) {
+	for _, test := range lengthTests {
+		b.Run(string(test.name),
+			func(b *testing.B) {
+				benchmarkLengthByte(b, test.inspector, test.test)
+			},
+		)
+	}
+}

--- a/config/condition.libsonnet
+++ b/config/condition.libsonnet
@@ -33,6 +33,20 @@
       settings: { key: key, type: 'unspecified', negate: negate },
     },
   },
+  length: {
+    equals(key, value, type='byte', negate=false): {
+      type: 'length',
+      settings: { key: key, value: value, type: type, 'function': 'equals', negate: negate },
+    },
+    greaterthan(key, value, type='byte', negate=false): {
+      type: 'length',
+      settings: { key: key, value: value, type: type, 'function': 'greaterthan', negate: negate },
+    },
+    lessthan(key, value, type='byte', negate=false): {
+      type: 'length',
+      settings: { key: key, value: value, type: type, 'function': 'lessthan', negate: negate },
+    },
+  },
   regexp(key, expression, negate=false): {
     type: 'regexp',
     settings: { key: key, expression: expression, negate: negate },

--- a/config/process.libsonnet
+++ b/config/process.libsonnet
@@ -1,4 +1,14 @@
 {
+  aggregate(output, 
+            aggregate_key='', separator='', max_count=1000, max_size=10000,
+            condition_operator='', condition_inspectors=[]): {
+    type: 'aggregate',
+    settings: {
+      options: { aggregate_key: aggregate_key, separator: separator, max_count: max_count, max_size: max_size },
+      condition: { operator: condition_operator, inspectors: condition_inspectors},
+      output_key: output,
+    },
+  },
   base64(input, output, direction, 
          condition_operator='', condition_inspectors=[]): {
     type: 'base64',
@@ -104,6 +114,15 @@
       input_key: input, output_key: output,
     },
   },
+  for_each(input, output, processor, 
+           condition_operator='', condition_inspectors=[]): {
+    type: 'for_each',
+    settings: {
+      options: { processor: processor },
+      condition: { operator: condition_operator, inspectors: condition_inspectors},
+      input_key: input, output_key: output,
+    },
+  },
   group(input, output, 
         keys=[], 
         condition_operator='', condition_inspectors=[]): {
@@ -160,12 +179,30 @@
       input_key: input, output_key: output,
     },
   },
+  pipeline(input, output, processors, 
+           condition_operator='', condition_inspectors=[]): {
+    type: 'pipeline',
+    settings: {
+      options: { processors: processors },
+      condition: { operator: condition_operator, inspectors: condition_inspectors},
+      input_key: input, output_key: output,
+    },
+  },
   replace(input, output, old, new, 
           count=-1, 
           condition_operator='', condition_inspectors=[]): {
     type: 'replace',
     settings: {
       options: { old: old, new: new, count: count },
+      condition: { operator: condition_operator, inspectors: condition_inspectors},
+      input_key: input, output_key: output,
+    },
+  },
+  split(input, output, separator,
+        condition_operator='', condition_inspectors=[]): {
+    type: 'split',
+    settings: {
+      options: { separator: separator },
       condition: { operator: condition_operator, inspectors: condition_inspectors},
       input_key: input, output_key: output,
     },

--- a/process/aggregate.go
+++ b/process/aggregate.go
@@ -1,0 +1,189 @@
+package process
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/brexhq/substation/condition"
+	"github.com/brexhq/substation/internal/errors"
+	"github.com/brexhq/substation/internal/json"
+	"github.com/jshlbrd/go-aggregate"
+)
+
+// AggregateBufferSizeLimit is returned when the aggregate's buffer size limit is reached. If this error occurs, then increase the size of the buffer or use the Drop processor to remove data that exceeds the buffer limit.
+const AggregateBufferSizeLimit = errors.Error("AggregateBufferSizeLimit")
+
+/*
+AggregateOptions contains custom options settings for the Aggregate processor:
+	AggregateKey (optional):
+		the JSON key-value that is used to organize aggregated data
+		defaults to empty string, only applies to JSON
+	Separator (optional):
+		the string that separates aggregated data
+		defaults to empty string, only applies to data
+	MaxCount (optional):
+		the maximum number of items stored in a buffer when aggregating data
+		defaults to 1000
+	MaxSize (optional):
+		the maximum size, in bytes, of items stored in a buffer when aggregating data
+		defaults to 10000 (10KB)
+*/
+type AggregateOptions struct {
+	AggregateKey string `json:"aggregate_key"`
+	Separator    string `json:"separator"`
+	MaxCount     int    `json:"max_count"`
+	MaxSize      int    `json:"max_size"`
+}
+
+/*
+Aggregate processes data by buffering and aggregating it
+into a single item.
+
+Data is processed by aggregating it into in-memory buffers
+until the configured count or size of the aggregate meets
+a threshold and new data is produced. This supports multiple
+data aggregation patterns:
+	- concatenate batches of data with a separator value
+	- store batches of data in a JSON array
+	- organize nested JSON in a JSON array based on unique keys
+
+The processor supports these patterns:
+	JSON array:
+		foo bar baz qux >>> {"aggregate":["foo","bar","baz","qux"]}
+		{"foo":"bar"} {"baz":"qux"} >>> {"aggregate":[{"foo":"bar"},{"baz":"qux"}]}
+	data:
+		foo bar baz qux >>> foo\nbar\nbaz\qux
+		{"foo":"bar"} {"baz":"qux"} >>> {"foo":"bar"}\n{"baz":"qux"}
+
+The processor uses this Jsonnet configuration:
+	{
+		type: 'aggregate',
+		settings: {
+			options: {
+				max_count: 1000,
+				max_size: 1000,
+			},
+			output_key: 'aggregate.-1',
+		},
+	}
+*/
+type Aggregate struct {
+	Options   AggregateOptions         `json:"options"`
+	Condition condition.OperatorConfig `json:"condition"`
+	OutputKey string                   `json:"output_key"`
+}
+
+// Slice processes a slice of bytes with the Aggregate processor. Conditions are optionally applied on the bytes to enable processing.
+func (p Aggregate) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
+	op, err := condition.OperatorFactory(p.Condition)
+	if err != nil {
+		return nil, fmt.Errorf("slicer settings %+v: %w", p, err)
+	}
+
+	// aggregateKeys is used to return elements stored in the
+	// buffer in order if the aggregate doesn't meet the
+	// configured threshold. any aggregate that meets the
+	// threshold is delivered immediately, out of order.
+	var aggregateKeys []string
+	buffer := map[string]*aggregate.Bytes{}
+
+	if p.Options.MaxCount == 0 {
+		p.Options.MaxCount = 1000
+	}
+
+	if p.Options.MaxSize == 0 {
+		p.Options.MaxSize = 10000
+	}
+
+	slice := NewSlice(&s)
+	for _, data := range s {
+		ok, err := op.Operate(data)
+		if err != nil {
+			return nil, fmt.Errorf("slicer settings %+v: %w", p, err)
+		}
+
+		if !ok {
+			slice = append(slice, data)
+			continue
+		}
+
+		// data that exceeds the size of the buffer will never
+		// fit within it
+		if len(data) > p.Options.MaxSize {
+			return nil, fmt.Errorf("aggregate: size limit %d reached (%d): %w", p.Options.MaxSize, len(data), AggregateBufferSizeLimit)
+		}
+
+		var aggregateKey string
+		if p.Options.AggregateKey != "" {
+			aggregateKey = json.Get(data, p.Options.AggregateKey).String()
+		}
+
+		if _, ok := buffer[aggregateKey]; !ok {
+			buffer[aggregateKey] = &aggregate.Bytes{}
+			buffer[aggregateKey].New(p.Options.MaxSize, p.Options.MaxCount)
+			aggregateKeys = append(aggregateKeys, aggregateKey)
+		}
+
+		ok, err = buffer[aggregateKey].Add(data)
+		if err != nil {
+			return nil, fmt.Errorf("aggregate: %v", err)
+		}
+
+		// data was successfully added to the buffer, every item after
+		// this is a failure
+		if ok {
+			continue
+		}
+
+		elements := buffer[aggregateKey].Get()
+		if p.OutputKey != "" {
+			var tmp []byte
+			for _, element := range elements {
+				var err error
+
+				tmp, err = json.Set(tmp, p.OutputKey, element)
+				if err != nil {
+					return nil, fmt.Errorf("aggregate: %v", err)
+				}
+			}
+
+			slice = append(slice, tmp)
+		} else {
+			tmp := bytes.Join(elements, []byte(p.Options.Separator))
+			slice = append(slice, tmp)
+		}
+
+		// by this point, addition of the failed data is guaranteed to
+		// succeed after the buffer is reset
+		buffer[aggregateKey].Reset()
+		buffer[aggregateKey].Add(data)
+	}
+
+	// remaining items must be drained from the buffer, otherwise data is lost
+	for _, key := range aggregateKeys {
+		if buffer[key].Count() == 0 {
+			continue
+		}
+
+		elements := buffer[key].Get()
+		if p.OutputKey != "" {
+			var tmp []byte
+			for _, element := range elements {
+				var err error
+
+				tmp, err = json.Set(tmp, p.OutputKey, element)
+				if err != nil {
+					return nil, fmt.Errorf("aggregate: %v", err)
+				}
+			}
+
+			slice = append(slice, tmp)
+		} else {
+			tmp := bytes.Join(elements, []byte(p.Options.Separator))
+			slice = append(slice, tmp)
+		}
+	}
+
+	return slice, nil
+}

--- a/process/aggregate_test.go
+++ b/process/aggregate_test.go
@@ -1,0 +1,224 @@
+package process
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+)
+
+var aggregateTests = []struct {
+	name     string
+	proc     Aggregate
+	test     [][]byte
+	expected [][]byte
+	err      error
+}{
+	{
+		"single aggregate",
+		Aggregate{
+			Options: AggregateOptions{
+				Separator: `\n`,
+			},
+		},
+		[][]byte{
+			[]byte(`{"foo":"bar"}`),
+			[]byte(`{"baz":"qux"}`),
+			[]byte(`{"quux":"corge"}`),
+		},
+		[][]byte{
+			[]byte(`{"foo":"bar"}\n{"baz":"qux"}\n{"quux":"corge"}`),
+		},
+		nil,
+	},
+	// identical to the single buffer test, but improves performance due to lowered count and size limits
+	{
+		"single aggregate with better performance",
+		Aggregate{
+			Options: AggregateOptions{
+				Separator: `\n`,
+				MaxCount:  3,
+				MaxSize:   50,
+			},
+		},
+		[][]byte{
+			[]byte(`{"foo":"bar"}`),
+			[]byte(`{"baz":"qux"}`),
+			[]byte(`{"quux":"corge"}`),
+		},
+		[][]byte{
+			[]byte(`{"foo":"bar"}\n{"baz":"qux"}\n{"quux":"corge"}`),
+		},
+		nil,
+	},
+	{
+		"multiple aggregates",
+		Aggregate{
+			Options: AggregateOptions{
+				Separator: `\n`,
+				MaxCount:  2,
+			},
+		},
+		[][]byte{
+			[]byte(`{"foo":"bar"}`),
+			[]byte(`{"baz":"qux"}`),
+			[]byte(`{"quux":"corge"}`),
+		},
+		[][]byte{
+			[]byte(`{"foo":"bar"}\n{"baz":"qux"}`),
+			[]byte(`{"quux":"corge"}`),
+		},
+		nil,
+	},
+	{
+		"single JSON array aggregate",
+		Aggregate{
+			OutputKey: "aggregate.-1",
+		},
+		[][]byte{
+			[]byte(`{"foo":"bar"}`),
+			[]byte(`{"baz":"qux"}`),
+			[]byte(`{"quux":"corge"}`),
+		},
+		[][]byte{
+			[]byte(`{"aggregate":[{"foo":"bar"},{"baz":"qux"},{"quux":"corge"}]}`),
+		},
+		nil,
+	},
+	{
+		"multiple JSON array aggregates",
+		Aggregate{
+			Options: AggregateOptions{
+				MaxCount: 2,
+			},
+			OutputKey: "aggregate.-1",
+		},
+		[][]byte{
+			[]byte(`{"foo":"bar"}`),
+			[]byte(`{"baz":"qux"}`),
+			[]byte(`{"quux":"corge"}`),
+		},
+		[][]byte{
+			[]byte(`{"aggregate":[{"foo":"bar"},{"baz":"qux"}]}`),
+			[]byte(`{"aggregate":[{"quux":"corge"}]}`),
+		},
+		nil,
+	},
+	{
+		"single JSON array aggregate",
+		Aggregate{
+			OutputKey: "aggregate.-1",
+		},
+		[][]byte{
+			[]byte(`foo`),
+			[]byte(`bar`),
+			[]byte(`baz`),
+			[]byte(`qux`),
+			[]byte(`quux`),
+			[]byte(`corge`),
+		},
+		[][]byte{
+			[]byte(`{"aggregate":["foo","bar","baz","qux","quux","corge"]}`),
+		},
+		nil,
+	},
+	{
+		"multiple JSON array aggregates",
+		Aggregate{
+			Options: AggregateOptions{
+				MaxCount: 2,
+			},
+			OutputKey: "aggregate.-1",
+		},
+		[][]byte{
+			[]byte(`foo`),
+			[]byte(`bar`),
+			[]byte(`baz`),
+			[]byte(`qux`),
+			[]byte(`quux`),
+			[]byte(`corge`),
+		},
+		[][]byte{
+			[]byte(`{"aggregate":["foo","bar"]}`),
+			[]byte(`{"aggregate":["baz","qux"]}`),
+			[]byte(`{"aggregate":["quux","corge"]}`),
+		},
+		nil,
+	},
+	{
+		"JSON key aggregates",
+		Aggregate{
+			Options: AggregateOptions{
+				AggregateKey: "foo",
+			},
+			OutputKey: "aggregate.-1",
+		},
+		[][]byte{
+			[]byte(`{"foo":"bar"}`),
+			[]byte(`{"foo":"baz"}`),
+			[]byte(`{"foo":"bar"}`),
+			[]byte(`{"foo":"qux"}`),
+			[]byte(`{"foo":"bar"}`),
+		},
+		[][]byte{
+			[]byte(`{"aggregate":[{"foo":"bar"},{"foo":"bar"},{"foo":"bar"}]}`),
+			[]byte(`{"aggregate":[{"foo":"baz"}]}`),
+			[]byte(`{"aggregate":[{"foo":"qux"}]}`),
+		},
+		nil,
+	},
+	// results in error AggregateBufferSizeLimit due to MaxSize limit of 1 byte
+	{
+		"buffer size limit",
+		Aggregate{
+			Options: AggregateOptions{
+				Separator: `\n`,
+				MaxSize:   1,
+			},
+		},
+		[][]byte{
+			[]byte(`{"foo":"bar"}`),
+			[]byte(`{"baz":"qux"}`),
+		},
+		[][]byte{},
+		AggregateBufferSizeLimit,
+	},
+}
+
+func TestAggregate(t *testing.T) {
+	ctx := context.TODO()
+	for _, test := range aggregateTests {
+		res, err := test.proc.Slice(ctx, test.test)
+		if err != nil && errors.Is(err, test.err) {
+			continue
+		} else if err != nil {
+			t.Log(err)
+			t.Fail()
+		}
+
+		for i, processed := range res {
+			expected := test.expected[i]
+			if c := bytes.Compare(expected, processed); c != 0 {
+				t.Logf("expected %s, got %s", expected, string(processed))
+				t.Fail()
+			}
+		}
+	}
+}
+
+func benchmarkAggregateSlice(b *testing.B, slicer Aggregate, slice [][]byte) {
+	ctx := context.TODO()
+	for i := 0; i < b.N; i++ {
+		slicer.Slice(ctx, slice)
+	}
+}
+
+func BenchmarkAggregateSlice(b *testing.B) {
+	for _, test := range aggregateTests {
+		b.Run(string(test.name),
+			func(b *testing.B) {
+				benchmarkAggregateSlice(b, test.proc, test.test)
+			},
+		)
+	}
+}

--- a/process/concat.go
+++ b/process/concat.go
@@ -78,7 +78,7 @@ func (p Concat) Byte(ctx context.Context, data []byte) ([]byte, error) {
 	}
 
 	// only supports JSON, error early if there are no keys
-	if p.InputKey == "" && p.OutputKey == "" {
+	if p.InputKey == "" || p.OutputKey == "" {
 		return nil, fmt.Errorf("byter settings %+v: %w", p, ProcessorInvalidSettings)
 	}
 

--- a/process/convert.go
+++ b/process/convert.go
@@ -86,20 +86,22 @@ func (p Convert) Byte(ctx context.Context, data []byte) ([]byte, error) {
 	}
 
 	// only supports JSON, error early if there are no keys
-	if p.InputKey != "" && p.OutputKey != "" {
-		value := json.Get(data, p.InputKey)
-		switch p.Options.Type {
-		case "bool":
-			return json.Set(data, p.OutputKey, value.Bool())
-		case "int":
-			return json.Set(data, p.OutputKey, value.Int())
-		case "float":
-			return json.Set(data, p.OutputKey, value.Float())
-		case "uint":
-			return json.Set(data, p.OutputKey, value.Uint())
-		case "string":
-			return json.Set(data, p.OutputKey, value.String())
-		}
+	if p.InputKey == "" || p.OutputKey == "" {
+		return nil, fmt.Errorf("byter settings %+v: %w", p, ProcessorInvalidSettings)
+	}
+
+	value := json.Get(data, p.InputKey)
+	switch p.Options.Type {
+	case "bool":
+		return json.Set(data, p.OutputKey, value.Bool())
+	case "int":
+		return json.Set(data, p.OutputKey, value.Int())
+	case "float":
+		return json.Set(data, p.OutputKey, value.Float())
+	case "uint":
+		return json.Set(data, p.OutputKey, value.Uint())
+	case "string":
+		return json.Set(data, p.OutputKey, value.String())
 	}
 
 	return nil, fmt.Errorf("byter settings %+v: %w", p, ProcessorInvalidSettings)

--- a/process/dynamodb.go
+++ b/process/dynamodb.go
@@ -111,7 +111,7 @@ func (p DynamoDB) Byte(ctx context.Context, data []byte) ([]byte, error) {
 	}
 
 	// only supports JSON, error early if there are no keys
-	if p.InputKey == "" && p.OutputKey == "" {
+	if p.InputKey == "" || p.OutputKey == "" {
 		return nil, fmt.Errorf("byter settings %+v: %w", p, ProcessorInvalidSettings)
 	}
 

--- a/process/flatten.go
+++ b/process/flatten.go
@@ -70,7 +70,7 @@ func (p Flatten) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
 // Byte processes bytes with the Flatten processor.
 func (p Flatten) Byte(ctx context.Context, data []byte) ([]byte, error) {
 	// only supports JSON, error early if there are no keys
-	if p.InputKey == "" && p.OutputKey == "" {
+	if p.InputKey == "" || p.OutputKey == "" {
 		return nil, fmt.Errorf("byter settings %+v: %w", p, ProcessorInvalidSettings)
 	}
 

--- a/process/for_each.go
+++ b/process/for_each.go
@@ -98,7 +98,7 @@ above produces this temporary JSON during processing:
 */
 func (p ForEach) Byte(ctx context.Context, data []byte) ([]byte, error) {
 	// only supports JSON, error early if there are no keys
-	if p.InputKey == "" && p.OutputKey == "" {
+	if p.InputKey == "" || p.OutputKey == "" {
 		return nil, fmt.Errorf("byter settings %+v: %w", p, ProcessorInvalidSettings)
 	}
 

--- a/process/group.go
+++ b/process/group.go
@@ -71,7 +71,7 @@ func (p Group) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
 // Byte processes bytes with the Group processor.
 func (p Group) Byte(ctx context.Context, data []byte) ([]byte, error) {
 	// only supports JSON arrays, error early if there are no keys
-	if p.InputKey == "" && p.OutputKey == "" {
+	if p.InputKey == "" || p.OutputKey == "" {
 		return nil, fmt.Errorf("byter settings %+v: %w", p, ProcessorInvalidSettings)
 	}
 

--- a/process/lambda.go
+++ b/process/lambda.go
@@ -94,7 +94,7 @@ func (p Lambda) Byte(ctx context.Context, data []byte) ([]byte, error) {
 	}
 
 	// only supports JSON, error early if there are no keys
-	if p.InputKey == "" && p.OutputKey == "" {
+	if p.InputKey == "" || p.OutputKey == "" {
 		return nil, fmt.Errorf("byter settings %+v: %w", p, ProcessorInvalidSettings)
 	}
 

--- a/process/math.go
+++ b/process/math.go
@@ -83,7 +83,7 @@ func (p Math) Byte(ctx context.Context, data []byte) ([]byte, error) {
 	}
 
 	// only supports JSON, error early if there are no keys
-	if p.InputKey == "" && p.OutputKey == "" {
+	if p.InputKey == "" || p.OutputKey == "" {
 		return nil, fmt.Errorf("byter settings %+v: %w", p, ProcessorInvalidSettings)
 	}
 

--- a/process/process.go
+++ b/process/process.go
@@ -134,6 +134,10 @@ func ByterFactory(cfg config.Config) (Byter, error) {
 		var p Replace
 		config.Decode(cfg.Settings, &p)
 		return p, nil
+	case "split":
+		var p Split
+		config.Decode(cfg.Settings, &p)
+		return p, nil
 	case "time":
 		var p Time
 		config.Decode(cfg.Settings, &p)
@@ -146,6 +150,10 @@ func ByterFactory(cfg config.Config) (Byter, error) {
 // SlicerFactory loads a Slicer from a Config. This is the recommended function for retrieving ready-to-use Slicers.
 func SlicerFactory(cfg config.Config) (Slicer, error) {
 	switch t := cfg.Type; t {
+	case "aggregate":
+		var p Aggregate
+		config.Decode(cfg.Settings, &p)
+		return p, nil
 	case "base64":
 		var p Base64
 		config.Decode(cfg.Settings, &p)
@@ -232,6 +240,10 @@ func SlicerFactory(cfg config.Config) (Slicer, error) {
 		return p, nil
 	case "replace":
 		var p Replace
+		config.Decode(cfg.Settings, &p)
+		return p, nil
+	case "split":
+		var p Split
 		config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "time":

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -3,17 +3,20 @@ package process
 import (
 	"bytes"
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/brexhq/substation/internal/config"
 )
 
-var processTests = []struct {
+var processByteTests = []struct {
+	name     string
 	conf     []config.Config
 	test     []byte
 	expected []byte
 }{
 	{
+		"copy",
 		[]config.Config{
 			{
 				Type: "copy",
@@ -26,6 +29,7 @@ var processTests = []struct {
 		[]byte(`{"foo":"bar"}`),
 	},
 	{
+		"insert",
 		[]config.Config{
 			{
 				Type: "insert",
@@ -41,6 +45,7 @@ var processTests = []struct {
 		[]byte(`{"hello":"world","foo":"bar"}`),
 	},
 	{
+		"gzip",
 		[]config.Config{
 			{
 				Type: "gzip",
@@ -55,6 +60,7 @@ var processTests = []struct {
 		[]byte(`{"hello":"goodbye"}`),
 	},
 	{
+		"base64",
 		[]config.Config{
 			{
 				Type: "base64",
@@ -69,6 +75,24 @@ var processTests = []struct {
 		[]byte(`{"hello":"world"}`),
 	},
 	{
+		"split",
+		[]config.Config{
+			{
+				Type: "split",
+				Settings: map[string]interface{}{
+					"options": map[string]interface{}{
+						"separator": ".",
+					},
+					"input_key":  "foo",
+					"output_key": "foo",
+				},
+			},
+		},
+		[]byte(`{"foo":"bar.baz"}`),
+		[]byte(`{"foo":["bar","baz"]}`),
+	},
+	{
+		"time",
 		[]config.Config{
 			{
 				Type: "time",
@@ -90,7 +114,7 @@ var processTests = []struct {
 func TestByterAll(t *testing.T) {
 	ctx := context.TODO()
 
-	for _, test := range processTests {
+	for _, test := range processByteTests {
 		byters, err := MakeAllByters(test.conf)
 		if err != nil {
 			t.Log(err)
@@ -111,127 +135,188 @@ func TestByterAll(t *testing.T) {
 }
 
 func TestByterFactory(t *testing.T) {
-	ctx := context.TODO()
-
-	for _, test := range processTests {
-		conf := test.conf[0]
-		byter, err := ByterFactory(conf)
+	for _, test := range processByteTests {
+		_, err := ByterFactory(test.conf[0])
 		if err != nil {
 			t.Log(err)
-			t.Fail()
-		}
-
-		processed, err := byter.Byte(ctx, test.test)
-		if err != nil {
-			t.Log(err)
-			t.Fail()
-		}
-
-		if c := bytes.Compare(processed, test.expected); c != 0 {
-			t.Logf("expected %v, got %v", test.expected, processed)
 			t.Fail()
 		}
 	}
 }
 
+func benchmarkByterFactory(b *testing.B, conf config.Config) {
+	for i := 0; i < b.N; i++ {
+		ByterFactory(conf)
+	}
+}
+
+func BenchmarkByterFactory(b *testing.B) {
+	for _, test := range processByteTests {
+		b.Run(string(test.name),
+			func(b *testing.B) {
+				benchmarkByterFactory(b, test.conf[0])
+			},
+		)
+	}
+}
+
+func benchmarkByte(b *testing.B, conf []config.Config, data []byte) {
+	ctx := context.TODO()
+	for i := 0; i < b.N; i++ {
+		byters, _ := MakeAllByters(conf)
+		Byte(ctx, byters, data)
+	}
+}
+
+func BenchmarkByte(b *testing.B) {
+	for _, test := range processByteTests {
+		b.Run(string(test.name),
+			func(b *testing.B) {
+				benchmarkByte(b, test.conf, test.test)
+			},
+		)
+	}
+}
+
+var processSliceTests = []struct {
+	name     string
+	conf     []config.Config
+	test     [][]byte
+	expected [][]byte
+	err      error
+}{
+	{
+		"aggregate",
+		[]config.Config{
+			{
+				Type: "aggregate",
+				Settings: map[string]interface{}{
+					"options": map[string]interface{}{
+						"aggregate_key": "foo",
+					},
+					"output_key": "aggregate.-1",
+				},
+			},
+			{
+				Type: "copy",
+				Settings: map[string]interface{}{
+					"input_key":  "aggregate.#",
+					"output_key": "aggregate.0.count",
+				},
+			},
+			{
+				Type: "copy",
+				Settings: map[string]interface{}{
+					"input_key": "aggregate.0",
+				},
+			},
+		},
+		[][]byte{
+			[]byte(`{"foo":"bar"}`),
+			[]byte(`{"foo":"baz"}`),
+			[]byte(`{"foo":"bar"}`),
+			[]byte(`{"foo":"qux"}`),
+			[]byte(`{"foo":"bar"}`),
+			[]byte(`{"foo":"qux"}`),
+		},
+		[][]byte{
+			[]byte(`{"foo":"bar","count":3}`),
+			[]byte(`{"foo":"baz","count":1}`),
+			[]byte(`{"foo":"qux","count":2}`),
+		},
+		nil,
+	},
+	{
+		"split",
+		[]config.Config{
+			{
+				Type: "split",
+				Settings: map[string]interface{}{
+					"options": map[string]interface{}{
+						"separator": `\n`,
+					},
+				},
+			},
+		},
+		[][]byte{
+			[]byte(`foo\nbar\nbaz`),
+		},
+		[][]byte{
+			[]byte(`foo`),
+			[]byte(`bar`),
+			[]byte(`baz`),
+		},
+		nil,
+	},
+}
+
 func TestSlice(t *testing.T) {
 	ctx := context.TODO()
-	for _, test := range processTests {
-		slice := make([][]byte, 1, 1)
-		slice[0] = test.test
-
+	for _, test := range processSliceTests {
 		slicers, err := MakeAllSlicers(test.conf)
 		if err != nil {
 			t.Log(err)
 			t.Fail()
 		}
 
-		processed, err := Slice(ctx, slicers, slice)
-		if err != nil {
+		res, err := Slice(ctx, slicers, test.test)
+		if err != nil && errors.Is(err, test.err) {
+			continue
+		} else if err != nil {
 			t.Log(err)
 			t.Fail()
 		}
 
-		if c := bytes.Compare(processed[0], test.expected); c != 0 {
-			t.Logf("expected %v, got %v", test.expected, processed)
-			t.Fail()
+		for i, processed := range res {
+			expected := test.expected[i]
+			if c := bytes.Compare(expected, processed); c != 0 {
+				t.Logf("expected %s, got %s", expected, string(processed))
+				t.Fail()
+			}
 		}
 	}
 }
 
-func TestSliceFactory(t *testing.T) {
-	ctx := context.TODO()
-
-	for _, test := range processTests {
-		slice := make([][]byte, 1, 1)
-		slice[0] = test.test
-
-		conf := test.conf[0]
-		slicer, err := SlicerFactory(conf)
-		if err != nil {
-			t.Log(err)
-			t.Fail()
-		}
-
-		processed, err := slicer.Slice(ctx, slice)
-		if err != nil {
-			t.Log(err)
-			t.Fail()
-		}
-
-		if c := bytes.Compare(processed[0], test.expected); c != 0 {
-			t.Logf("expected %v, got %v", test.expected, processed)
-			t.Fail()
-		}
-	}
-}
-
-func BenchmarkByterFactory(b *testing.B) {
+func benchmarkSlice(b *testing.B, conf []config.Config, data [][]byte) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
-		byter, err := ByterFactory(processTests[0].conf[0])
-		if err != nil {
-			b.Log(err)
-			b.Fail()
-		}
-
-		byter.Byte(ctx, processTests[0].test)
+		slicers, _ := MakeAllSlicers(conf)
+		Slice(ctx, slicers, data)
 	}
 }
 
-var byter, _ = ByterFactory(processTests[0].conf[0])
+func BenchmarkSlice(b *testing.B) {
+	for _, test := range processSliceTests {
+		b.Run(string(test.name),
+			func(b *testing.B) {
+				benchmarkSlice(b, test.conf, test.test)
+			},
+		)
+	}
+}
 
-func BenchmarkByte(b *testing.B) {
-	ctx := context.TODO()
+func TestSlicerFactory(t *testing.T) {
+	for _, test := range processSliceTests {
+		_, err := SlicerFactory(test.conf[0])
+		if err != nil {
+			t.Log(err)
+			t.Fail()
+		}
+	}
+}
+
+func benchmarkSlicerFactory(b *testing.B, conf config.Config) {
 	for i := 0; i < b.N; i++ {
-		byter.Byte(ctx, processTests[0].test)
+		SlicerFactory(conf)
 	}
 }
 
 func BenchmarkSlicerFactory(b *testing.B) {
-	slice := make([][]byte, 1, 1)
-	slice[0] = processTests[0].test
-
-	ctx := context.TODO()
-	for i := 0; i < b.N; i++ {
-		slicer, err := SlicerFactory(processTests[0].conf[0])
-		if err != nil {
-			b.Log(err)
-			b.Fail()
-		}
-
-		slicer.Slice(ctx, slice)
-	}
-}
-
-var slicer, _ = SlicerFactory(processTests[0].conf[0])
-
-func BenchmarkSlice(b *testing.B) {
-	slice := make([][]byte, 1, 1)
-	slice[0] = processTests[0].test
-
-	ctx := context.TODO()
-	for i := 0; i < b.N; i++ {
-		slicer.Slice(ctx, slice)
+	for _, test := range processSliceTests {
+		b.Run(string(test.name),
+			func(b *testing.B) {
+				benchmarkSlicerFactory(b, test.conf[0])
+			},
+		)
 	}
 }

--- a/process/split.go
+++ b/process/split.go
@@ -1,0 +1,109 @@
+package process
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/brexhq/substation/condition"
+	"github.com/brexhq/substation/internal/json"
+)
+
+/*
+SplitOptions contains custom options settings for the Split processor:
+	Separator:
+		the string that separates aggregated data
+*/
+type SplitOptions struct {
+	Separator string `json:"separator"`
+}
+
+/*
+Split processes data by splitting it into multiple elements or items. The processor supports these patterns:
+	JSON:
+		{"split":"foo.bar"} >>> {"split":["foo","bar"]}
+	data:
+		foo\nbar\nbaz\qux >>> foo bar baz qux
+		{"foo":"bar"}\n{"baz":"qux"} >>> {"foo":"bar"} {"baz":"qux"}
+
+The processor uses this Jsonnet configuration:
+	{
+		type: 'split',
+		settings: {
+			options: {
+				separator: '.',
+			},
+			input_key: 'split',
+			output_key: 'split',
+		},
+	}
+*/
+type Split struct {
+	Options   SplitOptions             `json:"options"`
+	Condition condition.OperatorConfig `json:"condition"`
+	InputKey  string                   `json:"input_key"`
+	OutputKey string                   `json:"output_key"`
+}
+
+// Slice processes a slice of bytes with the Split processor. Conditions are optionally applied on the bytes to enable processing.
+func (p Split) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
+	op, err := condition.OperatorFactory(p.Condition)
+	if err != nil {
+		return nil, fmt.Errorf("slicer settings %+v: %w", p, err)
+	}
+
+	slice := NewSlice(&s)
+	for _, data := range s {
+		ok, err := op.Operate(data)
+		if err != nil {
+			return nil, fmt.Errorf("slicer settings %+v: %w", p, err)
+		}
+
+		if !ok {
+			slice = append(slice, data)
+			continue
+		}
+
+		// JSON processing
+		if p.InputKey != "" && p.OutputKey != "" {
+			processed, err := p.Byte(ctx, data)
+			if err != nil {
+				return nil, fmt.Errorf("slicer: %v", err)
+			}
+			slice = append(slice, processed)
+
+			continue
+		}
+
+		// data processing
+		if p.InputKey == "" && p.OutputKey == "" {
+			for _, x := range bytes.Split(data, []byte(p.Options.Separator)) {
+				slice = append(slice, x)
+			}
+
+			continue
+		}
+
+		return nil, fmt.Errorf("slicer settings %+v: %w", p, ProcessorInvalidSettings)
+	}
+
+	return slice, nil
+}
+
+// Byte processes bytes with the Split processor.
+func (p Split) Byte(ctx context.Context, data []byte) ([]byte, error) {
+	// error early if required options are missing
+	if p.Options.Separator == "" {
+		return nil, fmt.Errorf("byter settings %+v: %w", p, ProcessorInvalidSettings)
+	}
+
+	// only supports JSON, error early if there are no keys
+	if p.InputKey == "" || p.OutputKey == "" {
+		return nil, fmt.Errorf("byter settings %+v: %w", p, ProcessorInvalidSettings)
+	}
+
+	value := json.Get(data, p.InputKey).String()
+	split := strings.Split(value, p.Options.Separator)
+	return json.Set(data, p.OutputKey, split)
+}

--- a/process/split_test.go
+++ b/process/split_test.go
@@ -1,0 +1,155 @@
+package process
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+)
+
+var splitByteTests = []struct {
+	name     string
+	proc     Split
+	test     []byte
+	expected []byte
+	err      error
+}{
+	{
+		"JSON",
+		Split{
+			Options: SplitOptions{
+				Separator: ".",
+			},
+			InputKey:  "split",
+			OutputKey: "split",
+		},
+		[]byte(`{"split":"foo.bar"}`),
+		[]byte(`{"split":["foo","bar"]}`),
+		nil,
+	},
+	// the test case below is invalid because the Byter
+	// cannot split a single item into multiple items
+	{
+		"invalid settings",
+		Split{
+			Options: SplitOptions{
+				Separator: ".",
+			},
+		},
+		[]byte(`foo.bar`),
+		[]byte{},
+		ProcessorInvalidSettings,
+	},
+}
+
+func TestSplitByte(t *testing.T) {
+	ctx := context.TODO()
+	for _, test := range splitByteTests {
+		processed, err := test.proc.Byte(ctx, test.test)
+		if err != nil && errors.Is(err, test.err) {
+			continue
+		} else if err != nil {
+			t.Log(err)
+			t.Fail()
+		}
+
+		expected := test.expected
+		if c := bytes.Compare(expected, processed); c != 0 {
+			t.Logf("expected %s, got %s", expected, string(processed))
+			t.Fail()
+		}
+	}
+}
+
+func benchmarkSplitByte(b *testing.B, byter Split, data []byte) {
+	ctx := context.TODO()
+	for i := 0; i < b.N; i++ {
+		byter.Byte(ctx, data)
+	}
+}
+
+func BenchmarkSplitByte(b *testing.B) {
+	for _, test := range splitByteTests {
+		b.Run(string(test.name),
+			func(b *testing.B) {
+				benchmarkSplitByte(b, test.proc, test.test)
+			},
+		)
+	}
+}
+
+var splitSliceTests = []struct {
+	name     string
+	proc     Split
+	test     [][]byte
+	expected [][]byte
+	err      error
+}{
+	{
+		"data",
+		Split{
+			Options: SplitOptions{
+				Separator: `\n`,
+			},
+		},
+		[][]byte{
+			[]byte(`{"foo":"bar"}\n{"baz":"qux"}\n{"quux":"corge"}`),
+		},
+		[][]byte{
+			[]byte(`{"foo":"bar"}`),
+			[]byte(`{"baz":"qux"}`),
+			[]byte(`{"quux":"corge"}`),
+		},
+		nil,
+	},
+	{
+		"invalid settings",
+		Split{
+			InputKey: "split",
+			Options: SplitOptions{
+				Separator: ".",
+			},
+		},
+		[][]byte{},
+		[][]byte{},
+		ProcessorInvalidSettings,
+	},
+}
+
+func TestSplitSlice(t *testing.T) {
+	ctx := context.TODO()
+	for _, test := range splitSliceTests {
+		res, err := test.proc.Slice(ctx, test.test)
+		if err != nil && errors.Is(err, test.err) {
+			continue
+		} else if err != nil {
+			t.Log(err)
+			t.Fail()
+		}
+
+		for i, processed := range res {
+			expected := test.expected[i]
+			if c := bytes.Compare(expected, processed); c != 0 {
+				t.Logf("expected %s, got %s", expected, string(processed))
+				t.Fail()
+			}
+		}
+	}
+}
+
+func benchmarkSplitSlice(b *testing.B, slicer Split, slice [][]byte) {
+	ctx := context.TODO()
+	for i := 0; i < b.N; i++ {
+		slicer.Slice(ctx, slice)
+	}
+}
+
+func BenchmarkSplitSlice(b *testing.B) {
+	for _, test := range splitSliceTests {
+		b.Run(string(test.name),
+			func(b *testing.B) {
+				benchmarkSplitSlice(b, test.proc, test.test)
+			},
+		)
+	}
+}


### PR DESCRIPTION
## Description
- Adds Aggregate processor
- Adds Split processor
- Adds Length inspector
- Fixes incorrect JSON parsing logic in some processors
- Updates Condition and Process tests with better support for [table driven tests](https://dave.cheney.net/2019/05/07/prefer-table-driven-tests)

## Motivation and Context
These changes introduce the ability for user-defined aggregation and "de-aggregation" of data. 

Until now the ability to aggregate data was limited to sinks (e.g., Kinesis, Sumo Logic), but this provides flexibility in how users join data together during the transformation process. The primary use case for this is to reduce the number of emitted events, which can be achieved at least two ways:
- [Aggregate data into JSON arrays](https://github.com/brexhq/substation/pull/10/files#diff-777524ea7822511be6057bf60384fcd7d12e971c64e65469fa91fe42f921f6e8R73-R87), resulting in fewer events that are larger in size with no data loss
- [Summarize duplicate data in JSON objects](https://github.com/brexhq/substation/pull/10/files#diff-f36536d30bc87f99132e4b7102e0f0c05ab2ddd05c08439d7d98a18efdc43729R188-R228), resulting in fewer events with purposeful data loss

The Split processor and Length inspector were added as complementary functions to support aggregation. Split (along with the existing Expand processor) can "de-aggregate" data and Length can filter aggregated data that exceeds a total length threshold.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
- All new features have unit tests
- libsonnet support was tested via the file/substation app
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
