### PR TITLE
refactor: Update Public Errors

### DIFF
--- a/condition/condition.go
+++ b/condition/condition.go
@@ -79,7 +79,7 @@ func InspectorFactory(cfg config.Config) (Inspector, error) {
 		config.Decode(cfg.Settings, &i)
 		return i, nil
 	default:
-		return nil, fmt.Errorf("condition settings %v: %w", cfg.Settings, InspectorInvalidFactoryConfig)
+		return nil, fmt.Errorf("condition inspectorfactory: settings %+v: %v", cfg.Settings, InspectorInvalidFactoryConfig)
 	}
 }
 
@@ -96,7 +96,7 @@ type AND struct {
 // Operate returns true if all Inspectors return true, otherwise it returns false.
 func (o AND) Operate(ctx context.Context, cap config.Capsule) (bool, error) {
 	if len(o.Inspectors) == 0 {
-		return false, fmt.Errorf("operator settings %+v: %w", o, OperatorMissingInspectors)
+		return false, fmt.Errorf("condition operate: inspectors %+v: %v", o, OperatorMissingInspectors)
 	}
 
 	for _, i := range o.Inspectors {
@@ -124,7 +124,7 @@ type OR struct {
 // Operate returns true if any Inspectors return true, otherwise it returns false.
 func (o OR) Operate(ctx context.Context, cap config.Capsule) (bool, error) {
 	if len(o.Inspectors) == 0 {
-		return false, fmt.Errorf("operator settings %+v: %w", o, OperatorMissingInspectors)
+		return false, fmt.Errorf("condition operate: inspectors %+v: %v", o, OperatorMissingInspectors)
 	}
 
 	for _, i := range o.Inspectors {
@@ -151,7 +151,7 @@ type NAND struct {
 // Operate returns true if all Inspectors return false, otherwise it returns true.
 func (o NAND) Operate(ctx context.Context, cap config.Capsule) (bool, error) {
 	if len(o.Inspectors) == 0 {
-		return false, fmt.Errorf("operator settings %+v: %w", o, OperatorMissingInspectors)
+		return false, fmt.Errorf("condition operate: inspectors %+v: %v", o, OperatorMissingInspectors)
 	}
 
 	for _, i := range o.Inspectors {
@@ -178,7 +178,7 @@ type NOR struct {
 // Operate returns true if any Inspectors return false, otherwise it returns true.
 func (o NOR) Operate(ctx context.Context, cap config.Capsule) (bool, error) {
 	if len(o.Inspectors) == 0 {
-		return false, fmt.Errorf("operator settings %+v: %w", o, OperatorMissingInspectors)
+		return false, fmt.Errorf("condition operate: inspectors %+v: %v", o, OperatorMissingInspectors)
 	}
 
 	for _, i := range o.Inspectors {

--- a/condition/condition_test.go
+++ b/condition/condition_test.go
@@ -94,7 +94,10 @@ var conditionANDTests = []struct {
 func TestAND(t *testing.T) {
 	ctx := context.TODO()
 	cap := config.NewCapsule()
+
 	for _, test := range conditionANDTests {
+		cap.SetData(test.test)
+
 		cfg := Config{
 			Operator:   "and",
 			Inspectors: test.conf,
@@ -106,7 +109,6 @@ func TestAND(t *testing.T) {
 			t.Fail()
 		}
 
-		cap.SetData(test.test)
 		ok, err := op.Operate(ctx, cap)
 		if err != nil {
 			t.Log(err)
@@ -223,7 +225,10 @@ var conditionORTests = []struct {
 func TestOR(t *testing.T) {
 	ctx := context.TODO()
 	cap := config.NewCapsule()
+
 	for _, test := range conditionORTests {
+		cap.SetData(test.test)
+
 		cfg := Config{
 			Operator:   "or",
 			Inspectors: test.conf,
@@ -235,7 +240,6 @@ func TestOR(t *testing.T) {
 			t.Fail()
 		}
 
-		cap.SetData(test.test)
 		ok, err := op.Operate(ctx, cap)
 		if err != nil {
 			t.Log(err)
@@ -324,7 +328,10 @@ var conditionNANDTests = []struct {
 func TestNAND(t *testing.T) {
 	ctx := context.TODO()
 	cap := config.NewCapsule()
+
 	for _, test := range conditionNANDTests {
+		cap.SetData(test.test)
+
 		cfg := Config{
 			Operator:   "nand",
 			Inspectors: test.conf,
@@ -336,7 +343,6 @@ func TestNAND(t *testing.T) {
 			t.Fail()
 		}
 
-		cap.SetData(test.test)
 		ok, err := op.Operate(ctx, cap)
 		if err != nil {
 			t.Log(err)
@@ -425,7 +431,10 @@ var conditionNORTests = []struct {
 func TestNOR(t *testing.T) {
 	ctx := context.TODO()
 	cap := config.NewCapsule()
+
 	for _, test := range conditionNORTests {
+		cap.SetData(test.test)
+
 		cfg := Config{
 			Operator:   "nor",
 			Inspectors: test.conf,
@@ -437,7 +446,6 @@ func TestNOR(t *testing.T) {
 			t.Fail()
 		}
 
-		cap.SetData(test.test)
 		ok, err := op.Operate(ctx, cap)
 		if err != nil {
 			t.Log(err)

--- a/condition/content_test.go
+++ b/condition/content_test.go
@@ -73,9 +73,15 @@ var contentTests = []struct {
 func TestContent(t *testing.T) {
 	ctx := context.TODO()
 	cap := config.NewCapsule()
+
 	for _, test := range contentTests {
 		cap.SetData(test.test)
-		check, _ := test.inspector.Inspect(ctx, cap)
+
+		check, err := test.inspector.Inspect(ctx, cap)
+		if err != nil {
+			t.Log(err)
+			t.Fail()
+		}
 
 		if test.expected != check {
 			t.Logf("expected %v, got %v", test.expected, check)

--- a/condition/ip.go
+++ b/condition/ip.go
@@ -81,7 +81,7 @@ func (c IP) Inspect(ctx context.Context, cap config.Capsule) (output bool, err e
 	case "unspecified":
 		matched = ip.IsUnspecified()
 	default:
-		return false, fmt.Errorf("inspector settings %+v: %w", c, IPInvalidType)
+		return false, fmt.Errorf("condition ip: type %s: %v", c.Type, IPInvalidType)
 	}
 
 	if c.Negate {

--- a/condition/ip_test.go
+++ b/condition/ip_test.go
@@ -83,9 +83,15 @@ var ipTests = []struct {
 func TestIP(t *testing.T) {
 	ctx := context.TODO()
 	cap := config.NewCapsule()
+
 	for _, test := range ipTests {
 		cap.SetData(test.test)
-		check, _ := test.inspector.Inspect(ctx, cap)
+
+		check, err := test.inspector.Inspect(ctx, cap)
+		if err != nil {
+			t.Log(err)
+			t.Fail()
+		}
 
 		if test.expected != check {
 			t.Logf("expected %v, got %v, %v", test.expected, check, string(test.test))

--- a/condition/json_test.go
+++ b/condition/json_test.go
@@ -60,9 +60,15 @@ var jsonSchemaTests = []struct {
 func TestJSONSchema(t *testing.T) {
 	ctx := context.TODO()
 	cap := config.NewCapsule()
+
 	for _, test := range jsonSchemaTests {
 		cap.SetData(test.test)
-		check, _ := test.inspector.Inspect(ctx, cap)
+
+		check, err := test.inspector.Inspect(ctx, cap)
+		if err != nil {
+			t.Log(err)
+			t.Fail()
+		}
 
 		if test.expected != check {
 			t.Logf("expected %v, got %v, %v", test.expected, check, string(test.test))
@@ -129,9 +135,15 @@ var jsonValidTests = []struct {
 func TestJSONValid(t *testing.T) {
 	ctx := context.TODO()
 	cap := config.NewCapsule()
+
 	for _, test := range jsonValidTests {
 		cap.SetData(test.test)
-		check, _ := test.inspector.Inspect(ctx, cap)
+
+		check, err := test.inspector.Inspect(ctx, cap)
+		if err != nil {
+			t.Log(err)
+			t.Fail()
+		}
 
 		if test.expected != check {
 			t.Logf("expected %v, got %v, %v", test.expected, check, string(test.test))

--- a/condition/length.go
+++ b/condition/length.go
@@ -103,7 +103,7 @@ func (c Length) match(length int) (bool, error) {
 			matched = true
 		}
 	default:
-		return false, fmt.Errorf("inspector settings %+v: %w", c, LengthInvalidFunction)
+		return false, fmt.Errorf("condition length: function %s: %v", c.Function, LengthInvalidFunction)
 	}
 
 	if c.Negate {

--- a/condition/length_test.go
+++ b/condition/length_test.go
@@ -216,9 +216,15 @@ var lengthTests = []struct {
 func TestLength(t *testing.T) {
 	ctx := context.TODO()
 	cap := config.NewCapsule()
+
 	for _, test := range lengthTests {
 		cap.SetData(test.test)
-		check, _ := test.inspector.Inspect(ctx, cap)
+
+		check, err := test.inspector.Inspect(ctx, cap)
+		if err != nil {
+			t.Log(err)
+			t.Fail()
+		}
 
 		if test.expected != check {
 			t.Logf("expected %v, got %v", test.expected, check)

--- a/condition/regexp.go
+++ b/condition/regexp.go
@@ -44,7 +44,7 @@ type RegExp struct {
 func (c RegExp) Inspect(ctx context.Context, cap config.Capsule) (output bool, err error) {
 	re, err := regexp.Compile(c.Expression)
 	if err != nil {
-		return false, fmt.Errorf("inspector settings %+v: %v", c, err)
+		return false, fmt.Errorf("condition regexp: %v", err)
 	}
 
 	var matched bool

--- a/condition/regexp_test.go
+++ b/condition/regexp_test.go
@@ -52,9 +52,15 @@ var regexpTests = []struct {
 func TestRegExp(t *testing.T) {
 	ctx := context.TODO()
 	cap := config.NewCapsule()
+
 	for _, test := range regexpTests {
 		cap.SetData(test.test)
-		check, _ := test.inspector.Inspect(ctx, cap)
+
+		check, err := test.inspector.Inspect(ctx, cap)
+		if err != nil {
+			t.Log(err)
+			t.Fail()
+		}
 
 		if test.expected != check {
 			t.Logf("expected %v, got %v", test.expected, check)

--- a/condition/strings.go
+++ b/condition/strings.go
@@ -75,7 +75,7 @@ func (c Strings) Inspect(ctx context.Context, cap config.Capsule) (output bool, 
 	case "startswith":
 		matched = strings.HasPrefix(check, c.Expression)
 	default:
-		return false, fmt.Errorf("inspector settings %+v: %w", c, StringsInvalidFunction)
+		return false, fmt.Errorf("condition strings: function %s: %v", c.Function, StringsInvalidFunction)
 	}
 
 	if c.Negate {

--- a/condition/strings_test.go
+++ b/condition/strings_test.go
@@ -140,9 +140,15 @@ var stringsTests = []struct {
 func TestStrings(t *testing.T) {
 	ctx := context.TODO()
 	cap := config.NewCapsule()
+
 	for _, test := range stringsTests {
 		cap.SetData(test.test)
-		check, _ := test.inspector.Inspect(ctx, cap)
+
+		check, err := test.inspector.Inspect(ctx, cap)
+		if err != nil {
+			t.Log(err)
+			t.Fail()
+		}
 
 		if test.expected != check {
 			t.Logf("expected %v, got %v", test.expected, check)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -109,11 +109,11 @@ var capsuleDeleteTests = []struct {
 }
 
 func TestCapsuleDelete(t *testing.T) {
+	cap := NewCapsule()
 	for _, test := range capsuleDeleteTests {
-		cap := NewCapsule()
 		cap.SetData(test.data).SetMetadata(test.metadata)
-
 		cap.Delete(test.key)
+
 		if !bytes.Equal(cap.GetData(), test.dataExpected) &&
 			!bytes.Equal(cap.GetMetadata(), test.metadataExpected) {
 			t.Logf("expected %s %s, got %s %s", test.dataExpected, test.metadataExpected, cap.GetData(), cap.GetMetadata())
@@ -129,10 +129,10 @@ func benchmarkTestCapsuleDelete(b *testing.B, key string, cap Capsule) {
 }
 
 func BenchmarkTestCapsuleDelete(b *testing.B) {
+	cap := NewCapsule()
 	for _, test := range capsuleSetTests {
 		b.Run(string(test.name),
 			func(b *testing.B) {
-				cap := NewCapsule()
 				cap.SetData(test.data).SetMetadata(test.metadata)
 				benchmarkTestCapsuleDelete(b, test.key, cap)
 			},
@@ -190,8 +190,8 @@ var capsuleGetTests = []struct {
 }
 
 func TestCapsuleGet(t *testing.T) {
+	cap := NewCapsule()
 	for _, test := range capsuleGetTests {
-		cap := NewCapsule()
 		cap.SetData(test.data).SetMetadata(test.metadata)
 
 		result := cap.Get(test.key).String()
@@ -209,10 +209,10 @@ func benchmarkTestCapsuleGet(b *testing.B, key string, cap Capsule) {
 }
 
 func BenchmarkTestCapsuleGet(b *testing.B) {
+	cap := NewCapsule()
 	for _, test := range capsuleGetTests {
 		b.Run(string(test.name),
 			func(b *testing.B) {
-				cap := NewCapsule()
 				cap.SetData(test.data).SetMetadata(test.metadata)
 				benchmarkTestCapsuleGet(b, test.key, cap)
 			},
@@ -288,10 +288,10 @@ func benchmarkTestCapsuleSet(b *testing.B, key string, val interface{}, cap Caps
 }
 
 func BenchmarkTestCapsuleSet(b *testing.B) {
+	cap := NewCapsule()
 	for _, test := range capsuleSetTests {
 		b.Run(string(test.name),
 			func(b *testing.B) {
-				cap := NewCapsule()
 				cap.SetData(test.data).SetMetadata(test.metadata)
 				benchmarkTestCapsuleSet(b, test.key, test.value, cap)
 			},
@@ -347,11 +347,11 @@ var capsuleSetRawTests = []struct {
 }
 
 func TestCapsuleSetRaw(t *testing.T) {
+	cap := NewCapsule()
 	for _, test := range capsuleSetRawTests {
-		cap := NewCapsule()
 		cap.SetData(test.data).SetMetadata(test.metadata)
-
 		cap.Set(test.key, test.value)
+
 		if !bytes.Equal(cap.GetData(), test.dataExpected) &&
 			!bytes.Equal(cap.GetMetadata(), test.metadataExpected) {
 			t.Logf("expected %s %s, got %s %s", test.dataExpected, test.metadataExpected, cap.GetData(), cap.GetMetadata())
@@ -367,10 +367,10 @@ func benchmarkTestCapsuleSetRaw(b *testing.B, key string, val interface{}, cap C
 }
 
 func BenchmarkTestCapsuleSetRaw(b *testing.B) {
+	cap := NewCapsule()
 	for _, test := range capsuleSetRawTests {
 		b.Run(string(test.name),
 			func(b *testing.B) {
-				cap := NewCapsule()
 				cap.SetData(test.data).SetMetadata(test.metadata)
 				benchmarkTestCapsuleSetRaw(b, test.key, test.value, cap)
 			},
@@ -400,8 +400,8 @@ var capsuleSetDataTests = []struct {
 }
 
 func TestCapsuleSetData(t *testing.T) {
+	cap := NewCapsule()
 	for _, test := range capsuleSetDataTests {
-		cap := NewCapsule()
 		cap.SetData(test.data)
 
 		if !bytes.Equal(cap.GetData(), test.expected) {
@@ -418,10 +418,10 @@ func benchmarkTestCapsuleSetData(b *testing.B, val []byte, cap Capsule) {
 }
 
 func BenchmarkTestCapsuleSetData(b *testing.B) {
+	cap := NewCapsule()
 	for _, test := range capsuleSetDataTests {
 		b.Run(string(test.name),
 			func(b *testing.B) {
-				cap := NewCapsule()
 				benchmarkTestCapsuleSetData(b, test.data, cap)
 			},
 		)
@@ -455,8 +455,8 @@ var capsuleSetMetadataTests = []struct {
 }
 
 func TestCapsuleSetMetadata(t *testing.T) {
+	cap := NewCapsule()
 	for _, test := range capsuleSetMetadataTests {
-		cap := NewCapsule()
 		cap.SetMetadata(test.metadata)
 
 		if !bytes.Equal(cap.GetMetadata(), test.expected) {
@@ -473,10 +473,10 @@ func benchmarkTestCapsuleSetMetadata(b *testing.B, val interface{}, cap Capsule)
 }
 
 func BenchmarkTestCapsuleSetMetadata(b *testing.B) {
+	cap := NewCapsule()
 	for _, test := range capsuleSetMetadataTests {
 		b.Run(string(test.name),
 			func(b *testing.B) {
-				cap := NewCapsule()
 				benchmarkTestCapsuleSetMetadata(b, test.metadata, cap)
 			},
 		)

--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -68,7 +68,7 @@ func (h *HTTP) Post(ctx context.Context, url string, payload interface{}, header
 	case string:
 		tmp = []byte(p)
 	default:
-		return nil, fmt.Errorf("http post URL %s: %w", url, HTTPInvalidPayload)
+		return nil, fmt.Errorf("http post URL %s: %v", url, HTTPInvalidPayload)
 	}
 
 	req, err := retryablehttp.NewRequest("POST", url, tmp)

--- a/internal/http/http_test.go
+++ b/internal/http/http_test.go
@@ -25,10 +25,6 @@ func TestPost(t *testing.T) {
 			payload:  []byte("test"),
 			expected: nil,
 		},
-		{
-			payload:  1337,
-			expected: HTTPInvalidPayload,
-		},
 	}
 
 	serv := httptest.NewServer(

--- a/process/aggregate.go
+++ b/process/aggregate.go
@@ -97,14 +97,14 @@ func (p Aggregate) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]con
 
 	op, err := condition.OperatorFactory(p.Condition)
 	if err != nil {
-		return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+		return nil, fmt.Errorf("process aggregate applybatch: %v", err)
 	}
 
 	newCaps := newBatch(&caps)
 	for _, cap := range caps {
 		ok, err := op.Operate(ctx, cap)
 		if err != nil {
-			return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+			return nil, fmt.Errorf("process aggregate applybatch: %v", err)
 		}
 
 		if !ok {
@@ -116,7 +116,7 @@ func (p Aggregate) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]con
 		// fit within it
 		length := len(cap.GetData())
 		if length > p.Options.MaxSize {
-			return nil, fmt.Errorf("aggregate: size limit %d reached (%d): %w", p.Options.MaxSize, length, AggregateBufferSizeLimit)
+			return nil, fmt.Errorf("process aggregate applybatch: size limit %d reached (%d): %v", p.Options.MaxSize, length, AggregateBufferSizeLimit)
 		}
 
 		var aggregateKey string
@@ -132,7 +132,7 @@ func (p Aggregate) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]con
 
 		ok, err = buffer[aggregateKey].Add(cap.GetData())
 		if err != nil {
-			return nil, fmt.Errorf("aggregate: %v", err)
+			return nil, fmt.Errorf("process aggregate applybatch: %v", err)
 		}
 
 		// data was successfully added to the buffer, every item after
@@ -150,7 +150,7 @@ func (p Aggregate) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]con
 
 				value, err = json.Set(value, p.OutputKey, element)
 				if err != nil {
-					return nil, fmt.Errorf("aggregate: %v", err)
+					return nil, fmt.Errorf("process aggregate applybatch: %v", err)
 				}
 			}
 
@@ -184,7 +184,7 @@ func (p Aggregate) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]con
 
 				value, err = json.Set(value, p.OutputKey, element)
 				if err != nil {
-					return nil, fmt.Errorf("aggregate: %v", err)
+					return nil, fmt.Errorf("process aggregate applybatch: %v", err)
 				}
 			}
 

--- a/process/base64_test.go
+++ b/process/base64_test.go
@@ -3,7 +3,6 @@ package process
 import (
 	"bytes"
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/brexhq/substation/config"
@@ -51,57 +50,23 @@ var base64Tests = []struct {
 		[]byte(`{"foo":"bar"}`),
 		nil,
 	},
-	{
-		"invalid settings",
-		Base64{},
-		[]byte{},
-		[]byte{},
-		ProcessorInvalidSettings,
-	},
-	{
-		"invalid direction",
-		Base64{
-			Options: Base64Options{
-				Direction: "foo",
-			},
-			InputKey:  "foo",
-			OutputKey: "foo",
-		},
-		[]byte(`{"foo":"YmFy"}`),
-		[]byte(``),
-		Base64InvalidDirection,
-	},
-	{
-		"JSON binary",
-		Base64{
-			Options: Base64Options{
-				Direction: "from",
-			},
-			InputKey:  "foo",
-			OutputKey: "foo",
-		},
-		[]byte(`{"foo":"eJwFwDENAAAAwjCtTAL+j6YdAl0BNg=="}`),
-		[]byte(``),
-		Base64JSONDecodedBinary,
-	},
 }
 
 func TestBase64(t *testing.T) {
 	ctx := context.TODO()
 	cap := config.NewCapsule()
+
 	for _, test := range base64Tests {
 		cap.SetData(test.test)
 
-		res, err := test.proc.Apply(ctx, cap)
-		if err != nil && errors.Is(err, test.err) {
-			continue
-		} else if err != nil {
+		result, err := test.proc.Apply(ctx, cap)
+		if err != nil {
 			t.Log(err)
 			t.Fail()
 		}
 
-		if c := bytes.Compare(res.GetData(), test.expected); c != 0 {
-			t.Logf("expected %s, got %s", test.expected, res.GetData())
+		if !bytes.Equal(result.GetData(), test.expected) {
+			t.Logf("expected %s, got %s", test.expected, result.GetData())
 			t.Fail()
 		}
 	}

--- a/process/capture.go
+++ b/process/capture.go
@@ -62,12 +62,12 @@ type CaptureOptions struct {
 func (p Capture) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.Capsule, error) {
 	op, err := condition.OperatorFactory(p.Condition)
 	if err != nil {
-		return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+		return nil, fmt.Errorf("process capture applybatch: %v", err)
 	}
 
 	caps, err = conditionallyApplyBatch(ctx, caps, op, p)
 	if err != nil {
-		return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+		return nil, fmt.Errorf("process capture applybatch: %v", err)
 	}
 
 	return caps, nil
@@ -77,12 +77,12 @@ func (p Capture) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]confi
 func (p Capture) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, error) {
 	// error early if required options are missing
 	if p.Options.Expression == "" || p.Options.Function == "" {
-		return cap, fmt.Errorf("apply settings %+v: %w", p, ProcessorInvalidSettings)
+		return cap, fmt.Errorf("process capture apply: options %+v: %v", p.Options, ProcessorMissingRequiredOptions)
 	}
 
 	re, err := regexp.Compile(p.Options.Expression)
 	if err != nil {
-		return cap, fmt.Errorf("apply settings %+v: %v", p, err)
+		return cap, fmt.Errorf("process capture apply: %v", err)
 	}
 
 	if p.Options.Count == 0 {
@@ -97,7 +97,7 @@ func (p Capture) Apply(ctx context.Context, cap config.Capsule) (config.Capsule,
 		case "find":
 			match := re.FindStringSubmatch(result)
 			if err := cap.Set(p.OutputKey, p.getStringMatch(match)); err != nil {
-				return cap, fmt.Errorf("apply settings %+v: %v", p, err)
+				return cap, fmt.Errorf("process capture apply: %v", err)
 			}
 
 			return cap, nil
@@ -111,7 +111,7 @@ func (p Capture) Apply(ctx context.Context, cap config.Capsule) (config.Capsule,
 			}
 
 			if err := cap.Set(p.OutputKey, matches); err != nil {
-				return cap, fmt.Errorf("apply settings %+v: %v", p, err)
+				return cap, fmt.Errorf("process capture apply: %v", err)
 			}
 
 			return cap, nil
@@ -137,7 +137,7 @@ func (p Capture) Apply(ctx context.Context, cap config.Capsule) (config.Capsule,
 				}
 
 				if err := newCap.Set(names[i], m); err != nil {
-					return cap, fmt.Errorf("apply settings %+v: %v", p, err)
+					return cap, fmt.Errorf("process capture apply: %v", err)
 				}
 			}
 
@@ -145,7 +145,7 @@ func (p Capture) Apply(ctx context.Context, cap config.Capsule) (config.Capsule,
 		}
 	}
 
-	return cap, fmt.Errorf("apply settings %+v: %w", p, ProcessorInvalidSettings)
+	return cap, fmt.Errorf("process capture apply: inputkey %s outputkey %s: %v", p.InputKey, p.OutputKey, ProcessorInvalidDataPattern)
 }
 
 func (p Capture) getStringMatch(match []string) string {

--- a/process/capture_test.go
+++ b/process/capture_test.go
@@ -3,7 +3,6 @@ package process
 import (
 	"bytes"
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/brexhq/substation/config"
@@ -69,31 +68,23 @@ var captureTests = []struct {
 		[]byte(`{"foo":"bar","qux":"quux"}`),
 		nil,
 	},
-	{
-		"invalid settings",
-		Capture{},
-		[]byte{},
-		[]byte{},
-		ProcessorInvalidSettings,
-	},
 }
 
 func TestCapture(t *testing.T) {
 	ctx := context.TODO()
 	cap := config.NewCapsule()
+
 	for _, test := range captureTests {
 		cap.SetData(test.test)
 
-		res, err := test.proc.Apply(ctx, cap)
-		if err != nil && errors.Is(err, test.err) {
-			continue
-		} else if err != nil {
+		result, err := test.proc.Apply(ctx, cap)
+		if err != nil {
 			t.Log(err)
 			t.Fail()
 		}
 
-		if c := bytes.Compare(res.GetData(), test.expected); c != 0 {
-			t.Logf("expected %s, got %s", test.expected, res.GetData())
+		if !bytes.Equal(result.GetData(), test.expected) {
+			t.Logf("expected %s, got %s", test.expected, result.GetData())
 			t.Fail()
 		}
 	}

--- a/process/case.go
+++ b/process/case.go
@@ -59,12 +59,12 @@ type CaseOptions struct {
 func (p Case) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.Capsule, error) {
 	op, err := condition.OperatorFactory(p.Condition)
 	if err != nil {
-		return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+		return nil, fmt.Errorf("process case applybatch: %v", err)
 	}
 
 	caps, err = conditionallyApplyBatch(ctx, caps, op, p)
 	if err != nil {
-		return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+		return nil, fmt.Errorf("process case applybatch: %v", err)
 	}
 
 	return caps, nil
@@ -74,7 +74,7 @@ func (p Case) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.C
 func (p Case) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, error) {
 	// error early if required options are missing
 	if p.Options.Case == "" {
-		return cap, fmt.Errorf("apply settings %+v: %w", p, ProcessorInvalidSettings)
+		return cap, fmt.Errorf("process case apply: options %+v: %v", p.Options, ProcessorMissingRequiredOptions)
 	}
 
 	// JSON processing
@@ -90,11 +90,11 @@ func (p Case) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, er
 		case "snake":
 			value = strcase.ToSnake(result)
 		default:
-			return cap, fmt.Errorf("apply settings %+v: %w", p, CaseInvalidCase)
+			return cap, fmt.Errorf("process case apply: case %s: %v", p.Options.Case, CaseInvalidCase)
 		}
 
 		if err := cap.Set(p.OutputKey, value); err != nil {
-			return cap, fmt.Errorf("apply settings %+v: %v", p, err)
+			return cap, fmt.Errorf("process case apply: %v", err)
 		}
 
 		return cap, nil
@@ -109,12 +109,12 @@ func (p Case) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, er
 		case "lower":
 			value = bytes.ToLower(cap.GetData())
 		default:
-			return cap, fmt.Errorf("apply settings %+v: %w", p, CaseInvalidCase)
+			return cap, fmt.Errorf("process case apply: case %s: %v", p.Options.Case, CaseInvalidCase)
 		}
 
 		cap.SetData(value)
 		return cap, nil
 	}
 
-	return cap, fmt.Errorf("apply settings %+v: %w", p, ProcessorInvalidSettings)
+	return cap, fmt.Errorf("process case apply: inputkey %s outputkey %s: %v", p.InputKey, p.OutputKey, ProcessorInvalidDataPattern)
 }

--- a/process/case_test.go
+++ b/process/case_test.go
@@ -3,7 +3,6 @@ package process
 import (
 	"bytes"
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/brexhq/substation/config"
@@ -55,31 +54,23 @@ var caseTests = []struct {
 		[]byte(`{"foo":"ab_c"})`),
 		nil,
 	},
-	{
-		"invalid settings",
-		Case{},
-		[]byte{},
-		[]byte{},
-		ProcessorInvalidSettings,
-	},
 }
 
 func TestCase(t *testing.T) {
 	ctx := context.TODO()
 	cap := config.NewCapsule()
+
 	for _, test := range caseTests {
 		cap.SetData(test.test)
 
-		res, err := test.proc.Apply(ctx, cap)
-		if err != nil && errors.Is(err, test.err) {
-			continue
-		} else if err != nil {
+		result, err := test.proc.Apply(ctx, cap)
+		if err != nil {
 			t.Log(err)
 			t.Fail()
 		}
 
-		if c := bytes.Compare(res.GetData(), test.expected); c != 0 {
-			t.Logf("expected %s, got %s", test.expected, res.GetData())
+		if !bytes.Equal(result.GetData(), test.expected) {
+			t.Logf("expected %s, got %s", test.expected, result.GetData())
 			t.Fail()
 		}
 	}

--- a/process/concat.go
+++ b/process/concat.go
@@ -45,12 +45,12 @@ type ConcatOptions struct {
 func (p Concat) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.Capsule, error) {
 	op, err := condition.OperatorFactory(p.Condition)
 	if err != nil {
-		return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+		return nil, fmt.Errorf("process concat applybatch: %v", err)
 	}
 
 	caps, err = conditionallyApplyBatch(ctx, caps, op, p)
 	if err != nil {
-		return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+		return nil, fmt.Errorf("process concat applybatch: %v", err)
 	}
 
 	return caps, nil
@@ -60,12 +60,12 @@ func (p Concat) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config
 func (p Concat) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, error) {
 	// error early if required options are missing
 	if p.Options.Separator == "" {
-		return cap, fmt.Errorf("apply settings %+v: %w", p, ProcessorInvalidSettings)
+		return cap, fmt.Errorf("process concat apply: options %+v: %v", p.Options, ProcessorMissingRequiredOptions)
 	}
 
 	// only supports JSON, error early if there are no keys
 	if p.InputKey == "" && p.OutputKey == "" {
-		return cap, fmt.Errorf("apply settings %+v: %w", p, ProcessorInvalidSettings)
+		return cap, fmt.Errorf("process concat apply: inputkey %s outputkey %s: %v", p.InputKey, p.OutputKey, ProcessorInvalidDataPattern)
 	}
 
 	// data is processed by retrieving and iterating the
@@ -86,7 +86,7 @@ func (p Concat) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, 
 	}
 
 	if err := cap.Set(p.OutputKey, value); err != nil {
-		return cap, fmt.Errorf("apply settings %+v: %v", p, err)
+		return cap, fmt.Errorf("process dynamodb apply: %v", err)
 	}
 
 	return cap, nil

--- a/process/concat_test.go
+++ b/process/concat_test.go
@@ -3,7 +3,6 @@ package process
 import (
 	"bytes"
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/brexhq/substation/config"
@@ -29,31 +28,23 @@ var concatTests = []struct {
 		[]byte(`{"foo":"bar.baz"}`),
 		nil,
 	},
-	{
-		"invalid settings",
-		Concat{},
-		[]byte{},
-		[]byte{},
-		ProcessorInvalidSettings,
-	},
 }
 
 func TestConcat(t *testing.T) {
 	ctx := context.TODO()
 	cap := config.NewCapsule()
+
 	for _, test := range concatTests {
 		cap.SetData(test.test)
 
-		res, err := test.proc.Apply(ctx, cap)
-		if err != nil && errors.Is(err, test.err) {
-			continue
-		} else if err != nil {
+		result, err := test.proc.Apply(ctx, cap)
+		if err != nil {
 			t.Log(err)
 			t.Fail()
 		}
 
-		if c := bytes.Compare(res.GetData(), test.expected); c != 0 {
-			t.Logf("expected %s, got %s", test.expected, res.GetData())
+		if !bytes.Equal(result.GetData(), test.expected) {
+			t.Logf("expected %s, got %s", test.expected, result.GetData())
 			t.Fail()
 		}
 	}

--- a/process/convert.go
+++ b/process/convert.go
@@ -53,12 +53,12 @@ type ConvertOptions struct {
 func (p Convert) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.Capsule, error) {
 	op, err := condition.OperatorFactory(p.Condition)
 	if err != nil {
-		return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+		return nil, fmt.Errorf("process convert applybatch: %v", err)
 	}
 
 	caps, err = conditionallyApplyBatch(ctx, caps, op, p)
 	if err != nil {
-		return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+		return nil, fmt.Errorf("process convert applybatch: %v", err)
 	}
 
 	return caps, nil
@@ -68,7 +68,7 @@ func (p Convert) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]confi
 func (p Convert) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, error) {
 	// error early if required options are missing
 	if p.Options.Type == "" {
-		return cap, fmt.Errorf("apply settings %+v: %w", p, ProcessorInvalidSettings)
+		return cap, fmt.Errorf("process convert apply: options %+v: %v", p.Options, ProcessorMissingRequiredOptions)
 	}
 
 	// only supports JSON, error early if there are no keys
@@ -90,11 +90,11 @@ func (p Convert) Apply(ctx context.Context, cap config.Capsule) (config.Capsule,
 		}
 
 		if err := cap.Set(p.OutputKey, value); err != nil {
-			return cap, fmt.Errorf("apply settings %+v: %v", p, err)
+			return cap, fmt.Errorf("process convert apply: %v", err)
 		}
 
 		return cap, nil
 	}
 
-	return cap, fmt.Errorf("apply settings %+v: %w", p, ProcessorInvalidSettings)
+	return cap, fmt.Errorf("process convert apply: inputkey %s outputkey %s: %v", p.InputKey, p.OutputKey, ProcessorInvalidDataPattern)
 }

--- a/process/convert_test.go
+++ b/process/convert_test.go
@@ -3,7 +3,6 @@ package process
 import (
 	"bytes"
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/brexhq/substation/config"
@@ -112,19 +111,18 @@ var convertTests = []struct {
 func TestConvert(t *testing.T) {
 	ctx := context.TODO()
 	cap := config.NewCapsule()
+
 	for _, test := range convertTests {
 		cap.SetData(test.test)
 
-		res, err := test.proc.Apply(ctx, cap)
-		if err != nil && errors.Is(err, test.err) {
-			continue
-		} else if err != nil {
+		result, err := test.proc.Apply(ctx, cap)
+		if err != nil {
 			t.Log(err)
 			t.Fail()
 		}
 
-		if c := bytes.Compare(res.GetData(), test.expected); c != 0 {
-			t.Logf("expected %s, got %s", test.expected, res.GetData())
+		if !bytes.Equal(result.GetData(), test.expected) {
+			t.Logf("expected %s, got %s", test.expected, result.GetData())
 			t.Fail()
 		}
 	}

--- a/process/copy.go
+++ b/process/copy.go
@@ -37,12 +37,12 @@ type Copy struct {
 func (p Copy) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.Capsule, error) {
 	op, err := condition.OperatorFactory(p.Condition)
 	if err != nil {
-		return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+		return nil, fmt.Errorf("process copy applybatch: %v", err)
 	}
 
 	caps, err = conditionallyApplyBatch(ctx, caps, op, p)
 	if err != nil {
-		return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+		return nil, fmt.Errorf("process copy applybatch: %v", err)
 	}
 
 	return caps, nil
@@ -53,7 +53,7 @@ func (p Copy) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, er
 	// JSON processing
 	if p.InputKey != "" && p.OutputKey != "" {
 		if err := cap.Set(p.OutputKey, cap.Get(p.InputKey)); err != nil {
-			return cap, fmt.Errorf("apply settings %+v: %v", p, err)
+			return cap, fmt.Errorf("process copy apply: %v", err)
 		}
 
 		return cap, nil
@@ -85,11 +85,11 @@ func (p Copy) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, er
 		}
 
 		if err := cap.Set(p.OutputKey, value); err != nil {
-			return cap, fmt.Errorf("apply settings %+v: %v", p, err)
+			return cap, fmt.Errorf("process copy apply: %v", err)
 		}
 
 		return cap, nil
 	}
 
-	return cap, nil
+	return cap, fmt.Errorf("process copy apply: inputkey %s outputkey %s: %v", p.InputKey, p.OutputKey, ProcessorInvalidDataPattern)
 }

--- a/process/copy_test.go
+++ b/process/copy_test.go
@@ -3,7 +3,6 @@ package process
 import (
 	"bytes"
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/brexhq/substation/config"
@@ -67,19 +66,18 @@ var copyTests = []struct {
 func TestCopy(t *testing.T) {
 	ctx := context.TODO()
 	cap := config.NewCapsule()
+
 	for _, test := range copyTests {
 		cap.SetData(test.test)
 
-		res, err := test.proc.Apply(ctx, cap)
-		if err != nil && errors.Is(err, test.err) {
-			continue
-		} else if err != nil {
+		result, err := test.proc.Apply(ctx, cap)
+		if err != nil {
 			t.Log(err)
 			t.Fail()
 		}
 
-		if c := bytes.Compare(res.GetData(), test.expected); c != 0 {
-			t.Logf("expected %s, got %s", test.expected, res.GetData())
+		if !bytes.Equal(result.GetData(), test.expected) {
+			t.Logf("expected %s, got %s", test.expected, result.GetData())
 			t.Fail()
 		}
 	}

--- a/process/count.go
+++ b/process/count.go
@@ -21,7 +21,7 @@ type Count struct{}
 func (p Count) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.Capsule, error) {
 	newCap := config.NewCapsule()
 	if err := newCap.Set("count", len(caps)); err != nil {
-		return caps, fmt.Errorf("apply settings %+v: %v", p, err)
+		return caps, fmt.Errorf("process count apply: : %v", err)
 	}
 
 	newCaps := make([]config.Capsule, 0, 1)

--- a/process/count_test.go
+++ b/process/count_test.go
@@ -3,7 +3,6 @@ package process
 import (
 	"bytes"
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/brexhq/substation/config"
@@ -32,6 +31,7 @@ var countTests = []struct {
 func TestCount(t *testing.T) {
 	ctx := context.TODO()
 	cap := config.NewCapsule()
+
 	for _, test := range countTests {
 		var caps []config.Capsule
 		for _, t := range test.test {
@@ -39,15 +39,13 @@ func TestCount(t *testing.T) {
 			caps = append(caps, cap)
 		}
 
-		res, err := test.proc.ApplyBatch(ctx, caps)
-		if err != nil && errors.Is(err, test.err) {
-			continue
-		} else if err != nil {
+		result, err := test.proc.ApplyBatch(ctx, caps)
+		if err != nil {
 			t.Log(err)
 			t.Fail()
 		}
 
-		count := res[0].GetData()
+		count := result[0].GetData()
 		if !bytes.Equal(count, test.expected) {
 			t.Logf("expected %s, got %s", test.expected, count)
 			t.Fail()

--- a/process/delete.go
+++ b/process/delete.go
@@ -6,11 +6,7 @@ import (
 
 	"github.com/brexhq/substation/condition"
 	"github.com/brexhq/substation/config"
-	"github.com/brexhq/substation/internal/errors"
 )
-
-// DeleteInvalidSettings is returned when the Copy processor is configured with invalid Input and Output settings.
-const DeleteInvalidSettings = errors.Error("DeleteInvalidSettings")
 
 /*
 Delete processes data by deleting JSON keys. The processor supports these patterns:
@@ -34,12 +30,12 @@ type Delete struct {
 func (p Delete) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.Capsule, error) {
 	op, err := condition.OperatorFactory(p.Condition)
 	if err != nil {
-		return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+		return nil, fmt.Errorf("process delete applybatch: %v", err)
 	}
 
 	caps, err = conditionallyApplyBatch(ctx, caps, op, p)
 	if err != nil {
-		return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+		return nil, fmt.Errorf("process delete applybatch: %v", err)
 	}
 
 	return caps, nil
@@ -50,11 +46,11 @@ func (p Delete) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config
 func (p Delete) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, error) {
 	// only supports JSON, error early if there are no keys
 	if p.InputKey == "" {
-		return cap, fmt.Errorf("apply settings %+v: %w", p, ProcessorInvalidSettings)
+		return cap, fmt.Errorf("process delete apply: inputkey %s: %v", p.InputKey, ProcessorInvalidDataPattern)
 	}
 
 	if err := cap.Delete(p.InputKey); err != nil {
-		return cap, fmt.Errorf("apply settings %+v: %v", p, err)
+		return cap, fmt.Errorf("process delete apply: %v", err)
 	}
 
 	return cap, nil

--- a/process/delete_test.go
+++ b/process/delete_test.go
@@ -3,7 +3,6 @@ package process
 import (
 	"bytes"
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/brexhq/substation/config"
@@ -39,19 +38,18 @@ var deleteTests = []struct {
 func TestDelete(t *testing.T) {
 	ctx := context.TODO()
 	cap := config.NewCapsule()
+
 	for _, test := range convertTests {
 		cap.SetData(test.test)
 
-		res, err := test.proc.Apply(ctx, cap)
-		if err != nil && errors.Is(err, test.err) {
-			continue
-		} else if err != nil {
+		result, err := test.proc.Apply(ctx, cap)
+		if err != nil {
 			t.Log(err)
 			t.Fail()
 		}
 
-		if !bytes.Equal(res.GetData(), test.expected) {
-			t.Logf("expected %s, got %s", test.expected, res.GetData())
+		if !bytes.Equal(result.GetData(), test.expected) {
+			t.Logf("expected %s, got %s", test.expected, result.GetData())
 			t.Fail()
 		}
 	}

--- a/process/domain.go
+++ b/process/domain.go
@@ -58,12 +58,12 @@ type DomainOptions struct {
 func (p Domain) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.Capsule, error) {
 	op, err := condition.OperatorFactory(p.Condition)
 	if err != nil {
-		return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+		return nil, fmt.Errorf("process domain applybatch: %v", err)
 	}
 
 	caps, err = conditionallyApplyBatch(ctx, caps, op, p)
 	if err != nil {
-		return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+		return nil, fmt.Errorf("process domain applybatch: %v", err)
 	}
 
 	return caps, nil
@@ -73,7 +73,7 @@ func (p Domain) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config
 func (p Domain) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, error) {
 	// error early if required options are missing
 	if p.Options.Function == "" {
-		return cap, fmt.Errorf("apply settings %+v: %w", p, ProcessorInvalidSettings)
+		return cap, fmt.Errorf("process domain apply: options %+v: %v", p.Options, ProcessorMissingRequiredOptions)
 	}
 
 	// JSON processing
@@ -82,7 +82,7 @@ func (p Domain) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, 
 		value, _ := p.domain(result)
 
 		if err := cap.Set(p.OutputKey, value); err != nil {
-			return cap, fmt.Errorf("apply settings %+v: %v", p, err)
+			return cap, fmt.Errorf("process domain apply: %v", err)
 		}
 
 		return cap, nil
@@ -96,7 +96,7 @@ func (p Domain) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, 
 		return cap, nil
 	}
 
-	return cap, fmt.Errorf("apply settings %+v: %w", p, ProcessorInvalidSettings)
+	return cap, fmt.Errorf("process domain apply: inputkey %s outputkey %s: %v", p.InputKey, p.OutputKey, ProcessorInvalidDataPattern)
 }
 
 func (p Domain) domain(s string) (string, error) {

--- a/process/domain.go
+++ b/process/domain.go
@@ -107,13 +107,13 @@ func (p Domain) domain(s string) (string, error) {
 	case "domain":
 		domain, err := publicsuffix.EffectiveTLDPlusOne(s)
 		if err != nil {
-			return "", fmt.Errorf("domain %s: %w", s, DomainNoSubdomain)
+			return "", fmt.Errorf("domain %s: %v", s, DomainNoSubdomain)
 		}
 		return domain, nil
 	case "subdomain":
 		domain, err := publicsuffix.EffectiveTLDPlusOne(s)
 		if err != nil {
-			return "", fmt.Errorf("domain %s: %w", s, DomainNoSubdomain)
+			return "", fmt.Errorf("domain %s: %v", s, DomainNoSubdomain)
 		}
 
 		// subdomain is the input string minus the domain and a leading dot:
@@ -122,7 +122,7 @@ func (p Domain) domain(s string) (string, error) {
 		// subdomain == "foo" ("foo.bar.com" minus ".bar.com")
 		subdomain := strings.Replace(s, "."+domain, "", 1)
 		if subdomain == domain {
-			return "", fmt.Errorf("domain %s: %w", s, DomainNoSubdomain)
+			return "", fmt.Errorf("domain %s: %v", s, DomainNoSubdomain)
 		}
 		return subdomain, nil
 	default:

--- a/process/domain_test.go
+++ b/process/domain_test.go
@@ -3,7 +3,6 @@ package process
 import (
 	"bytes"
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/brexhq/substation/config"
@@ -80,31 +79,23 @@ var domainTests = []struct {
 		[]byte(`www`),
 		nil,
 	},
-	{
-		"invalid settings",
-		Domain{},
-		[]byte{},
-		[]byte{},
-		ProcessorInvalidSettings,
-	},
 }
 
 func TestDomain(t *testing.T) {
 	ctx := context.TODO()
 	cap := config.NewCapsule()
+
 	for _, test := range domainTests {
 		cap.SetData(test.test)
 
-		res, err := test.proc.Apply(ctx, cap)
-		if err != nil && errors.Is(err, test.err) {
-			continue
-		} else if err != nil {
+		result, err := test.proc.Apply(ctx, cap)
+		if err != nil {
 			t.Log(err)
 			t.Fail()
 		}
 
-		if c := bytes.Compare(res.GetData(), test.expected); c != 0 {
-			t.Logf("expected %s, got %s", test.expected, res.GetData())
+		if !bytes.Equal(result.GetData(), test.expected) {
+			t.Logf("expected %s, got %s", test.expected, result.GetData())
 			t.Fail()
 		}
 	}

--- a/process/drop.go
+++ b/process/drop.go
@@ -24,14 +24,14 @@ type Drop struct {
 func (p Drop) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.Capsule, error) {
 	op, err := condition.OperatorFactory(p.Condition)
 	if err != nil {
-		return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+		return nil, fmt.Errorf("process drop applybatch: %v", err)
 	}
 
 	newCaps := newBatch(&caps)
 	for _, cap := range caps {
 		ok, err := op.Operate(ctx, cap)
 		if err != nil {
-			return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+			return nil, fmt.Errorf("process drop applybatch: %v", err)
 		}
 
 		if !ok {

--- a/process/drop_test.go
+++ b/process/drop_test.go
@@ -2,7 +2,6 @@ package process
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/brexhq/substation/config"
@@ -29,6 +28,7 @@ var dropTests = []struct {
 func TestDrop(t *testing.T) {
 	ctx := context.TODO()
 	cap := config.NewCapsule()
+
 	for _, test := range dropTests {
 		var caps []config.Capsule
 		for _, t := range test.test {
@@ -36,15 +36,13 @@ func TestDrop(t *testing.T) {
 			caps = append(caps, cap)
 		}
 
-		res, err := test.proc.ApplyBatch(ctx, caps)
-		if err != nil && errors.Is(err, test.err) {
-			continue
-		} else if err != nil {
+		result, err := test.proc.ApplyBatch(ctx, caps)
+		if err != nil {
 			t.Log(err)
 			t.Fail()
 		}
 
-		length := len(res)
+		length := len(result)
 		if length != 0 {
 			t.Logf("got %d", length)
 			t.Fail()

--- a/process/expand.go
+++ b/process/expand.go
@@ -31,19 +31,19 @@ type Expand struct {
 func (p Expand) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.Capsule, error) {
 	// only supports JSON, error early if there is no input key
 	if p.InputKey == "" {
-		return nil, fmt.Errorf("applybatch settings %+v: %w", p, ProcessorInvalidSettings)
+		return nil, fmt.Errorf("process expand applybatch: inputkey %s: %v", p.InputKey, ProcessorInvalidDataPattern)
 	}
 
 	op, err := condition.OperatorFactory(p.Condition)
 	if err != nil {
-		return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+		return nil, fmt.Errorf("process expand applybatch: %v", err)
 	}
 
 	newCaps := newBatch(&caps)
 	for _, cap := range caps {
 		ok, err := op.Operate(ctx, cap)
 		if err != nil {
-			return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+			return nil, fmt.Errorf("process expand applybatch: %v", err)
 		}
 
 		if !ok {
@@ -76,7 +76,7 @@ func (p Expand) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config
 
 				expand, err = json.Set(expand, key, val)
 				if err != nil {
-					return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+					return nil, fmt.Errorf("process expand applybatch: %v", err)
 				}
 			}
 

--- a/process/expand_test.go
+++ b/process/expand_test.go
@@ -3,7 +3,6 @@ package process
 import (
 	"bytes"
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/brexhq/substation/config"
@@ -39,35 +38,27 @@ var expandTests = []struct {
 		},
 		nil,
 	},
-	{
-		"invalid settings",
-		Expand{},
-		[]byte{},
-		[][]byte{},
-		ProcessorInvalidSettings,
-	},
 }
 
 func TestExpand(t *testing.T) {
 	ctx := context.TODO()
 	cap := config.NewCapsule()
+
 	for _, test := range expandTests {
 		slice := make([]config.Capsule, 1)
 		cap.SetData(test.test)
 		slice[0] = cap
 
-		res, err := test.proc.ApplyBatch(ctx, slice)
-		if err != nil && errors.Is(err, test.err) {
-			continue
-		} else if err != nil {
+		result, err := test.proc.ApplyBatch(ctx, slice)
+		if err != nil {
 			t.Log(err)
 			t.Fail()
 		}
 
-		for i, processed := range res {
+		for i, res := range result {
 			expected := test.expected[i]
-			if c := bytes.Compare(expected, processed.GetData()); c != 0 {
-				t.Logf("expected %s, got %s", expected, processed)
+			if !bytes.Equal(expected, res.GetData()) {
+				t.Logf("expected %s, got %s", expected, res)
 				t.Fail()
 			}
 		}

--- a/process/flatten.go
+++ b/process/flatten.go
@@ -42,12 +42,12 @@ type FlattenOptions struct {
 func (p Flatten) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.Capsule, error) {
 	op, err := condition.OperatorFactory(p.Condition)
 	if err != nil {
-		return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+		return nil, fmt.Errorf("process flatten applybatch: %v", err)
 	}
 
 	caps, err = conditionallyApplyBatch(ctx, caps, op, p)
 	if err != nil {
-		return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+		return nil, fmt.Errorf("process flatten applybatch: %v", err)
 	}
 
 	return caps, nil
@@ -57,7 +57,7 @@ func (p Flatten) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]confi
 func (p Flatten) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, error) {
 	// only supports JSON, error early if there are no keys
 	if p.InputKey == "" && p.OutputKey == "" {
-		return cap, fmt.Errorf("apply settings %+v: %w", p, ProcessorInvalidSettings)
+		return cap, fmt.Errorf("process flatten apply: inputkey %s outputkey %s: %v", p.InputKey, p.OutputKey, ProcessorInvalidDataPattern)
 	}
 
 	var value interface{}
@@ -68,7 +68,7 @@ func (p Flatten) Apply(ctx context.Context, cap config.Capsule) (config.Capsule,
 	}
 
 	if err := cap.Set(p.OutputKey, value); err != nil {
-		return cap, fmt.Errorf("apply settings %+v: %v", p, err)
+		return cap, fmt.Errorf("process flatten apply: %v", err)
 	}
 
 	return cap, nil

--- a/process/flatten_test.go
+++ b/process/flatten_test.go
@@ -3,7 +3,6 @@ package process
 import (
 	"bytes"
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/brexhq/substation/config"
@@ -39,37 +38,23 @@ var flattenTests = []struct {
 		[]byte(`{"flatten":["foo","bar","baz"]}`),
 		nil,
 	},
-	{
-		"invalid settings",
-		Flatten{
-			Options: FlattenOptions{
-				Deep: true,
-			},
-			InputKey:  "flatten",
-			OutputKey: "flatten",
-		},
-		[]byte(`{"flatten":[["foo"],[[["bar",[["baz"]]]]]]}`),
-		[]byte(`{"flatten":["foo","bar","baz"]}`),
-		ProcessorInvalidSettings,
-	},
 }
 
 func TestFlatten(t *testing.T) {
 	ctx := context.TODO()
 	cap := config.NewCapsule()
+
 	for _, test := range flattenTests {
 		cap.SetData(test.test)
 
-		res, err := test.proc.Apply(ctx, cap)
-		if err != nil && errors.Is(err, test.err) {
-			continue
-		} else if err != nil {
+		result, err := test.proc.Apply(ctx, cap)
+		if err != nil {
 			t.Log(err)
 			t.Fail()
 		}
 
-		if c := bytes.Compare(res.GetData(), test.expected); c != 0 {
-			t.Logf("expected %s, got %s", test.expected, res.GetData())
+		if !bytes.Equal(result.GetData(), test.expected) {
+			t.Logf("expected %s, got %s", test.expected, result.GetData())
 			t.Fail()
 		}
 	}

--- a/process/for_each.go
+++ b/process/for_each.go
@@ -54,12 +54,12 @@ type ForEachOptions struct {
 func (p ForEach) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.Capsule, error) {
 	op, err := condition.OperatorFactory(p.Condition)
 	if err != nil {
-		return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+		return nil, fmt.Errorf("process for_each applybatch: %v", err)
 	}
 
 	caps, err = conditionallyApplyBatch(ctx, caps, op, p)
 	if err != nil {
-		return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+		return nil, fmt.Errorf("process for_each applybatch: %v", err)
 	}
 
 	return caps, nil
@@ -78,7 +78,7 @@ processing workflow. For example:
 func (p ForEach) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, error) {
 	// only supports JSON, error early if there are no keys
 	if p.InputKey == "" && p.OutputKey == "" {
-		return cap, fmt.Errorf("apply settings %+v: %w", p, ProcessorInvalidSettings)
+		return cap, fmt.Errorf("process for_each apply: inputkey %s outputkey %s: %v", p.InputKey, p.OutputKey, ProcessorInvalidDataPattern)
 	}
 
 	// configured processor is converted to a JSON object so that the
@@ -107,7 +107,7 @@ func (p ForEach) Apply(ctx context.Context, cap config.Capsule) (config.Capsule,
 
 	applicator, err := ApplicatorFactory(processor)
 	if err != nil {
-		return cap, err
+		return cap, fmt.Errorf("process for_each apply: %v", err)
 	}
 
 	result := cap.Get(p.InputKey)
@@ -118,17 +118,17 @@ func (p ForEach) Apply(ctx context.Context, cap config.Capsule) (config.Capsule,
 	for _, res := range result.Array() {
 		tmpCap := config.NewCapsule()
 		if err := tmpCap.Set(processor.Type, res); err != nil {
-			return cap, fmt.Errorf("apply settings %+v: %v", p, err)
+			return cap, fmt.Errorf("process for_each apply: %v", err)
 		}
 
 		tmpCap, err = applicator.Apply(ctx, tmpCap)
 		if err != nil {
-			return cap, fmt.Errorf("apply settings %+v: %v", p, err)
+			return cap, fmt.Errorf("process for_each apply: %v", err)
 		}
 
 		value := tmpCap.Get(processor.Type)
 		if err := cap.Set(p.OutputKey, value); err != nil {
-			return cap, fmt.Errorf("apply settings %+v: %v", p, err)
+			return cap, fmt.Errorf("process for_each apply: %v", err)
 		}
 	}
 

--- a/process/for_each_test.go
+++ b/process/for_each_test.go
@@ -3,7 +3,6 @@ package process
 import (
 	"bytes"
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/brexhq/substation/config"
@@ -318,31 +317,23 @@ var foreachTests = []struct {
 		[]byte(`{"input":["2021-03-06T00:02:57Z","2021-03-06T00:03:57Z","2021-03-06T00:04:57Z"],"output":["2021-03-06T00:02:57.000000Z","2021-03-06T00:03:57.000000Z","2021-03-06T00:04:57.000000Z"]}`),
 		nil,
 	},
-	{
-		"invalid settings",
-		ForEach{},
-		[]byte{},
-		[]byte{},
-		ProcessorInvalidSettings,
-	},
 }
 
 func TestForEach(t *testing.T) {
 	ctx := context.TODO()
 	cap := config.NewCapsule()
+
 	for _, test := range foreachTests {
 		cap.SetData(test.test)
 
-		res, err := test.proc.Apply(ctx, cap)
-		if err != nil && errors.Is(err, test.err) {
-			continue
-		} else if err != nil {
+		result, err := test.proc.Apply(ctx, cap)
+		if err != nil {
 			t.Log(err)
 			t.Fail()
 		}
 
-		if c := bytes.Compare(res.GetData(), test.expected); c != 0 {
-			t.Logf("expected %s, got %s", test.expected, res.GetData())
+		if !bytes.Equal(result.GetData(), test.expected) {
+			t.Logf("expected %s, got %s", test.expected, result.GetData())
 			t.Fail()
 		}
 	}

--- a/process/group.go
+++ b/process/group.go
@@ -44,12 +44,12 @@ type GroupOptions struct {
 func (p Group) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.Capsule, error) {
 	op, err := condition.OperatorFactory(p.Condition)
 	if err != nil {
-		return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+		return nil, fmt.Errorf("process group applybatch: %v", err)
 	}
 
 	caps, err = conditionallyApplyBatch(ctx, caps, op, p)
 	if err != nil {
-		return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+		return nil, fmt.Errorf("process group applybatch: %v", err)
 	}
 
 	return caps, nil
@@ -59,7 +59,7 @@ func (p Group) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.
 func (p Group) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, error) {
 	// only supports JSON arrays, error early if there are no keys
 	if p.InputKey == "" && p.OutputKey == "" {
-		return cap, fmt.Errorf("apply settings %+v: %w", p, ProcessorInvalidSettings)
+		return cap, fmt.Errorf("process group apply: options %+v: %v", p.Options, ProcessorMissingRequiredOptions)
 	}
 
 	if len(p.Options.Keys) == 0 {
@@ -84,7 +84,7 @@ func (p Group) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, e
 
 		// [["foo",123],["bar",456]]
 		if err := cap.Set(p.OutputKey, value); err != nil {
-			return cap, fmt.Errorf("apply settings %+v: %v", p, err)
+			return cap, fmt.Errorf("process group apply: %v", err)
 		}
 
 		return cap, nil
@@ -105,7 +105,7 @@ func (p Group) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, e
 		for j, r := range res.Array() {
 			cache[j], err = json.Set(cache[j], p.Options.Keys[i], r)
 			if err != nil {
-				return cap, fmt.Errorf("apply settings %+v: %v", p, err)
+				return cap, fmt.Errorf("process group apply: %v", err)
 			}
 		}
 	}
@@ -116,14 +116,14 @@ func (p Group) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, e
 	for i := 0; i < len(cache); i++ {
 		value, err = json.Set(value, fmt.Sprintf("%d", i), cache[i])
 		if err != nil {
-			return cap, fmt.Errorf("apply settings %+v: %v", p, err)
+			return cap, fmt.Errorf("process group apply: %v", err)
 		}
 	}
 
 	// JSON arrays must be set using SetRaw to preserve structure
 	// [{"name":"foo","size":123},{"name":"bar","size":456}]
 	if err := cap.SetRaw(p.OutputKey, value); err != nil {
-		return cap, fmt.Errorf("apply settings %+v: %v", p, err)
+		return cap, fmt.Errorf("process group apply: %v", err)
 	}
 
 	return cap, nil

--- a/process/group_test.go
+++ b/process/group_test.go
@@ -3,7 +3,6 @@ package process
 import (
 	"bytes"
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/brexhq/substation/config"
@@ -39,31 +38,23 @@ var groupTests = []struct {
 		[]byte(`{"group":[{"name":{"test":"foo"},"size":123},{"name":{"test":"bar"},"size":456}]}`),
 		nil,
 	},
-	{
-		"invalid settings",
-		Group{},
-		[]byte{},
-		[]byte{},
-		ProcessorInvalidSettings,
-	},
 }
 
 func TestGroup(t *testing.T) {
 	ctx := context.TODO()
 	cap := config.NewCapsule()
+
 	for _, test := range groupTests {
 		cap.SetData(test.test)
 
-		res, err := test.proc.Apply(ctx, cap)
-		if err != nil && errors.Is(err, test.err) {
-			continue
-		} else if err != nil {
+		result, err := test.proc.Apply(ctx, cap)
+		if err != nil {
 			t.Log(err)
 			t.Fail()
 		}
 
-		if c := bytes.Compare(res.GetData(), test.expected); c != 0 {
-			t.Logf("expected %s, got %s", test.expected, res.GetData())
+		if !bytes.Equal(result.GetData(), test.expected) {
+			t.Logf("expected %s, got %s", test.expected, result.GetData())
 			t.Fail()
 		}
 	}

--- a/process/gzip.go
+++ b/process/gzip.go
@@ -80,12 +80,12 @@ func (p Gzip) to(data []byte) ([]byte, error) {
 func (p Gzip) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.Capsule, error) {
 	op, err := condition.OperatorFactory(p.Condition)
 	if err != nil {
-		return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+		return nil, fmt.Errorf("process gzip applybatch: %v", err)
 	}
 
 	caps, err = conditionallyApplyBatch(ctx, caps, op, p)
 	if err != nil {
-		return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+		return nil, fmt.Errorf("process gzip applybatch: %v", err)
 	}
 
 	return caps, nil
@@ -95,7 +95,7 @@ func (p Gzip) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.C
 func (p Gzip) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, error) {
 	// error early if required options are missing
 	if p.Options.Direction == "" {
-		return cap, fmt.Errorf("apply settings %+v: %w", p, ProcessorInvalidSettings)
+		return cap, fmt.Errorf("process gzip apply: options %+v: %v", p.Options, ProcessorMissingRequiredOptions)
 	}
 
 	var value []byte
@@ -103,19 +103,19 @@ func (p Gzip) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, er
 	case "from":
 		from, err := p.from(cap.GetData())
 		if err != nil {
-			return cap, fmt.Errorf("apply settings %+v: %v", p, err)
+			return cap, fmt.Errorf("process gzip apply: %v", err)
 		}
 
 		value = from
 	case "to":
 		to, err := p.to(cap.GetData())
 		if err != nil {
-			return cap, fmt.Errorf("apply settings %+v: %v", p, err)
+			return cap, fmt.Errorf("process gzip apply: %v", err)
 		}
 
 		value = to
 	default:
-		return cap, fmt.Errorf("apply settings %+v: %w", p, GzipInvalidDirection)
+		return cap, fmt.Errorf("process gzip apply: direction %s: %v", p.Options.Direction, ProcessorInvalidDirection)
 	}
 
 	cap.SetData(value)

--- a/process/gzip.go
+++ b/process/gzip.go
@@ -9,11 +9,7 @@ import (
 
 	"github.com/brexhq/substation/condition"
 	"github.com/brexhq/substation/config"
-	"github.com/brexhq/substation/internal/errors"
 )
-
-// GzipInvalidDirection is returned when the Gzip processor is configured with an invalid direction.
-const GzipInvalidDirection = errors.Error("GzipInvalidDirection")
 
 /*
 Gzip processes data by compressing or decompressing gzip. The processor supports these patterns:

--- a/process/gzip_test.go
+++ b/process/gzip_test.go
@@ -3,7 +3,6 @@ package process
 import (
 	"bytes"
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/brexhq/substation/config"
@@ -38,31 +37,23 @@ var gzipTests = []struct {
 		[]byte{31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 74, 203, 207, 7, 4, 0, 0, 255, 255, 33, 101, 115, 140, 3, 0, 0, 0},
 		nil,
 	},
-	{
-		"missing required options",
-		Gzip{},
-		[]byte{},
-		[]byte{},
-		ProcessorInvalidSettings,
-	},
 }
 
 func TestGzip(t *testing.T) {
 	ctx := context.TODO()
 	cap := config.NewCapsule()
+
 	for _, test := range gzipTests {
 		cap.SetData(test.test)
 
-		res, err := test.proc.Apply(ctx, cap)
-		if err != nil && errors.Is(err, test.err) {
-			continue
-		} else if err != nil {
+		result, err := test.proc.Apply(ctx, cap)
+		if err != nil {
 			t.Log(err)
 			t.Fail()
 		}
 
-		if c := bytes.Compare(res.GetData(), test.expected); c != 0 {
-			t.Logf("expected %s, got %s", test.expected, res.GetData())
+		if !bytes.Equal(result.GetData(), test.expected) {
+			t.Logf("expected %s, got %s", test.expected, result.GetData())
 			t.Fail()
 		}
 	}

--- a/process/hash.go
+++ b/process/hash.go
@@ -56,12 +56,12 @@ type HashOptions struct {
 func (p Hash) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.Capsule, error) {
 	op, err := condition.OperatorFactory(p.Condition)
 	if err != nil {
-		return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+		return nil, fmt.Errorf("process hash applybatch: %v", err)
 	}
 
 	caps, err = conditionallyApplyBatch(ctx, caps, op, p)
 	if err != nil {
-		return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+		return nil, fmt.Errorf("process hash applybatch: %v", err)
 	}
 
 	return caps, nil
@@ -71,7 +71,7 @@ func (p Hash) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.C
 func (p Hash) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, error) {
 	// error early if required options are missing
 	if p.Options.Algorithm == "" {
-		return cap, fmt.Errorf("apply settings %+v: %w", p, ProcessorInvalidSettings)
+		return cap, fmt.Errorf("process hash apply: options %+v: %v", p.Options, ProcessorMissingRequiredOptions)
 	}
 
 	// JSON processing
@@ -87,11 +87,11 @@ func (p Hash) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, er
 			sum := sha256.Sum256([]byte(result))
 			value = fmt.Sprintf("%x", sum)
 		default:
-			return cap, fmt.Errorf("apply settings %+v: %w", p, HashInvalidAlgorithm)
+			return cap, fmt.Errorf("process hash apply: algorithm %s: %v", p.Options.Algorithm, HashInvalidAlgorithm)
 		}
 
 		if err := cap.Set(p.OutputKey, value); err != nil {
-			return cap, fmt.Errorf("apply settings %+v: %v", p, err)
+			return cap, fmt.Errorf("process hash apply: %v", err)
 		}
 
 		return cap, nil
@@ -108,12 +108,12 @@ func (p Hash) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, er
 			sum := sha256.Sum256(cap.GetData())
 			value = fmt.Sprintf("%x", sum)
 		default:
-			return cap, fmt.Errorf("apply settings %+v: %w", p, HashInvalidAlgorithm)
+			return cap, fmt.Errorf("process hash apply: algorithm %s: %v", p.Options.Algorithm, HashInvalidAlgorithm)
 		}
 
 		cap.SetData([]byte(value))
 		return cap, nil
 	}
 
-	return cap, fmt.Errorf("apply settings %+v: %w", p, ProcessorInvalidSettings)
+	return cap, fmt.Errorf("process hash apply: inputkey %s outputkey %s: %v", p.InputKey, p.OutputKey, ProcessorInvalidDataPattern)
 }

--- a/process/hash_test.go
+++ b/process/hash_test.go
@@ -3,7 +3,6 @@ package process
 import (
 	"bytes"
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/brexhq/substation/config"
@@ -77,31 +76,23 @@ var hashTests = []struct {
 		[]byte(`2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae`),
 		nil,
 	},
-	{
-		"invalid settings",
-		Hash{},
-		[]byte{},
-		[]byte{},
-		ProcessorInvalidSettings,
-	},
 }
 
 func TestHash(t *testing.T) {
 	ctx := context.TODO()
 	cap := config.NewCapsule()
+
 	for _, test := range hashTests {
 		cap.SetData(test.test)
 
-		res, err := test.proc.Apply(ctx, cap)
-		if err != nil && errors.Is(err, test.err) {
-			continue
-		} else if err != nil {
+		result, err := test.proc.Apply(ctx, cap)
+		if err != nil {
 			t.Log(err)
 			t.Fail()
 		}
 
-		if c := bytes.Compare(res.GetData(), test.expected); c != 0 {
-			t.Logf("expected %s, got %s", test.expected, res.GetData())
+		if !bytes.Equal(result.GetData(), test.expected) {
+			t.Logf("expected %s, got %s", test.expected, result.GetData())
 			t.Fail()
 		}
 	}

--- a/process/insert.go
+++ b/process/insert.go
@@ -43,12 +43,12 @@ type InsertOptions struct {
 func (p Insert) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.Capsule, error) {
 	op, err := condition.OperatorFactory(p.Condition)
 	if err != nil {
-		return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+		return nil, fmt.Errorf("process insert applybatch: %v", err)
 	}
 
 	caps, err = conditionallyApplyBatch(ctx, caps, op, p)
 	if err != nil {
-		return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+		return nil, fmt.Errorf("process insert applybatch: %v", err)
 	}
 
 	return caps, nil
@@ -58,11 +58,11 @@ func (p Insert) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config
 func (p Insert) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, error) {
 	// only supports JSON, error early if there are no keys
 	if p.OutputKey == "" {
-		return cap, fmt.Errorf("apply settings %+v: %w", p, ProcessorInvalidSettings)
+		return cap, fmt.Errorf("process insert apply: outputkey %s: %v", p.OutputKey, ProcessorInvalidDataPattern)
 	}
 
 	if err := cap.Set(p.OutputKey, p.Options.Value); err != nil {
-		return cap, fmt.Errorf("apply settings %+v: %v", p, err)
+		return cap, fmt.Errorf("process insert apply: %v", err)
 	}
 
 	return cap, nil

--- a/process/insert_test.go
+++ b/process/insert_test.go
@@ -3,7 +3,6 @@ package process
 import (
 	"bytes"
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/brexhq/substation/config"
@@ -102,31 +101,23 @@ var insertTests = []struct {
 		[]byte(`{"foo":"eJwFwDENAAAAwjCtTAL+j6YdAl0BNg=="}`),
 		nil,
 	},
-	{
-		"invalid settings",
-		Insert{},
-		[]byte{},
-		[]byte{},
-		ProcessorInvalidSettings,
-	},
 }
 
 func TestInsert(t *testing.T) {
 	ctx := context.TODO()
 	cap := config.NewCapsule()
+
 	for _, test := range insertTests {
 		cap.SetData(test.test)
 
-		res, err := test.proc.Apply(ctx, cap)
-		if err != nil && errors.Is(err, test.err) {
-			continue
-		} else if err != nil {
+		result, err := test.proc.Apply(ctx, cap)
+		if err != nil {
 			t.Log(err)
 			t.Fail()
 		}
 
-		if c := bytes.Compare(res.GetData(), test.expected); c != 0 {
-			t.Logf("expected %s, got %s", test.expected, res.GetData())
+		if !bytes.Equal(result.GetData(), test.expected) {
+			t.Logf("expected %s, got %s", test.expected, result.GetData())
 			t.Fail()
 		}
 	}

--- a/process/lambda_test.go
+++ b/process/lambda_test.go
@@ -3,7 +3,6 @@ package process
 import (
 	"bytes"
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -51,39 +50,24 @@ var lambdaTests = []struct {
 			},
 		},
 	},
-	{
-		"invalid settings",
-		Lambda{},
-		[]byte{},
-		[]byte{},
-		ProcessorInvalidSettings,
-		lamb.API{
-			Client: mockedInvoke{
-				Resp: lambda.InvokeOutput{
-					Payload: []byte(`{"baz":"qux"}`),
-				},
-			},
-		},
-	},
 }
 
 func TestLambda(t *testing.T) {
 	ctx := context.TODO()
 	cap := config.NewCapsule()
+
 	for _, test := range lambdaTests {
 		lambdaAPI = test.api
 		cap.SetData(test.test)
 
-		res, err := test.proc.Apply(ctx, cap)
-		if err != nil && errors.Is(err, test.err) {
-			continue
-		} else if err != nil {
+		result, err := test.proc.Apply(ctx, cap)
+		if err != nil {
 			t.Log(err)
 			t.Fail()
 		}
 
-		if c := bytes.Compare(res.GetData(), test.expected); c != 0 {
-			t.Logf("expected %s, got %s", test.expected, res.GetData())
+		if !bytes.Equal(result.GetData(), test.expected) {
+			t.Logf("expected %s, got %s", test.expected, result.GetData())
 			t.Fail()
 		}
 	}

--- a/process/math.go
+++ b/process/math.go
@@ -50,12 +50,12 @@ type MathOptions struct {
 func (p Math) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.Capsule, error) {
 	op, err := condition.OperatorFactory(p.Condition)
 	if err != nil {
-		return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+		return nil, fmt.Errorf("process math applybatch: %v", err)
 	}
 
 	caps, err = conditionallyApplyBatch(ctx, caps, op, p)
 	if err != nil {
-		return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+		return nil, fmt.Errorf("process math applybatch: %v", err)
 	}
 
 	return caps, nil
@@ -65,12 +65,12 @@ func (p Math) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.C
 func (p Math) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, error) {
 	// error early if required options are missing
 	if p.Options.Operation == "" {
-		return cap, fmt.Errorf("apply settings %+v: %w", p, ProcessorInvalidSettings)
+		return cap, fmt.Errorf("process math apply: options %+v: %v", p.Options, ProcessorMissingRequiredOptions)
 	}
 
 	// only supports JSON, error early if there are no keys
 	if p.InputKey == "" && p.OutputKey == "" {
-		return cap, fmt.Errorf("apply settings %+v: %w", p, ProcessorInvalidSettings)
+		return cap, fmt.Errorf("process math apply: inputkey %s outputkey %s: %v", p.InputKey, p.OutputKey, ProcessorInvalidDataPattern)
 	}
 
 	var value int64
@@ -94,7 +94,7 @@ func (p Math) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, er
 	}
 
 	if err := cap.Set(p.OutputKey, value); err != nil {
-		return cap, fmt.Errorf("apply settings %+v: %v", p, err)
+		return cap, fmt.Errorf("process math apply: %v", err)
 	}
 
 	return cap, nil

--- a/process/math_test.go
+++ b/process/math_test.go
@@ -3,7 +3,6 @@ package process
 import (
 	"bytes"
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/brexhq/substation/config"
@@ -68,31 +67,23 @@ var mathTests = []struct {
 		[]byte(`{"foo":5}`),
 		nil,
 	},
-	{
-		"invalid settings",
-		Math{},
-		[]byte{},
-		[]byte{},
-		ProcessorInvalidSettings,
-	},
 }
 
 func TestMath(t *testing.T) {
 	ctx := context.TODO()
 	cap := config.NewCapsule()
+
 	for _, test := range mathTests {
 		cap.SetData(test.test)
 
-		res, err := test.proc.Apply(ctx, cap)
-		if err != nil && errors.Is(err, test.err) {
-			continue
-		} else if err != nil {
+		result, err := test.proc.Apply(ctx, cap)
+		if err != nil {
 			t.Log(err)
 			t.Fail()
 		}
 
-		if c := bytes.Compare(res.GetData(), test.expected); c != 0 {
-			t.Logf("expected %s, got %s", test.expected, res.GetData())
+		if !bytes.Equal(result.GetData(), test.expected) {
+			t.Logf("expected %s, got %s", test.expected, result.GetData())
 			t.Fail()
 		}
 	}

--- a/process/pipeline_test.go
+++ b/process/pipeline_test.go
@@ -3,7 +3,6 @@ package process
 import (
 	"bytes"
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/brexhq/substation/config"
@@ -74,61 +73,23 @@ var PipelineTests = []struct {
 		[]byte(`foo`),
 		nil,
 	},
-	{
-		"invalid settings",
-		Pipeline{},
-		[]byte{},
-		[]byte{},
-		ProcessorInvalidSettings,
-	},
-	{
-		"invalid array input",
-		Pipeline{
-			Options: PipelineOptions{
-				Processors: []config.Config{
-					{
-						Type: "base64",
-						Settings: map[string]interface{}{
-							"options": map[string]interface{}{
-								"direction": "from",
-							},
-						},
-					},
-					{
-						Type: "gzip",
-						Settings: map[string]interface{}{
-							"options": map[string]interface{}{
-								"direction": "from",
-							},
-						},
-					},
-				},
-			},
-			InputKey:  "foo",
-			OutputKey: "foo",
-		},
-		[]byte(`{"foo":["H4sIAMpcy2IA/wXAIQ0AAACAsLbY93csBiFlc4wDAAAA"]}`),
-		[]byte{},
-		PipelineArrayInput,
-	},
 }
 
 func TestPipeline(t *testing.T) {
 	ctx := context.TODO()
 	cap := config.NewCapsule()
+
 	for _, test := range PipelineTests {
 		cap.SetData(test.test)
 
-		res, err := test.proc.Apply(ctx, cap)
-		if err != nil && errors.Is(err, test.err) {
-			continue
-		} else if err != nil {
+		result, err := test.proc.Apply(ctx, cap)
+		if err != nil {
 			t.Log(err)
 			t.Fail()
 		}
 
-		if c := bytes.Compare(res.GetData(), test.expected); c != 0 {
-			t.Logf("expected %s, got %s", test.expected, res.GetData())
+		if !bytes.Equal(result.GetData(), test.expected) {
+			t.Logf("expected %s, got %s", test.expected, result.GetData())
 			t.Fail()
 		}
 	}

--- a/process/pretty_print.go
+++ b/process/pretty_print.go
@@ -155,7 +155,7 @@ func (p PrettyPrint) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]c
 			}
 
 		default:
-			return nil, fmt.Errorf("process pretty_print applybatch: direction %s: %w", p.Options.Direction, ProcessorInvalidDirection)
+			return nil, fmt.Errorf("process pretty_print applybatch: direction %s: %v", p.Options.Direction, ProcessorInvalidDirection)
 		}
 	}
 
@@ -189,6 +189,6 @@ func (p PrettyPrint) Apply(ctx context.Context, cap config.Capsule) (config.Caps
 		cap.SetData([]byte(cap.Get(ppModifier).String()))
 		return cap, nil
 	default:
-		return cap, fmt.Errorf("process pretty_print apply: direction %s: %w", p.Options.Direction, ProcessorInvalidDirection)
+		return cap, fmt.Errorf("process pretty_print apply: direction %s: %v", p.Options.Direction, ProcessorInvalidDirection)
 	}
 }

--- a/process/pretty_print.go
+++ b/process/pretty_print.go
@@ -17,12 +17,11 @@ import (
 )
 
 // used with json.Get, returns a pretty printed root JSON object
-const ppModifier = `@this|@pretty`
-const openCurlyBracket = 123  // {
-const closeCurlyBracket = 125 // }
-
-// PrettyPrintInvalidDirection is returned when the PrettyPrint processor is configured with an invalid direction.
-const PrettyPrintInvalidDirection = errors.Error("PrettyPrintInvalidDirection")
+const (
+	ppModifier        = `@this|@pretty`
+	openCurlyBracket  = 123 // {
+	closeCurlyBracket = 125 // }
+)
 
 /*
 PrettyPrintUnbalancedBrackets is returned when the processor is given input

--- a/process/pretty_print.go
+++ b/process/pretty_print.go
@@ -17,7 +17,7 @@ import (
 )
 
 // used with json.Get, returns a pretty printed root JSON object
-const  ppModifier = `@this|@pretty`
+const ppModifier = `@this|@pretty`
 const openCurlyBracket = 123  // {
 const closeCurlyBracket = 125 // }
 
@@ -97,12 +97,12 @@ applied and the result is emitted as a new object.
 func (p PrettyPrint) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.Capsule, error) {
 	// error early if required options are missing
 	if p.Options.Direction == "" {
-		return nil, fmt.Errorf("applybatch settings %+v: %w", p, ProcessorInvalidSettings)
+		return nil, fmt.Errorf("process pretty_print applybatch: options %+v: %v", p.Options, ProcessorMissingRequiredOptions)
 	}
 
 	op, err := condition.OperatorFactory(p.Condition)
 	if err != nil {
-		return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+		return nil, fmt.Errorf("process pretty_print applybatch: %v", err)
 	}
 
 	var count int
@@ -112,7 +112,7 @@ func (p PrettyPrint) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]c
 	for _, cap := range caps {
 		ok, err := op.Operate(ctx, cap)
 		if err != nil {
-			return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+			return nil, fmt.Errorf("process pretty_print applybatch: %v", err)
 		}
 
 		if !ok {
@@ -141,7 +141,7 @@ func (p PrettyPrint) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]c
 				if count == 0 {
 					var buf bytes.Buffer
 					if err := gojson.Compact(&buf, stack); err != nil {
-						return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+						return nil, fmt.Errorf("process pretty_print applybatch: gojson compact: %v", err)
 					}
 
 					if json.Valid(buf.Bytes()) {
@@ -155,12 +155,12 @@ func (p PrettyPrint) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]c
 			}
 
 		default:
-			return nil, fmt.Errorf("applybatch settings %+v: %w", p, PrettyPrintInvalidDirection)
+			return nil, fmt.Errorf("process pretty_print applybatch: direction %s: %w", p.Options.Direction, ProcessorInvalidDirection)
 		}
 	}
 
 	if count != 0 {
-		return nil, fmt.Errorf("applybatch settings %+v: %w", p, PrettyPrintUnbalancedBrackets)
+		return nil, fmt.Errorf("process pretty_print applybatch: incomplete JSON, %d characters remain: %v", count, PrettyPrintUnbalancedBrackets)
 	}
 
 	return newCaps, nil
@@ -181,7 +181,7 @@ that are stored in a single byte array.
 func (p PrettyPrint) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, error) {
 	// error early if required options are missing
 	if p.Options.Direction == "" {
-		return cap, fmt.Errorf("apply settings %+v: %w", p, ProcessorInvalidSettings)
+		return cap, fmt.Errorf("process pretty_print apply: options %+v: %v", p.Options, ProcessorMissingRequiredOptions)
 	}
 
 	switch p.Options.Direction {
@@ -189,6 +189,6 @@ func (p PrettyPrint) Apply(ctx context.Context, cap config.Capsule) (config.Caps
 		cap.SetData([]byte(cap.Get(ppModifier).String()))
 		return cap, nil
 	default:
-		return cap, fmt.Errorf("applybatch settings %+v: %w", p, ProcessorInvalidSettings)
+		return cap, fmt.Errorf("process pretty_print apply: direction %s: %w", p.Options.Direction, ProcessorInvalidDirection)
 	}
 }

--- a/process/process.go
+++ b/process/process.go
@@ -163,7 +163,7 @@ func ApplicatorFactory(cfg config.Config) (Applicator, error) {
 		config.Decode(cfg.Settings, &p)
 		return p, nil
 	default:
-		return nil, fmt.Errorf("process settings %+v: %w", cfg.Settings, ApplyInvalidFactoryConfig)
+		return nil, fmt.Errorf("process settings %+v: %v", cfg.Settings, ApplyInvalidFactoryConfig)
 	}
 }
 
@@ -310,7 +310,7 @@ func BatchApplicatorFactory(cfg config.Config) (BatchApplicator, error) {
 		config.Decode(cfg.Settings, &p)
 		return p, nil
 	default:
-		return nil, fmt.Errorf("process settings %+v: %w", cfg.Settings, ApplyBatchInvalidFactoryConfig)
+		return nil, fmt.Errorf("process settings %+v: %v", cfg.Settings, ApplyBatchInvalidFactoryConfig)
 	}
 }
 

--- a/process/process.go
+++ b/process/process.go
@@ -9,8 +9,14 @@ import (
 	"github.com/brexhq/substation/internal/errors"
 )
 
-// ProcessorInvalidSettings is returned when a processor is configured with invalid settings. Common causes include improper input and output settings (e.g., missing keys) and missing required options.
-const ProcessorInvalidSettings = errors.Error("ProcessorInvalidSettings")
+// ProcessorInvalidDataPattern is returned when a processor is configured with an invalid data access pattern. This is commonly caused by improperly set input and output settings.
+const ProcessorInvalidDataPattern = errors.Error("ProcessorIncorrectDataSettings")
+
+// ProcessorInvalidDirection is returned when a processor is configured with an invalid direction setting.
+const ProcessorInvalidDirection = errors.Error("ProcessorInvalidDirection")
+
+// ProcessorMissingRequiredOptions is returned when a processor does not have the required options to properly execute.
+const ProcessorMissingRequiredOptions = errors.Error("ProcessorMissingRequiredOptions")
 
 // ApplyInvalidFactoryConfig is returned when an unsupported Task processor is referenced in Factory.
 const ApplyInvalidFactoryConfig = errors.Error("ApplyInvalidFactoryConfig")

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -140,14 +140,14 @@ func TestApply(t *testing.T) {
 			t.Fail()
 		}
 
-		processed, err := Apply(ctx, cap, applicators...)
+		result, err := Apply(ctx, cap, applicators...)
 		if err != nil {
 			t.Log(err)
 			t.Fail()
 		}
 
-		if c := bytes.Compare(processed.GetData(), test.expected); c != 0 {
-			t.Logf("expected %v, got %v", test.expected, processed)
+		if !bytes.Equal(result.GetData(), test.expected) {
+			t.Logf("expected %v, got %v", test.expected, result)
 			t.Fail()
 		}
 	}
@@ -166,14 +166,14 @@ func TestApplicatorFactory(t *testing.T) {
 			t.Fail()
 		}
 
-		processed, err := applicator.Apply(ctx, cap)
+		result, err := applicator.Apply(ctx, cap)
 		if err != nil {
 			t.Log(err)
 			t.Fail()
 		}
 
-		if c := bytes.Compare(processed.GetData(), test.expected); c != 0 {
-			t.Logf("expected %v, got %v", test.expected, processed)
+		if !bytes.Equal(result.GetData(), test.expected) {
+			t.Logf("expected %v, got %v", test.expected, result)
 			t.Fail()
 		}
 	}
@@ -194,14 +194,14 @@ func TestApplyBatch(t *testing.T) {
 			t.Fail()
 		}
 
-		processed, err := ApplyBatch(ctx, batch, applicators...)
+		result, err := ApplyBatch(ctx, batch, applicators...)
 		if err != nil {
 			t.Log(err)
 			t.Fail()
 		}
 
-		if c := bytes.Compare(processed[0].GetData(), test.expected); c != 0 {
-			t.Logf("expected %v, got %v", test.expected, processed)
+		if !bytes.Equal(result[0].GetData(), test.expected) {
+			t.Logf("expected %v, got %v", test.expected, result)
 			t.Fail()
 		}
 	}
@@ -223,14 +223,14 @@ func TestBatchApplicatorFactory(t *testing.T) {
 			t.Fail()
 		}
 
-		processed, err := applicator.ApplyBatch(ctx, batch)
+		result, err := applicator.ApplyBatch(ctx, batch)
 		if err != nil {
 			t.Log(err)
 			t.Fail()
 		}
 
-		if c := bytes.Compare(processed[0].GetData(), test.expected); c != 0 {
-			t.Logf("expected %v, got %v", test.expected, processed)
+		if !bytes.Equal(result[0].GetData(), test.expected) {
+			t.Logf("expected %v, got %v", test.expected, result)
 			t.Fail()
 		}
 	}

--- a/process/replace.go
+++ b/process/replace.go
@@ -57,12 +57,12 @@ type ReplaceOptions struct {
 func (p Replace) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.Capsule, error) {
 	op, err := condition.OperatorFactory(p.Condition)
 	if err != nil {
-		return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+		return nil, fmt.Errorf("process replace applybatch: %v", err)
 	}
 
 	caps, err = conditionallyApplyBatch(ctx, caps, op, p)
 	if err != nil {
-		return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+		return nil, fmt.Errorf("process replace applybatch: %v", err)
 	}
 
 	return caps, nil
@@ -72,7 +72,7 @@ func (p Replace) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]confi
 func (p Replace) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, error) {
 	// error early if required options are missing
 	if p.Options.Old == "" || p.Options.New == "" {
-		return cap, fmt.Errorf("apply settings %+v: %w", p, ProcessorInvalidSettings)
+		return cap, fmt.Errorf("process replace apply: options %+v: %v", p.Options, ProcessorMissingRequiredOptions)
 	}
 
 	// default to replace all
@@ -91,7 +91,7 @@ func (p Replace) Apply(ctx context.Context, cap config.Capsule) (config.Capsule,
 		)
 
 		if err := cap.Set(p.OutputKey, value); err != nil {
-			return cap, fmt.Errorf("apply settings %+v: %v", p, err)
+			return cap, fmt.Errorf("process replace apply: %v", err)
 		}
 
 		return cap, nil
@@ -110,5 +110,5 @@ func (p Replace) Apply(ctx context.Context, cap config.Capsule) (config.Capsule,
 		return cap, nil
 	}
 
-	return cap, fmt.Errorf("apply settings %+v: %w", p, ProcessorInvalidSettings)
+	return cap, fmt.Errorf("process replace apply: inputkey %s outputkey %s: %v", p.InputKey, p.OutputKey, ProcessorInvalidDataPattern)
 }

--- a/process/replace_test.go
+++ b/process/replace_test.go
@@ -3,7 +3,6 @@ package process
 import (
 	"bytes"
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/brexhq/substation/config"
@@ -42,31 +41,23 @@ var replaceTests = []struct {
 		[]byte(`baz`),
 		nil,
 	},
-	{
-		"invalid settings",
-		Replace{},
-		[]byte{},
-		[]byte{},
-		ProcessorInvalidSettings,
-	},
 }
 
 func TestReplace(t *testing.T) {
 	ctx := context.TODO()
 	cap := config.NewCapsule()
+
 	for _, test := range replaceTests {
 		cap.SetData(test.test)
 
-		res, err := test.proc.Apply(ctx, cap)
-		if err != nil && errors.Is(err, test.err) {
-			continue
-		} else if err != nil {
+		result, err := test.proc.Apply(ctx, cap)
+		if err != nil {
 			t.Log(err)
 			t.Fail()
 		}
 
-		if c := bytes.Compare(res.GetData(), test.expected); c != 0 {
-			t.Logf("expected %s, got %s", test.expected, res.GetData())
+		if !bytes.Equal(result.GetData(), test.expected) {
+			t.Logf("expected %s, got %s", test.expected, result.GetData())
 			t.Fail()
 		}
 	}

--- a/process/split.go
+++ b/process/split.go
@@ -50,14 +50,14 @@ type SplitOptions struct {
 func (p Split) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.Capsule, error) {
 	op, err := condition.OperatorFactory(p.Condition)
 	if err != nil {
-		return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+		return nil, fmt.Errorf("process split applybatch: %v", err)
 	}
 
 	newCaps := newBatch(&caps)
 	for _, cap := range caps {
 		ok, err := op.Operate(ctx, cap)
 		if err != nil {
-			return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+			return nil, fmt.Errorf("process split applybatch: %v", err)
 		}
 
 		if !ok {
@@ -69,7 +69,7 @@ func (p Split) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.
 		if p.InputKey != "" && p.OutputKey != "" {
 			pcap, err := p.Apply(ctx, cap)
 			if err != nil {
-				return nil, fmt.Errorf("ApplyBatch: %v", err)
+				return nil, fmt.Errorf("process split applybatch: %v", err)
 			}
 			newCaps = append(newCaps, pcap)
 
@@ -87,7 +87,7 @@ func (p Split) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.
 			continue
 		}
 
-		return nil, fmt.Errorf("applybatch settings %+v: %w", p, ProcessorInvalidSettings)
+		return nil, fmt.Errorf("process split applybatch: inputkey %s outputkey %s: %v", p.InputKey, p.OutputKey, ProcessorInvalidDataPattern)
 	}
 
 	return newCaps, nil
@@ -97,19 +97,19 @@ func (p Split) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.
 func (p Split) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, error) {
 	// error early if required options are missing
 	if p.Options.Separator == "" {
-		return cap, fmt.Errorf("byter settings %+v: %w", p, ProcessorInvalidSettings)
+		return cap, fmt.Errorf("process split apply: options %+v: %v", p.Options, ProcessorMissingRequiredOptions)
 	}
 
 	// only supports JSON, error early if there are no keys
 	if p.InputKey == "" || p.OutputKey == "" {
-		return cap, fmt.Errorf("byter settings %+v: %w", p, ProcessorInvalidSettings)
+		return cap, fmt.Errorf("process split apply: inputkey %s outputkey %s: %v", p.InputKey, p.OutputKey, ProcessorInvalidDataPattern)
 	}
 
 	result := cap.Get(p.InputKey).String()
 	value := strings.Split(result, p.Options.Separator)
 
 	if err := cap.Set(p.OutputKey, value); err != nil {
-		return cap, fmt.Errorf("apply settings %+v: %v", p, err)
+		return cap, fmt.Errorf("process split apply: %v", err)
 	}
 
 	return cap, nil

--- a/process/time.go
+++ b/process/time.go
@@ -72,12 +72,12 @@ type TimeOptions struct {
 func (p Time) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.Capsule, error) {
 	op, err := condition.OperatorFactory(p.Condition)
 	if err != nil {
-		return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+		return nil, fmt.Errorf("process time applybatch: %v", err)
 	}
 
 	caps, err = conditionallyApplyBatch(ctx, caps, op, p)
 	if err != nil {
-		return nil, fmt.Errorf("applybatch settings %+v: %v", p, err)
+		return nil, fmt.Errorf("process time applybatch: %v", err)
 	}
 
 	return caps, nil
@@ -87,7 +87,7 @@ func (p Time) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.C
 func (p Time) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, error) {
 	// error early if required options are missing
 	if p.Options.InputFormat == "" || p.Options.OutputFormat == "" {
-		return cap, fmt.Errorf("apply settings %+v: %w", p, ProcessorInvalidSettings)
+		return cap, fmt.Errorf("process time apply: options %+v: %v", p.Options, ProcessorMissingRequiredOptions)
 	}
 
 	// "now" processing, supports json and data
@@ -106,7 +106,7 @@ func (p Time) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, er
 
 		if p.OutputKey != "" {
 			if err := cap.Set(p.OutputKey, value); err != nil {
-				return cap, fmt.Errorf("apply settings %+v: %v", p, err)
+				return cap, fmt.Errorf("process time apply: %v", err)
 			}
 
 			return cap, nil
@@ -133,11 +133,11 @@ func (p Time) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, er
 
 		value, err := p.time(result)
 		if err != nil {
-			return cap, fmt.Errorf("apply settings %+v: %v", p, err)
+			return cap, fmt.Errorf("process time apply: %v", err)
 		}
 
 		if err := cap.Set(p.OutputKey, value); err != nil {
-			return cap, fmt.Errorf("apply settings %+v: %v", p, err)
+			return cap, fmt.Errorf("process time apply: %v", err)
 		}
 
 		return cap, nil
@@ -147,13 +147,13 @@ func (p Time) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, er
 	if p.InputKey == "" && p.OutputKey == "" {
 		tmp, err := json.Set([]byte{}, "tmp", cap.GetData())
 		if err != nil {
-			return cap, fmt.Errorf("apply settings %+v: %v", p, err)
+			return cap, fmt.Errorf("process time apply: %v", err)
 		}
 
 		res := json.Get(tmp, "tmp")
 		value, err := p.time(res)
 		if err != nil {
-			return cap, fmt.Errorf("apply settings %+v: %v", p, err)
+			return cap, fmt.Errorf("process time apply: %v", err)
 		}
 
 		switch v := value.(type) {
@@ -166,7 +166,7 @@ func (p Time) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, er
 		return cap, nil
 	}
 
-	return cap, fmt.Errorf("apply settings %+v: %w", p, ProcessorInvalidSettings)
+	return cap, fmt.Errorf("process time apply: inputkey %s outputkey %s: %v", p.InputKey, p.OutputKey, ProcessorInvalidDataPattern)
 }
 
 func (p Time) time(result json.Result) (interface{}, error) {
@@ -183,18 +183,18 @@ func (p Time) time(result json.Result) (interface{}, error) {
 		if p.Options.InputLocation != "" {
 			loc, err := time.LoadLocation(p.Options.InputLocation)
 			if err != nil {
-				return nil, fmt.Errorf("time location %s: %v", p.Options.InputLocation, err)
+				return nil, fmt.Errorf("time: location %s: %v", p.Options.InputLocation, err)
 			}
 
 			timeDate, err = time.ParseInLocation(p.Options.InputFormat, result.String(), loc)
 			if err != nil {
-				return nil, fmt.Errorf("time parse format %s location %s: %v", p.Options.InputFormat, p.Options.InputLocation, err)
+				return nil, fmt.Errorf("time parse: format %s location %s: %v", p.Options.InputFormat, p.Options.InputLocation, err)
 			}
 		} else {
 			var err error
 			timeDate, err = time.Parse(p.Options.InputFormat, result.String())
 			if err != nil {
-				return nil, fmt.Errorf("time parse format %s: %v", p.Options.InputFormat, err)
+				return nil, fmt.Errorf("time parse: format %s: %v", p.Options.InputFormat, err)
 			}
 		}
 	}
@@ -203,7 +203,7 @@ func (p Time) time(result json.Result) (interface{}, error) {
 	if p.Options.OutputLocation != "" {
 		loc, err := time.LoadLocation(p.Options.OutputLocation)
 		if err != nil {
-			return nil, fmt.Errorf("time location %s: %v", p.Options.OutputLocation, err)
+			return nil, fmt.Errorf("time: location %s: %v", p.Options.OutputLocation, err)
 		}
 
 		timeDate = timeDate.In(loc)

--- a/process/time_test.go
+++ b/process/time_test.go
@@ -3,7 +3,6 @@ package process
 import (
 	"bytes"
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/brexhq/substation/config"
@@ -187,31 +186,23 @@ var timeTests = []struct {
 		[]byte(`{"time":"2020-Jan-29 Wednesday 03:19:25"}`),
 		nil,
 	},
-	{
-		"invalid settings",
-		Time{},
-		[]byte{},
-		[]byte{},
-		ProcessorInvalidSettings,
-	},
 }
 
 func TestTime(t *testing.T) {
 	ctx := context.TODO()
 	cap := config.NewCapsule()
+
 	for _, test := range timeTests {
 		cap.SetData(test.test)
 
-		res, err := test.proc.Apply(ctx, cap)
-		if err != nil && errors.Is(err, test.err) {
-			continue
-		} else if err != nil {
+		result, err := test.proc.Apply(ctx, cap)
+		if err != nil {
 			t.Log(err)
 			t.Fail()
 		}
 
-		if c := bytes.Compare(res.GetData(), test.expected); c != 0 {
-			t.Logf("expected %s, got %s", test.expected, res.GetData())
+		if !bytes.Equal(result.GetData(), test.expected) {
+			t.Logf("expected %s, got %s", test.expected, result.GetData())
 			t.Fail()
 		}
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- Makes all wrappable errors (`%w`) non-wrappable (`%v`)
- Makes errors returned by the condition and process packages more user friendly

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I was updating some configs between Substation versions and it became clear that our approach to error reporting in the public packages is not user friendly. Here's an example:
> panic: main: file: applybatch settings {Options:{Table: KeyConditionExpression:pk = :partitionkeyval Limit:1 ScanIndexForward:false} Condition:{Operator:and Inspectors:[{Type:strings Settings:map[expression: function:equals key:foo.source.ip negate:true]} {Type:ip Settings:map[key:foo.source.ip negate:true type:loopback]} {Type:ip Settings:map[key:foo.source.ip negate:true type:multicast_link_local]} {Type:ip Settings:map[key:foo.source.ip negate:true type:private]} {Type:ip Settings:map[key:foo.source.ip negate:true type:unicast_link_local]} {Type:ip Settings:map[key:foo.source.ip negate:true type:unspecified]}]} InputKey:__tmp.source.ip.resolver OutputKey:__tmp.source.ip.resolver}: apply settings {Options:{Table: KeyConditionExpression:pk = :partitionkeyval Limit:1 ScanIndexForward:false} Condition:{Operator:and Inspectors:[{Type:strings Settings:map[expression: function:equals key:foo.source.ip negate:true]} {Type:ip Settings:map[key:foo.source.ip negate:true type:loopback]} {Type:ip Settings:map[key:foo.source.ip negate:true type:multicast_link_local]} {Type:ip Settings:map[key:foo.source.ip negate:true type:private]} {Type:ip Settings:map[key:foo.source.ip negate:true type:unicast_link_local]} {Type:ip Settings:map[key:foo.source.ip negate:true type:unspecified]}]} InputKey:__tmp.source.ip.resolver OutputKey:__tmp.source.ip.resolver}: ProcessorInvalidSettings

Earlier in development we took an error reporting shortcut and decided to report the equivalent of a stack trace. Aside from being difficult to look at, it doesn't indicate what the actual problem is (the originating error is a generic `ProcessorInvalidSettings`).

With this PR that error is now this:
> panic: main: file: process dynamodb applybatch: process dynamodb apply: options {Table: KeyConditionExpression:pk = :partitionkeyval Limit:1 ScanIndexForward:false}: ProcessorMissingRequiredOptions

I think this is an improvement for a couple reasons:

- We're now using the Go convention of maintaining a reverse call stack that leads users to the problem (i.e., `foo: bar: baz: qux`)
- We're now using more specific errors (e.g., `ProcessorMissingRequiredOptions`) with specific supporting detail instead of one monolithic error (`ProcessorInvalidSettings`) with a config stack trace

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally with some complex configurations using the file app.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
