### PR TITLE
feat: Customizable Kinesis Data Stream Autoscaling

### DIFF
--- a/build/terraform/aws/kinesis/main.tf
+++ b/build/terraform/aws/kinesis/main.tf
@@ -16,8 +16,8 @@ resource "aws_cloudwatch_metric_alarm" "metric_alarm_downscale" {
   alarm_description   = var.stream_name
   actions_enabled     = true
   alarm_actions       = [var.autoscaling_topic]
-  evaluation_periods  = 60
-  datapoints_to_alarm = 57
+  evaluation_periods  = 120
+  datapoints_to_alarm = 114
   threshold           = 0.25
   comparison_operator = "LessThanOrEqualToThreshold"
   treat_missing_data  = "ignore"

--- a/build/terraform/aws/kinesis/main.tf
+++ b/build/terraform/aws/kinesis/main.tf
@@ -17,12 +17,12 @@ resource "aws_cloudwatch_metric_alarm" "metric_alarm_downscale" {
   actions_enabled     = true
   alarm_actions       = [var.autoscaling_topic]
   evaluation_periods  = 60
-  datapoints_to_alarm = 60
-  threshold           = 0.15
+  datapoints_to_alarm = 57
+  threshold           = 0.25
   comparison_operator = "LessThanOrEqualToThreshold"
   treat_missing_data  = "ignore"
   lifecycle {
-    ignore_changes = [metric_query]
+    ignore_changes = [metric_query, datapoints_to_alarm]
   }
 
   metric_query {
@@ -100,13 +100,13 @@ resource "aws_cloudwatch_metric_alarm" "metric_alarm_upscale" {
   alarm_description   = var.stream_name
   actions_enabled     = true
   alarm_actions       = [var.autoscaling_topic]
-  evaluation_periods  = 1
-  datapoints_to_alarm = 1
-  threshold           = 0.5
+  evaluation_periods  = 10
+  datapoints_to_alarm = 5
+  threshold           = 0.75
   comparison_operator = "GreaterThanOrEqualToThreshold"
   treat_missing_data  = "ignore"
   lifecycle {
-    ignore_changes = [metric_query]
+    ignore_changes = [metric_query, datapoints_to_alarm]
   }
 
   metric_query {

--- a/cmd/aws/lambda/README.md
+++ b/cmd/aws/lambda/README.md
@@ -2,13 +2,26 @@
 Contains Substation apps deployed as AWS Lambda functions. All Lambda functions get their configurations from [AWS AppConfig](https://docs.aws.amazon.com/appconfig/latest/userguide/what-is-appconfig.html).
 
 ## autoscaling
-This app handles Kinesis Data Stream autoscaling through SNS notifications and CloudWatch alarms. By default, Kinesis Data Streams will scale up by 50% if a stream exceeds 50% capacity within 1 minute and scale down by 50% if a stream stays below 15% capacity for 1 hour. Capacity is calculated as the maximum of volume (i.e., 60,000 events per minute) or size (i.e., 10GB data per minute).
+This app handles Kinesis Data Stream autoscaling through SNS notifications and CloudWatch alarms. The scaling behavior is to scale up / out if stream utilization is greater than 75% of the Kinesis service limits within a 10 minute period and scale down / in if stream utilization are less than 25% of the Kinesis service limits within a 60 minute period. In both cases, streams scale by 50%.
 
-For example, if a stream is configured with 10 shards and it exceeds 50% capacity, then the stream is scaled up to 15 shards; if the stream stays below 15% capacity for 1 hour, then the stream is scaled down to 5 shards. Shards will not scale evenly, but the autoscaling functionality follows [AWS best practices for resharding streams](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_UpdateShardCount.html).
+Stream utilization is based on volume (i.e., 60,000 events per minute) and size (i.e., 10GB data per minute); these values are converted to a percentage (0.0 to 1.0) and the maximum of either is considered the stream's current utilization.
+
+By default, streams must be above the upper threshold for at least 5 minutes to scale up and below the lower threshold for at least 57 minutes to scale down. These values can be overriden by the environment variables SUBSTATION_AUTOSCALING_UPSCALE_DATAPOINTS (cannot exceed 10 minutes) and SUBSTATION_AUTOSCALING_DOWNSCALE_DATAPOINTS (cannot exceed 60 minutes).
+
+For example:
+
+* If a stream is configured with 10 shards and it triggers the upscale alarm, then the stream is scaled up to 15 shards
+* If a stream is configured with 10 shards and it triggers the downscale alarm, then the stream is scaled down to 5 shards
+
+Shards will not scale evenly, but the autoscaling functionality follows [AWS best practices for resharding streams](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_UpdateShardCount.html). 
+
+We recommend using one autoscaling Lambda for an entire Substation deployment, but many can be used if needed. For example, one may be assigned to data pipelines that have predictable traffic (e.g., steady stream utilization) and another may be assigned to data pipelines that have unpredictable traffic (e.g., sporadic stream utilization, bursty stream utilization).
 
 ## substation
-This app handles ITL for data from these AWS services:
-- API Gateway (REST)
-- Kinesis Data Streams
-- S3 Buckets
-- S3 Buckets via SNS Topics
+This app handles ingest, transform, and load (ITL) for data from these AWS services:
+- [API Gateway](https://docs.aws.amazon.com/lambda/latest/dg/services-apigateway.html)
+- [Kinesis Data Streams](https://docs.aws.amazon.com/lambda/latest/dg/with-kinesis.html)
+- [S3](https://docs.aws.amazon.com/lambda/latest/dg/with-s3.html)
+- [S3 via SNS](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ways-to-add-notification-config-to-bucket.html)
+- [SNS](https://docs.aws.amazon.com/lambda/latest/dg/with-sns.html)
+- [SQS](https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html)

--- a/internal/aws/cloudwatch/cloudwatch.go
+++ b/internal/aws/cloudwatch/cloudwatch.go
@@ -14,16 +14,16 @@ import (
 
 const (
 	kinesisMetricsPeriod = 60
-	// AWS Kinesis streams will scale down / in if they are less than 25% of the Kinesis service limits within a 60 minute period.
-	kinesisDownscaleEvaluationPeriod, kinesisDownscaleThreshold = 1 * 60, 0.25
+	// AWS Kinesis streams will scale down / in if they are less than 25% of the Kinesis service limits within a 2 hour period.
+	kinesisDownscaleEvaluationPeriod, kinesisDownscaleThreshold = 2 * 60, 0.25
 	// AWS Kinesis streams will scale up / out if they are greater than 75% of the Kinesis service limits within a 10 minute period.
 	kinesisUpscaleEvaluationPeriod, kinesisUpscaleThreshold = 1 * 10, 0.75
 )
 
 var (
-	// By default, AWS Kinesis streams must be below the lower threshold for at least 57 minutes to scale down. This value can be overriden by the environment variable SUBSTATION_AUTOSCALING_DOWNSCALE_DATAPOINTS, but it cannot exceed 60 minutes.
-	kinesisDownscaleDatapoints = 57
-	// By default, AWS Kinesis streams must be above the upper threshold for at least 5 minutes to scale up. This value can be overriden by the environment variable SUBSTATION_AUTOSCALING_UPSCALE_DATAPOINTS, but it cannot exceed 10 minutes.
+	// By default, AWS Kinesis streams must be below the lower threshold for at least 95% of the evaluation period (114 minutes) to scale down. This value can be overriden by the environment variable SUBSTATION_AUTOSCALING_DOWNSCALE_DATAPOINTS, but it cannot exceed 120 minutes.
+	kinesisDownscaleDatapoints = 114
+	// By default, AWS Kinesis streams must be above the upper threshold for at least 50% of the evaluation period (5 minutes) to scale up. This value can be overriden by the environment variable SUBSTATION_AUTOSCALING_UPSCALE_DATAPOINTS, but it cannot exceed 10 minutes.
 	kinesisUpscaleDatapoints = 5
 )
 

--- a/internal/aws/cloudwatch/cloudwatch.go
+++ b/internal/aws/cloudwatch/cloudwatch.go
@@ -14,13 +14,42 @@ import (
 
 const (
 	kinesisMetricsPeriod = 60
-	// scale Kinesis stream down if it is below threshold for 1 hour
-	kinesisDownscaleEvaluationPeriod = 1 * 60
-	kinesisDownscaleThreshold        = 0.25
-	// scale Kinesis stream up if it is above threshold for 5 minutes
-	kinesisUpscaleEvaluationPeriod = 1 * 5
-	kinesisUpscaleThreshold        = 0.75
+	// AWS Kinesis streams will scale down / in if they are less than 25% of the Kinesis service limits within a 60 minute period.
+	kinesisDownscaleEvaluationPeriod, kinesisDownscaleThreshold = 1 * 60, 0.25
+	// AWS Kinesis streams will scale up / out if they are greater than 75% of the Kinesis service limits within a 10 minute period.
+	kinesisUpscaleEvaluationPeriod, kinesisUpscaleThreshold = 1 * 10, 0.75
 )
+
+var (
+	// By default, AWS Kinesis streams must be below the lower threshold for at least 57 minutes to scale down. This value can be overriden by the environment variable SUBSTATION_AUTOSCALING_DOWNSCALE_DATAPOINTS, but it cannot exceed 60 minutes.
+	kinesisDownscaleDatapoints = 57
+	// By default, AWS Kinesis streams must be above the upper threshold for at least 5 minutes to scale up. This value can be overriden by the environment variable SUBSTATION_AUTOSCALING_UPSCALE_DATAPOINTS, but it cannot exceed 10 minutes.
+	kinesisUpscaleDatapoints = 5
+)
+
+func init() {
+	if v, found := os.LookupEnv("SUBSTATION_AUTOSCALING_DOWNSCALE_DATAPOINTS"); found {
+		downscale, err := strconv.Atoi(v)
+		if err != nil {
+			panic(err)
+		}
+
+		if downscale <= kinesisDownscaleEvaluationPeriod {
+			kinesisDownscaleDatapoints = downscale
+		}
+	}
+
+	if v, found := os.LookupEnv("SUBSTATION_AUTOSCALING_UPSCALE_DATAPOINTS"); found {
+		upscale, err := strconv.Atoi(v)
+		if err != nil {
+			panic(err)
+		}
+
+		if upscale <= kinesisUpscaleEvaluationPeriod {
+			kinesisUpscaleDatapoints = upscale
+		}
+	}
+}
 
 // New returns a configured CloudWatch client.
 func New() *cloudwatch.CloudWatch {
@@ -75,7 +104,7 @@ func (a *API) UpdateKinesisDownscaleAlarm(ctx aws.Context, name, stream, topic s
 			ActionsEnabled:     aws.Bool(true),
 			AlarmActions:       []*string{aws.String(topic)},
 			EvaluationPeriods:  aws.Int64(kinesisDownscaleEvaluationPeriod),
-			DatapointsToAlarm:  aws.Int64(kinesisDownscaleEvaluationPeriod * 0.95),
+			DatapointsToAlarm:  aws.Int64(int64(kinesisDownscaleDatapoints)),
 			Threshold:          aws.Float64(kinesisDownscaleThreshold),
 			ComparisonOperator: aws.String("LessThanOrEqualToThreshold"),
 			TreatMissingData:   aws.String("ignore"),
@@ -179,7 +208,7 @@ func (a *API) UpdateKinesisUpscaleAlarm(ctx aws.Context, name, stream, topic str
 			ActionsEnabled:     aws.Bool(true),
 			AlarmActions:       []*string{aws.String(topic)},
 			EvaluationPeriods:  aws.Int64(kinesisUpscaleEvaluationPeriod),
-			DatapointsToAlarm:  aws.Int64(kinesisUpscaleEvaluationPeriod),
+			DatapointsToAlarm:  aws.Int64(int64(kinesisUpscaleDatapoints)),
 			Threshold:          aws.Float64(kinesisUpscaleThreshold),
 			ComparisonOperator: aws.String("GreaterThanOrEqualToThreshold"),
 			TreatMissingData:   aws.String("ignore"),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- Adds environment variables for customizable Kinesis Data Stream (KDS) autoscaling behavior
- Fixes default Terraform settings for KDS datapoint alarms

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We manage some KDS that require more aggressive autoscaling settings than others. The two stream behaviors we've observed are:
- steady stream utilization, where streams increase and decrease at a steady rate hour to hour or day to day
- bursty stream utilization, where streams increase and decrease suddenly minute to minute

The latter behavior requires customizable CloudWatch alarms, so to provide that this PR gives users the ability to override the number of datapoints that will trigger a scaling event. 

There are several parameters that could be tuned, but focusing on datapoints keeps the configuration simple and still addresses the majority of scaling use cases (i.e., independently scale up or down quickly or slowly). To support a wider variety of scaling use cases, the CloudWatch evaluation periods for scaling up and down were doubled (from 5 to 10 minutes for upscale and from 60 to 120 minutes for downscale). 

This also introduces the ability for users to deploy multiple autoscaling Lambda that address different scaling patterns. For example, 80% of data pipelines may use a "steady rate" autoscaling pattern and 20% of data pipelines may use a "burst rate" autoscaling pattern. This can all be managed via Terraform.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Testing pending -- will move out of draft when complete.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [x] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
