### PR TITLE
feat: PrettyPrint Processor

### DIFF
--- a/config/process.libsonnet
+++ b/config/process.libsonnet
@@ -160,6 +160,14 @@
       input_key: input, output_key: output,
     },
   },
+  pretty_print(direction,
+               condition_operator='', condition_inspectors=[]): {
+    type: 'pretty_print',
+    settings: {
+      options: { direction: direction },
+      condition: { operator: condition_operator, inspectors: condition_inspectors},
+    },
+  },
   replace(input, output, old, new, 
           count=-1, 
           condition_operator='', condition_inspectors=[]): {

--- a/process/pretty_print.go
+++ b/process/pretty_print.go
@@ -1,0 +1,181 @@
+package process
+
+/*
+
+ */
+
+import (
+	"bytes"
+	"context"
+	gojson "encoding/json"
+	"fmt"
+
+	"github.com/brexhq/substation/condition"
+	"github.com/brexhq/substation/internal/errors"
+	"github.com/brexhq/substation/internal/json"
+)
+
+// used with json.Get, returns a pretty printed root JSON object
+const ppModifier = `@this|@pretty`
+const openCurlyBracket = 123  // {
+const closeCurlyBracket = 125 // }
+
+/*
+PrettyPrintUnbalancedBrackets is returned when the processor is given input
+that does not contain an equal number of open curly brackets ( { ) and close
+curly brackets ( } ). The most common causes of this error are invalid input JSON
+(e.g., `{{"foo":"bar"}`) or using the processor with multi-core processing enabled.
+*/
+const PrettyPrintUnbalancedBrackets = errors.Error("PrettyPrintUnbalancedBrackets")
+
+/*
+PrettyPrintOptions contains custom options settings for the PrettyPrint processor:
+	Direction:
+		the direction of the pretty transformation
+		must be one of:
+			to: applies prettyprint formatting
+			from: reverses prettyprint formatting
+*/
+type PrettyPrintOptions struct {
+	Direction string `json:"direction"`
+}
+
+/*
+PrettyPrint processes data by applying or reversing prettyprint formatting to JSON.
+This processor has significant limitations when used to reverse prettyprint, including:
+	- cannot support multi-core processing
+	- invalid input will cause unpredictable results
+
+It is strongly recommended to _not_ use this processor unless absolutely necessary; a
+more reliable solution is to modify the source application emitting the multi-line JSON
+object so that it outputs a single-line object instead.
+
+The processor supports these patterns:
+	data:
+		{
+			"foo": "bar"
+		}  >>> {"foo":"bar"}
+
+		{"foo":"bar"} >>> {
+			"foo": "bar"
+		}
+
+The processor uses this Jsonnet configuration:
+	{
+		type: 'pretty_print',
+		settings: {
+			options: {
+				direction: 'from',
+			},
+		},
+	}
+*/
+type PrettyPrint struct {
+	Options   PrettyPrintOptions       `json:"options"`
+	Condition condition.OperatorConfig `json:"condition"`
+}
+
+/*
+Slice processes bytes with the PrettyPrint processor.
+
+Applying prettyprint formatting is handled by the
+gjson PrettyPrint modifier and is applied to the root
+JSON object.
+
+Reversing prettyprint formatting is handled by
+iterating incoming data per byte and pushing the
+bytes to a stack. When an equal number of open
+and close curly brackets ( { } ) are observed,
+then the stack of bytes has JSON compaction
+applied and the result is emitted as a new object.
+*/
+func (p PrettyPrint) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
+	// error early if required options are missing
+	if p.Options.Direction == "" {
+		return nil, fmt.Errorf("byter settings %+v: %w", p, ProcessorInvalidSettings)
+	}
+
+	op, err := condition.OperatorFactory(p.Condition)
+	if err != nil {
+		return nil, fmt.Errorf("slicer settings %+v: %w", p, err)
+	}
+
+	var count int
+	var stack []byte
+
+	slice := NewSlice(&s)
+	for _, data := range s {
+		ok, err := op.Operate(data)
+		if err != nil {
+			return nil, fmt.Errorf("slicer settings %+v: %w", p, err)
+		}
+
+		if !ok {
+			slice = append(slice, data)
+			continue
+		}
+
+		switch p.Options.Direction {
+		case "to":
+			s := json.Get(data, ppModifier).String()
+			slice = append(slice, []byte(s))
+
+		case "from":
+			for _, d := range data {
+				stack = append(stack, d)
+
+				if d == openCurlyBracket {
+					count++
+				}
+
+				if d == closeCurlyBracket {
+					count--
+				}
+
+				if count == 0 {
+					var buf bytes.Buffer
+					if err := gojson.Compact(&buf, stack); err != nil {
+						return nil, err
+					}
+
+					slice = append(slice, buf.Bytes())
+					stack = []byte{}
+				}
+			}
+
+		default:
+			return nil, fmt.Errorf("slicer settings %+v: %w", p, ProcessorInvalidSettings)
+		}
+	}
+
+	if count != 0 {
+		return nil, fmt.Errorf("slicer settings %+v: %w", p, PrettyPrintUnbalancedBrackets)
+	}
+
+	return slice, nil
+}
+
+/*
+Byte processes bytes with the PrettyPrint processor.
+
+Applying prettyprint formatting is handled by the
+gjson PrettyPrint modifier and is applied to the root
+JSON object.
+
+Byte _does not_ support reversing prettyprint formatting;
+this support is unnecessary for multi-line JSON objects
+that are stored in a single byte array.
+*/
+func (p PrettyPrint) Byte(ctx context.Context, data []byte) ([]byte, error) {
+	// error early if required options are missing
+	if p.Options.Direction == "" {
+		return nil, fmt.Errorf("byter settings %+v: %w", p, ProcessorInvalidSettings)
+	}
+
+	if p.Options.Direction == "to" {
+		value := json.Get(data, ppModifier).String()
+		return []byte(value), nil
+	}
+
+	return nil, fmt.Errorf("slicer settings %+v: %w", p, ProcessorInvalidSettings)
+}

