### PR TITLE
feat: Improvements to Reading and Decoding Files

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -151,7 +151,7 @@ func (sub *Substation) Sink(ctx context.Context, wg *sync.WaitGroup) {
 	sub.DoneSignal()
 }
 
-// GetConcurrency retrieves a concurrency value from the SUBSTATION_CONCURRENCY environment variable. If the environment variable is missing, then the concurrency value is the number of CPUs on the operating system. In native Substation applications, this value determines the number of transform goroutines; if set to 1, then multi-core processing is not enabled.
+// GetConcurrency retrieves a concurrency value from the SUBSTATION_CONCURRENCY environment variable. If the environment variable is missing, then the concurrency value is the number of CPUs on the host. In native Substation applications, this value determines the number of transform goroutines; if set to 1, then multi-core processing is not enabled.
 func GetConcurrency() (int, error) {
 	if val, found := os.LookupEnv("SUBSTATION_CONCURRENCY"); found {
 		v, err := strconv.Atoi(val)
@@ -162,4 +162,23 @@ func GetConcurrency() (int, error) {
 	}
 
 	return runtime.NumCPU(), nil
+}
+
+/*
+GetScanMethod retrieves a scan method from the SUBSTATION_SCAN_METHOD environment variable. This impacts the behavior of bufio scanners that are used throughout the application to read files. The options for this variable are:
+
+- "bytes" (https://pkg.go.dev/bufio#Scanner.Bytes)
+
+- "text" (https://pkg.go.dev/bufio#Scanner.Text)
+
+If the environment variable is missing, then the default method is "text".
+*/
+func GetScanMethod() string {
+	if val, found := os.LookupEnv("SUBSTATION_SCAN_METHOD"); found {
+		if val == "bytes" || val == "text" {
+			return val
+		}
+	}
+
+	return "text"
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- Fixes an edge case where [http.DetectContentType](https://pkg.go.dev/net/http#DetectContentType) incorrectly identifies Gzip files as not Gzip
- Adds a new environment variable for users to manage how files are read by [scanners](https://pkg.go.dev/bufio#Scanner)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We discovered an edge case where the HTTP DetectContentType method incorrectly identifies Gzip files created by AWS CloudTrail as _not being_ Gzip files. An example is a small file (~1kb) that was identified as `application/vnd.ms-fontobject`. To fix this, I updated the decode method to support file extension matching and the current MIME type matching. This fix is a backwards compatible, non-breaking change.

Since we're fixing file decoding, I figured that this is a good time to add better options for managing file reading too. The other change in this PR is allowing users to define how the application treats files as they are being read (either as "bytes" or "text"). The current behavior is to read as text, and that's what most users will want to do since they are likely handling event logs, but adding an option to read as bytes lets users ingest binary data directly if they want. This one is also a backwards compatible, non-breaking change.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with the file app on local files and a non-public, custom app that reads files directly from S3. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [x] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
