### PR TITLE
feat!: Add Forward Compatibility for SNS

### DIFF
--- a/build/terraform/aws/README.md
+++ b/build/terraform/aws/README.md
@@ -98,6 +98,12 @@ Read more about S3 [here](https://aws.amazon.com/s3/).
 
 This module creates a write once, read many (WORM) S3 bucket using [Object Lock](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock-overview.html) and applies the [Compliance](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock-overview.html#object-lock-retention-modes) retention mode setting. Objects written to these buckets _*cannot be deleted*_.
 
+### SNS
+
+This module is used for creating SNS topics. Topics can be standard or first-in-first-out (FIFO).
+
+Read more about SNS [here](https://aws.amazon.com/sns/).
+
 ### SQS
 
 This module is used for creating SQS queues. Queues can be standard or first-in-first-out (FIFO).

--- a/build/terraform/aws/iam/main.tf
+++ b/build/terraform/aws/iam/main.tf
@@ -166,7 +166,6 @@ data "aws_iam_policy_document" "secretsmanager_read" {
   }
 }
 
-
 data "aws_iam_policy_document" "sqs_read" {
   statement {
     effect = "Allow"

--- a/build/terraform/aws/sns/_variables.tf
+++ b/build/terraform/aws/sns/_variables.tf
@@ -1,0 +1,17 @@
+variable "name" {
+  type = string
+}
+
+variable "kms_key_id" {
+  type = string
+}
+
+variable "fifo" {
+  type    = bool
+  default = false
+}
+
+variable "tags" {
+  type    = map(any)
+  default = {}
+}

--- a/build/terraform/aws/sns/main.tf
+++ b/build/terraform/aws/sns/main.tf
@@ -1,0 +1,8 @@
+resource "aws_sns_topic" "topic" {
+  name                        = var.name
+  kms_master_key_id           = var.kms_key_id
+  fifo_topic                  = var.fifo ? true : false
+  content_based_deduplication = var.fifo ? true : false
+
+  tags = var.tags
+}

--- a/build/terraform/aws/sns/output.tf
+++ b/build/terraform/aws/sns/output.tf
@@ -1,0 +1,7 @@
+output "arn" {
+  value = aws_sns_topic.topic.arn
+}
+
+output "id" {
+  value = aws_sns_topic.topic.id
+}

--- a/cmd/aws/lambda/substation/main.go
+++ b/cmd/aws/lambda/substation/main.go
@@ -117,10 +117,10 @@ func gatewayHandler(ctx context.Context, request events.APIGatewayProxyRequest) 
 }
 
 type kinesisMetadata struct {
-	EventSourceArn              string    `json:"event_source_arn"`
-	ApproximateArrivalTimestamp time.Time `json:"approximate_arrival_timestamp"`
-	PartitionKey                string    `json:"partition_key"`
-	SequenceNumber              string    `json:"sequence_number"`
+	ApproximateArrivalTimestamp time.Time `json:"approximateArrivalTimestamp"`
+	EventSourceArn              string    `json:"eventSourceArn"`
+	PartitionKey                string    `json:"partitionKey"`
+	SequenceNumber              string    `json:"sequenceNumber"`
 }
 
 func kinesisHandler(ctx context.Context, event events.KinesisEvent) error {
@@ -158,8 +158,8 @@ func kinesisHandler(ctx context.Context, event events.KinesisEvent) error {
 			cap := config.NewCapsule()
 			cap.SetData(record.Data)
 			cap.SetMetadata(kinesisMetadata{
-				eventSourceArn,
 				*record.ApproximateArrivalTimestamp,
+				eventSourceArn,
 				*record.PartitionKey,
 				*record.SequenceNumber,
 			})
@@ -181,10 +181,11 @@ func kinesisHandler(ctx context.Context, event events.KinesisEvent) error {
 }
 
 type s3Metadata struct {
-	BucketArn  string `json:"bucket_arn"`
-	BucketName string `json:"bucket_name"`
-	ObjectKey  string `json:"object_key"`
-	ObjectSize int64  `json:"object_size"`
+	EventTime  time.Time `json:"eventTime"`
+	BucketArn  string    `json:"bucketArn"`
+	BucketName string    `json:"bucketName"`
+	ObjectKey  string    `json:"objectKey"`
+	ObjectSize int64     `json:"objectSize"`
 }
 
 func s3Handler(ctx context.Context, event events.S3Event) error {
@@ -231,6 +232,7 @@ func s3Handler(ctx context.Context, event events.S3Event) error {
 
 			cap := config.NewCapsule()
 			cap.SetMetadata(s3Metadata{
+				record.EventTime,
 				record.S3.Bucket.Arn,
 				record.S3.Bucket.Name,
 				record.S3.Object.Key,
@@ -308,6 +310,7 @@ func s3SnsHandler(ctx context.Context, event events.SNSEvent) error {
 
 				cap := config.NewCapsule()
 				cap.SetMetadata(s3Metadata{
+					record.EventTime,
 					record.S3.Bucket.Arn,
 					record.S3.Bucket.Name,
 					record.S3.Object.Key,
@@ -335,10 +338,10 @@ func s3SnsHandler(ctx context.Context, event events.SNSEvent) error {
 }
 
 type snsMetadata struct {
-	EventSubscriptionArn string    `json:"event_subscription_arn"`
-	MessageID            string    `json:"message_id"`
-	Subject              string    `json:"subject"`
 	Timestamp            time.Time `json:"timestamp"`
+	EventSubscriptionArn string    `json:"eventSubscriptionArn"`
+	MessageID            string    `json:"messageId"`
+	Subject              string    `json:"subject"`
 }
 
 func snsHandler(ctx context.Context, event events.SNSEvent) error {
@@ -366,10 +369,10 @@ func snsHandler(ctx context.Context, event events.SNSEvent) error {
 		for _, record := range event.Records {
 			cap := config.NewCapsule()
 			cap.SetMetadata(snsMetadata{
+				record.SNS.Timestamp,
 				record.EventSubscriptionArn,
 				record.SNS.MessageID,
 				record.SNS.Subject,
-				record.SNS.Timestamp,
 			})
 
 			cap.SetData([]byte(record.SNS.Message))
@@ -390,9 +393,9 @@ func snsHandler(ctx context.Context, event events.SNSEvent) error {
 }
 
 type sqsMetadata struct {
-	EventSourceArn string            `json:"event_source_arn"`
-	MessageID      string            `json:"message_id"`
-	BodyMd5        string            `json:"body_md5"`
+	EventSourceArn string            `json:"eventSourceArn"`
+	MessageID      string            `json:"messageId"`
+	BodyMd5        string            `json:"bodyMd5"`
 	Attributes     map[string]string `json:"attributes"`
 }
 

--- a/examples/aws/README.md
+++ b/examples/aws/README.md
@@ -15,6 +15,7 @@ graph TD
     s3_source_bucket(S3 Data Storage)
     s3_lake_bucket(Data Lake S3 Storage)
     s3_warehouse_bucket(Data Warehouse S3 Storage)
+    sns_topic(SNS Topic)
     sqs_queue(SQS Queue)
 
     %% Lambda data processing
@@ -25,12 +26,14 @@ graph TD
     s3_warehouse_sink_lambda[S3 Sink Lambda]
     s3_source_lambda[S3 Source Lambda]
     s3_lake_sink_lambda[S3 Sink Lambda]
+    sns_source_lambda[SNS Source Lambda]
     sqs_source_lambda[SQS Source Lambda]
 
     %% ingest
     gateway ---|Push| gateway_lambda ---|Push| kinesis_raw
     gateway_kinesis ---|Push| kinesis_raw
     s3_source_bucket ---|Pull| s3_source_lambda ---|Push| kinesis_raw
+    sns_topic ---|Push| sns_source_lambda ---|Push| kinesis_raw
     sqs_queue ---|Pull| sqs_source_lambda ---|Push| kinesis_raw
     kinesis_raw ---|Pull| s3_lake_sink_lambda ---|Push| s3_lake_bucket
 

--- a/examples/aws/config/substation_example_sns_source/config.jsonnet
+++ b/examples/aws/config/substation_example_sns_source/config.jsonnet
@@ -1,0 +1,8 @@
+local sinklib = import '../../../../build/config/sink.libsonnet';
+
+{
+  sink: sinklib.kinesis(stream='substation_example_raw'),
+  transform: {
+    type: 'transfer',
+  },
+}

--- a/examples/aws/terraform/example_appconfig.tf
+++ b/examples/aws/terraform/example_appconfig.tf
@@ -20,6 +20,7 @@ module "iam_example_appconfig_read_attachment" {
     module.lambda_example_processed_s3_sink.role,
     module.lambda_example_gateway_source.role,
     module.lambda_example_s3_source.role,
+    module.lambda_example_sns_source.role,
     module.lambda_example_sqs_source.role,
   ]
 }

--- a/examples/aws/terraform/example_kinesis.tf
+++ b/examples/aws/terraform/example_kinesis.tf
@@ -53,6 +53,8 @@ module "iam_example_kinesis_raw_write_attachment" {
   roles = [
     module.lambda_example_gateway_source.role,
     module.lambda_example_s3_source.role,
+    module.lambda_example_sns_source.role,
+    module.lambda_example_sqs_source.role,
     module.gateway_example_kinesis_source.role,
   ]
 }

--- a/examples/aws/terraform/example_kms.tf
+++ b/examples/aws/terraform/example_kms.tf
@@ -23,6 +23,7 @@ module "iam_example_kms_read_attachment" {
     module.lambda_example_raw_s3_sink.role,
     module.lambda_example_gateway_source.role,
     module.lambda_example_s3_source.role,
+    module.lambda_example_sns_source.role,
     module.lambda_example_sqs_source.role,
     module.gateway_example_kinesis_source.role,
   ]
@@ -53,6 +54,7 @@ module "iam_example_kms_write_attachment" {
     module.lambda_example_raw_s3_sink.role,
     module.lambda_example_gateway_source.role,
     module.lambda_example_s3_source.role,
+    module.lambda_example_sns_source.role,
     module.lambda_example_sqs_source.role,
     module.gateway_example_kinesis_source.role,
   ]

--- a/examples/aws/terraform/example_lambda_source_sns.tf
+++ b/examples/aws/terraform/example_lambda_source_sns.tf
@@ -1,0 +1,67 @@
+################################################
+# SNS topic
+# sends data to Lambda
+################################################
+
+module "sns_example_source" {
+  source     = "/workspaces/substation/build/terraform/aws/sns"
+  kms_key_id = module.kms_substation.key_id
+  name       = "substation_sns_example"
+}
+
+################################################
+# Lambda
+# reads from SNS topic, writes to raw Kinesis stream
+################################################
+
+module "lambda_example_sns_source" {
+  source        = "/workspaces/substation/build/terraform/aws/lambda"
+  function_name = "substation_example_sns_source"
+  description   = "Substation Lambda that is triggered from SNS and writes data to the raw Kinesis stream"
+  appconfig_id  = aws_appconfig_application.substation.id
+  kms_arn       = module.kms_substation.arn
+  image_uri     = "${module.ecr_substation.repository_url}:latest"
+  architectures = ["arm64"]
+  timeout       = 300
+
+  env = {
+    "AWS_MAX_ATTEMPTS" : 10
+    "AWS_APPCONFIG_EXTENSION_PREFETCH_LIST" : "/applications/substation/environments/prod/configurations/substation_example_sns_source"
+    "SUBSTATION_HANDLER" : "SNS"
+    "SUBSTATION_DEBUG" : 1
+  }
+  tags = {
+    owner = "example"
+  }
+
+  depends_on = [
+    aws_appconfig_application.substation,
+    module.ecr_substation.repository_url,
+  ]
+}
+
+resource "aws_sns_topic_subscription" "lambda_subscription_example_sns_source" {
+  topic_arn = module.sns_example_source.arn
+  protocol  = "lambda"
+  endpoint  = module.lambda_example_sns_source.arn
+
+  depends_on = [
+    module.lambda_example_sns_source.name
+  ]
+}
+
+################################################
+## permissions
+################################################
+
+resource "aws_lambda_permission" "lambda_example_sns_source_invoke" {
+  statement_id  = "AllowExecutionFromSNS"
+  action        = "lambda:InvokeFunction"
+  function_name = module.lambda_example_sns_source.name
+  principal     = "sns.amazonaws.com"
+  source_arn    = module.sns_example_source.arn
+
+  depends_on = [
+    module.lambda_example_sns_source.name
+  ]
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- Adds forward compatibility for Lambda triggers that rely on SNS topics
- Changes the ingest metadata structures to use camelCase JSON keys

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We made an early decision to exclusively tie SNS ingest to S3 objects, but SNS is the delivery service for other Lambda triggers as well (e.g., RDS). This PR corrects that mistake by separating SNS ingest into its own function and adds forward compatible support for other services that "ride on" SNS (like S3). We can use the naming convention `[service]-SNS` to trigger the function moving forward. There may be opportunities to do the same thing with SQS in the future and to add an SNS sink, but those are better handled in a separate PR.

I've added a new SNS Terraform module to support the SNS ingest function and added SNS ingest in the example AWS pipeline.

## How Has This Been Tested?

Tested in our development AWS account.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [x] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