--- a/process/pretty_print.go
+++ b/process/pretty_print.go
@@ -135,7 +135,7 @@ func (p PrettyPrint) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
 				if count == 0 {
 					var buf bytes.Buffer
 					if err := gojson.Compact(&buf, stack); err != nil {
-						return nil, err
+						return nil, fmt.Errorf("slicer settings %+v: %w", p, err)
 					}
 
 					if json.Valid(buf.Bytes()) {

--- a/process/pretty_print.go
+++ b/process/pretty_print.go
@@ -138,7 +138,10 @@ func (p PrettyPrint) Slice(ctx context.Context, s [][]byte) ([][]byte, error) {
 						return nil, err
 					}
 
-					slice = append(slice, buf.Bytes())
+					if json.Valid(buf.Bytes()) {
+						slice = append(slice, buf.Bytes())
+					}
+
 					stack = []byte{}
 				}
 			}

--- a/process/pretty_print_test.go
+++ b/process/pretty_print_test.go
@@ -1,0 +1,208 @@
+package process
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+)
+
+var prettyPrintSliceTests = []struct {
+	name     string
+	proc     PrettyPrint
+	test     [][]byte
+	expected [][]byte
+	err      error
+}{
+	{
+		"from",
+		PrettyPrint{
+			Options: PrettyPrintOptions{
+				Direction: "from",
+			},
+		},
+		[][]byte{
+			[]byte(`{
+				"foo":"bar"
+				}`),
+		},
+		[][]byte{
+			[]byte(`{"foo":"bar"}`),
+		},
+		nil,
+	},
+	{
+		"from",
+		PrettyPrint{
+			Options: PrettyPrintOptions{
+				Direction: "from",
+			},
+		},
+		[][]byte{
+			[]byte(`{`),
+			[]byte(`"foo":"bar",`),
+			[]byte(`"baz": {`),
+			[]byte(`	"qux": "corge"`),
+			[]byte(`}`),
+			[]byte(`}`),
+		},
+		[][]byte{
+			[]byte(`{"foo":"bar","baz":{"qux":"corge"}}`),
+		},
+		nil,
+	},
+	{
+		"to",
+		PrettyPrint{
+			Options: PrettyPrintOptions{
+				Direction: "to",
+			},
+		},
+		[][]byte{
+			[]byte(`{"foo":"bar"}`),
+		},
+		[][]byte{
+			[]byte(`{
+  "foo": "bar"
+}
+`),
+		},
+		nil,
+	},
+	{
+		"invalid settings",
+		PrettyPrint{
+			Options: PrettyPrintOptions{
+				Direction: "foo",
+			},
+		},
+		[][]byte{
+			[]byte(`{"foo":"bar"}`),
+		},
+		[][]byte{},
+		ProcessorInvalidSettings,
+	},
+	{
+		"unbalanced brackets",
+		PrettyPrint{
+			Options: PrettyPrintOptions{
+				Direction: "from",
+			},
+		},
+		[][]byte{
+			[]byte(`{{`),
+			[]byte(`"foo":"bar"`),
+			[]byte(`}`),
+		},
+		[][]byte{},
+		PrettyPrintUnbalancedBrackets,
+	},
+}
+
+func TestPrettyPrintSlice(t *testing.T) {
+	ctx := context.TODO()
+	for _, test := range prettyPrintSliceTests {
+		res, err := test.proc.Slice(ctx, test.test)
+		if err != nil && errors.Is(err, test.err) {
+			continue
+		} else if err != nil {
+			t.Log(err)
+			t.Fail()
+		}
+
+		for i, processed := range res {
+			expected := test.expected[i]
+			if c := bytes.Compare(expected, processed); c != 0 {
+				t.Logf("expected %s, got %s", expected, processed)
+				t.Fail()
+			}
+		}
+	}
+}
+
+func benchmarkPrettyPrintSlice(b *testing.B, slicer PrettyPrint, slice [][]byte) {
+	ctx := context.TODO()
+	for i := 0; i < b.N; i++ {
+		slicer.Slice(ctx, slice)
+	}
+}
+
+func BenchmarkPrettyPrintSlice(b *testing.B) {
+	for _, test := range prettyPrintSliceTests {
+		b.Run(string(test.name),
+			func(b *testing.B) {
+				benchmarkPrettyPrintSlice(b, test.proc, test.test)
+			},
+		)
+	}
+}
+
+var prettyPrintByteTests = []struct {
+	name     string
+	proc     PrettyPrint
+	test     []byte
+	expected []byte
+	err      error
+}{
+	{
+		"to",
+		PrettyPrint{
+			Options: PrettyPrintOptions{
+				Direction: "to",
+			},
+		},
+		[]byte(`{"foo":"bar"}`),
+		[]byte(`{
+  "foo": "bar"
+}
+`),
+		nil,
+	},
+	// PrettyPrint from is not supported in Byter
+	{
+		"invalid settings",
+		PrettyPrint{
+			Options: PrettyPrintOptions{
+				Direction: "from",
+			},
+		},
+		[]byte(`{"foo":"bar"}`),
+		[]byte{},
+		ProcessorInvalidSettings,
+	},
+}
+
+func TestPrettyPrintByte(t *testing.T) {
+	ctx := context.TODO()
+	for _, test := range prettyPrintByteTests {
+		res, err := test.proc.Byte(ctx, test.test)
+		if err != nil && errors.Is(err, test.err) {
+			continue
+		} else if err != nil {
+			t.Log(err)
+			t.Fail()
+		}
+
+		if c := bytes.Compare(test.expected, res); c != 0 {
+			t.Logf("expected %s, got %s", test.expected, res)
+			t.Fail()
+		}
+	}
+}
+
+func benchmarkPrettyPrintByte(b *testing.B, byter PrettyPrint, data []byte) {
+	ctx := context.TODO()
+	for i := 0; i < b.N; i++ {
+		byter.Byte(ctx, data)
+	}
+}
+
+func BenchmarkPrettyPrintByte(b *testing.B) {
+	for _, test := range prettyPrintByteTests {
+		b.Run(string(test.name),
+			func(b *testing.B) {
+				benchmarkPrettyPrintByte(b, test.proc, test.test)
+			},
+		)
+	}
+}

