### PR TITLE
fix: Kinesis ActiveShards Bug

### DIFF
--- a/internal/aws/kinesis/kinesis.go
+++ b/internal/aws/kinesis/kinesis.go
@@ -245,8 +245,7 @@ LOOP:
 
 		if output.NextToken != nil {
 			params = &kinesis.ListShardsInput{
-				StreamName: aws.String(stream),
-				NextToken:  output.NextToken,
+				NextToken: output.NextToken,
 			}
 		} else {
 			break LOOP


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Discovered a bug in the ActiveShards method when handling very large streams -- the Kinesis API does not accept both StreamName and NextToken, it's one or the other and using both causes errors.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This was an unknown bug and wasn't discovered until we started seeing anomalous errors with scaling very large streams.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Patched in our production AWS accounts, errors seem to be resolved but this is a bit difficult to test because the error only appears at huge scale. If related issues appear then we'll do another fix.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [ ] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
