### PR TITLE
refactor: Add Micro Delay to the Batch Transformer

### DIFF
--- a/internal/transform/transfer.go
+++ b/internal/transform/transfer.go
@@ -21,7 +21,8 @@ type Transfer struct{}
 func (transform *Transfer) Transform(ctx context.Context, in <-chan config.Capsule, out chan<- config.Capsule, kill chan struct{}) error {
 	var count int
 
-	// read and write encapsulated data from and to channels
+	// read and write encapsulated data from input and to output channels
+	// if a signal is received on the kill channel, then this is interrupted
 	for cap := range in {
 		select {
 		case <-kill:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- Adds microsecond delay to the batch transform input to enforce load balancing

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I noticed that some of our pipelines were showing symptoms that incoming data was not being balanced across batch transform goroutines (for example, if 1000 events come in, then 500 may go to the first transform, 400 to the second, and 100 to the third). Most users of the system would probably never notice this, but our use of DynamoDB and Lambda for data enrichment made it more apparent as I looked closer at the problem.

Since this transform is designed to read all data from the input channel into a batch (slice of capsules) before applying processing, the fix is to introduce a microsecond delay for each incoming capsule -- from what I saw during testing, this is the smallest amount of time the application must wait to enforce equal balancing across goroutines. In total this creates 1 second of delay for every 100,000 capsules put into the input channel, but in practice it's unlikely that any deployment would ever come close to 1 second of delay due to Lambda's [batching behavior](https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventsourcemapping.html#invocation-eventsourcemapping-batching).

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on two large deployments, the runtime duration of the Lambda showed better load balancing between goroutines.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [ ] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
