### PR TITLE
fix: Process Jsonnet Errors

### DIFF
--- a/config/process.libsonnet
+++ b/config/process.libsonnet
@@ -58,7 +58,7 @@
     type: 'delete',
     settings: {
       condition: { operator: condition_operator, inspectors: condition_inspectors},
-      input: input,
+      input_key: input,
     },
   },
   domain(input, output, _function, 
@@ -91,7 +91,7 @@
     type: 'expand',
     settings: {
       condition: { operator: condition_operator, inspectors: condition_inspectors},
-      input: input,
+      input_key: input,
     },
   },
   flatten(input, output, 
@@ -104,6 +104,15 @@
       input_key: input, output_key: output,
     },
   },
+  for_each(input, output, processor, 
+           condition_operator='', condition_inspectors=[]): {
+    type: 'for_each',
+    settings: {
+      options: { processor: processor },
+      condition: { operator: condition_operator, inspectors: condition_inspectors},
+      input_key: input, output_key: output,
+    },
+  },  
   group(input, output, 
         keys=[], 
         condition_operator='', condition_inspectors=[]): {
@@ -138,7 +147,7 @@
     settings: {
       options: { value: value },
       condition: { operator: condition_operator, inspectors: condition_inspectors},
-      output: output,
+      output_key: output,
     },
   },
   lambda(input, output, _function, 
@@ -156,6 +165,15 @@
     type: 'math',
     settings: {
       options: { operation: operation },
+      condition: { operator: condition_operator, inspectors: condition_inspectors},
+      input_key: input, output_key: output,
+    },
+  },
+  pipeline(input, output, processors, 
+           condition_operator='', condition_inspectors=[]): {
+    type: 'pipeline',
+    settings: {
+      options: { processors: processors },
       condition: { operator: condition_operator, inspectors: condition_inspectors},
       input_key: input, output_key: output,
     },

--- a/internal/json/json_test.go
+++ b/internal/json/json_test.go
@@ -41,6 +41,16 @@ var getTests = []struct {
 		test:     []byte(`{"foo":false}`),
 		expected: false,
 	},
+	{
+		name: "multi-line",
+		key:  "foo",
+		test: []byte(`{
+"foo":
+"string"
+}
+`),
+		expected: "string",
+	},
 }
 
 func TestGetJson(t *testing.T) {

--- a/process/for_each.go
+++ b/process/for_each.go
@@ -103,6 +103,8 @@ func (p ForEach) Byte(ctx context.Context, data []byte) ([]byte, error) {
 		return nil, fmt.Errorf("byter settings %+v: %w", p, ProcessorInvalidSettings)
 	}
 
+	// processor settings loaded via Jsonnet may create invalid keys such as
+	// `foo.bar.` -- the trailing dot creates an invalid path, so it is trimmed
 	if _, ok := p.Options.Processor.Settings["input_key"]; ok {
 		p.Options.Processor.Settings["input_key"] = p.Options.Processor.Type + "." + p.Options.Processor.Settings["input_key"].(string)
 	} else {

--- a/process/for_each.go
+++ b/process/for_each.go
@@ -3,6 +3,7 @@ package process
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/brexhq/substation/condition"
 	"github.com/brexhq/substation/internal/config"
@@ -107,12 +108,14 @@ func (p ForEach) Byte(ctx context.Context, data []byte) ([]byte, error) {
 	} else {
 		p.Options.Processor.Settings["input_key"] = p.Options.Processor.Type
 	}
+	p.Options.Processor.Settings["input_key"] = strings.TrimSuffix(p.Options.Processor.Settings["input_key"].(string), ".")
 
 	if _, ok := p.Options.Processor.Settings["output_key"]; ok {
 		p.Options.Processor.Settings["output_key"] = p.Options.Processor.Type + "." + p.Options.Processor.Settings["output_key"].(string)
 	} else {
 		p.Options.Processor.Settings["output_key"] = p.Options.Processor.Type
 	}
+	p.Options.Processor.Settings["output_key"] = strings.TrimSuffix(p.Options.Processor.Settings["output_key"].(string), ".")
 
 	byter, err := ByterFactory(p.Options.Processor)
 	if err != nil {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Fixes a bug in the ForEach processor when loading a config via Jsonnet
- Fixes incorrect settings in process.libsonnet functions
- Adds missing ForEach and Pipeline libsonnet functions
- Adds new test case for getting multi-line JSON

## Motivation and Context
This fixes an unreported issue that was observed when working with the ForEach processor -- some Jsonnet configurations can create incorrect JSON paths (e.g., `foo.bar.`, the trailing dot is an invalid path). 

This also fixes miscellaneous errors in the process.libsonnet file (missing functions and incorrect settings in functions) and adds a new test case for getting multi-line JSON objects.

## How Has This Been Tested?
Jsonnet changes were tested with local integration tests using the Substation file app.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