--- a/process/process.go
+++ b/process/process.go
@@ -130,6 +130,10 @@ func ByterFactory(cfg config.Config) (Byter, error) {
 		var p Pipeline
 		config.Decode(cfg.Settings, &p)
 		return p, nil
+	case "pretty_print":
+		var p PrettyPrint
+		config.Decode(cfg.Settings, &p)
+		return p, nil
 	case "replace":
 		var p Replace
 		config.Decode(cfg.Settings, &p)
@@ -228,6 +232,10 @@ func SlicerFactory(cfg config.Config) (Slicer, error) {
 		return p, nil
 	case "pipeline":
 		var p Pipeline
+		config.Decode(cfg.Settings, &p)
+		return p, nil
+	case "pretty_print":
+		var p PrettyPrint
 		config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "replace":

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -92,7 +92,7 @@ var processByteTests = []struct {
 		[]byte(`{"foo":["bar","baz"]}`),
 	},
 	{
-		"time",
+		"pretty_print",
 		[]config.Config{
 			{
 				Type: "pretty_print",
@@ -110,6 +110,7 @@ var processByteTests = []struct {
 `),
 	},
 	{
+		"time",
 		[]config.Config{
 			{
 				Type: "time",

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -71,6 +71,23 @@ var processTests = []struct {
 	{
 		[]config.Config{
 			{
+				Type: "pretty_print",
+				Settings: map[string]interface{}{
+					"options": map[string]interface{}{
+						"direction": "to",
+					},
+				},
+			},
+		},
+		[]byte(`{"foo":"bar"}`),
+		[]byte(`{
+  "foo": "bar"
+}
+`),
+	},
+	{
+		[]config.Config{
+			{
 				Type: "time",
 				Settings: map[string]interface{}{
 					"input_key":  "foo",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Adds PrettyPrint processor

## Motivation and Context
There are rare cases where a [prettyprint](https://en.wikipedia.org/wiki/Prettyprint) / multi-line JSON object may be ingested by Substation pipelines; the most likely cause is from reading a file that contains prettyprint objects. If this happens today, then the JSON object is immediately made invalid because the system reads files line-by-line using a [Scanner](https://pkg.go.dev/bufio#Scanner). For example, reading a file that contains the JSON object below would produce 3 byte inputs (where each line is one byte array): 
```
{
    "foo": "bar"
}
```

The PrettyPrint processor addresses this edge case by streaming all bytes in a slice into a [stack](https://en.wikipedia.org/wiki/Stack_(abstract_data_type)) and checks for balanced curly brackets (`{` and `}`); if the brackets are balanced, then it is assumed that the stack contains one valid JSON object, so the stack's data is [compacted](https://pkg.go.dev/encoding/json#Compact) and [validated](https://pkg.go.dev/encoding/json#Valid) before being output as a single-line JSON object. 

In practice, there are known failure scenarios where this processor will produce invalid JSON:
- the processor does not support multi-core processing (otherwise the prettyprint JSON may end up in different goroutines, corrupting the data)
- invalid input will produce unpredictable results (e.g., `{{"foo":"bar"}` will cause problems)

These issues become immediately evident during testing:
```
$ ./substation -input test.json -config config.json  -transforms 1
{
        "foo": "bar"
}

$ ./substation -input test.json -config config.json  -transforms 3
}
{
        "foo": "bar"
```


Overall the recommendation is _don't use this processor unless absolutely necessary_; if possible, then it's better to change the source application to stop producing prettyprint JSON. 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
- Added unit tests for PrettyPrint Bytes and Slices
- Added unit test in the process ByterFactory for retrieving a PrettyPrint Byter
- Integration tested locally using the process.libsonnet function and the Substation file app

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
