### PR TITLE
fix: replace golint with staticcheck

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -18,8 +18,8 @@ jobs:
 
     - name: lint
       run: |
-        go get golang.org/x/lint/golint
-        golint -set_exit_status ./...
+        go install honnef.co/go/tools/cmd/staticcheck@latest
+        staticcheck -checks all,-ST1000 ./...
 
     - name: tests
       run: go test -timeout 30s -v ./... 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   "terminal.integrated.defaultProfile.linux": "bash",
   "go.formatTool": "gofmt",
-  "go.lintTool": "golint",
   "go.inferGopath": false,
+  "go.lintFlags": ["-checks=all,-ST1000"],
+  "go.lintOnSave": "workspace",
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Replaces the deprecated [golint](https://github.com/golang/lint) tool with [staticcheck](https://staticcheck.io/docs/getting-started/). staticcheck is the recommended replacement for golint and gives us the ability to ignore lint errors. 

golint is replaced in both the lint GitHub Action and in the VS Code workspace settings.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

golint is deprecated and we had the need to ignore specific lint errors.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

staticcheck was tested locally in VS Code. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
