### PR TITLE
fix: Handling Large S3 Files

### DIFF
--- a/cmd/file/substation/main.go
+++ b/cmd/file/substation/main.go
@@ -90,13 +90,9 @@ func file(ctx context.Context, filename string) error {
 			fi.ModTime(),
 		})
 
+		// a scanner token can be up to 100MB
 		scanner := bufio.NewScanner(fileHandle)
-
-		// ensures that files containing a single line can fit
-		// within the scanner
-		s := int(float64(fi.Size()) * 1.1)
-		buf := make([]byte, s)
-		scanner.Buffer(buf, s)
+		scanner.Buffer([]byte{}, 100*1024*1024)
 
 		for scanner.Scan() {
 			cap.SetData([]byte(scanner.Text()))

--- a/internal/aws/s3manager/s3manager.go
+++ b/internal/aws/s3manager/s3manager.go
@@ -32,7 +32,7 @@ func init() {
 			panic(fmt.Errorf("s3manager init: %v", err))
 		}
 
-		maxCapacity = v * 1024 * 1024
+		maxCapacity = v * 1024 * 1024 / 2
 	}
 }
 

--- a/internal/aws/s3manager/s3manager.go
+++ b/internal/aws/s3manager/s3manager.go
@@ -18,6 +18,24 @@ import (
 	"github.com/aws/aws-xray-sdk-go/xray"
 )
 
+// maxCapacity limits the size of tokens in bufio scanners
+var maxCapacity int
+
+func init() {
+	// by default a scanner token can be up to 100MB. if
+	// executed in Lambda, then the capacity is half of the
+	// function's memory.
+	maxCapacity = 100 * 1024 * 1024
+	if val, ok := os.LookupEnv("AWS_LAMBDA_FUNCTION_MEMORY_SIZE"); ok {
+		v, err := strconv.Atoi(val)
+		if err != nil {
+			panic(fmt.Errorf("s3manager init: %v", err))
+		}
+
+		maxCapacity = v * 1024 * 1024
+	}
+}
+
 // NewS3 returns a configured S3 client.
 func NewS3() *s3.S3 {
 	conf := aws.NewConfig()
@@ -99,12 +117,7 @@ func (a *DownloaderAPI) DownloadAsScanner(ctx aws.Context, bucket, key string) (
 	}
 
 	scanner := bufio.NewScanner(decoded)
-
-	// ensures that files containing a single line can fit
-	// within the scanner
-	s := int(float64(size) * 1.1)
-	b := make([]byte, s)
-	scanner.Buffer(b, s)
+	scanner.Buffer([]byte{}, maxCapacity)
 
 	return scanner, nil
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- Fixes a regression introduced in https://github.com/brexhq/substation/pull/19 when handling very large S3 files that contain a single line of text
- Refactors the Expand processor to speed up data processing for very large JSON objects that contain 1000s of inner objects in an array

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

During migration of a data pipeline using https://github.com/brexhq/substation/pull/19 I discovered that it introduced a regression for the edge case of handling very large files downloaded from S3 that contain a single line of text (e.g., files from AWS CloudTrail in very busy AWS accounts).

As a longer term solution, the `s3manager` will do a one-time check on initialization for the amount of memory that can be allocated to a single token in a bufio scanner and uses this pattern:
- by default, the token can be up to 100MB in size
  - in practice, it should be impossible to use this setting -- the s3manager is a private package that is only used by other private packages, but this is included as a default in case that changes
- when run in an AWS Lambda, the token can be up to half of the total memory of the Lambda
  - e.g., if the Lambda is 128MB, then the token can be up to 64MB; if the Lambda is 1024MB (1GB), then the token can be up to 512MB

This also refactors the Expand processor to handle dealing with very large JSON objects that contain many large, inner objects. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested in our development AWS account on AWS CloudTrail files uploaded to S3.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
