### PR TITLE
fix(linter): fix golangci-lint warnings across substation

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -21,11 +21,10 @@ jobs:
     - name: tests
       run: go test -timeout 30s -v ./... 
 
-    - name: lint
-      uses: dominikh/staticcheck-action@v1.2.0
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
-        install-go: false
-        checks: "all,-ST1000"
+        version: v1.49
 
   python:
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,139 @@
+# This code is licensed under the terms of the MIT license.
+
+## Config for golangci-lint v1.49.0 based on https://gist.github.com/maratori/47a4d00457a92aa426dbd48a18776322
+
+run:
+  # Timeout for analysis, e.g. 30s, 5m.
+  # Default: 1m
+  timeout: 3m
+
+
+# This file contains only configs which differ from defaults.
+# All possible options can be found here https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
+linters-settings:
+  cyclop:
+    # The maximal code complexity to report.
+    # Default: 10
+    max-complexity: 30
+
+  errcheck:
+    # Report about not checking of errors in type assertions: `a := b.(MyStruct)`.
+    # Such cases aren't reported by default.
+    # Default: false
+    check-type-assertions: true
+
+  gocognit:
+    # Minimal code complexity to report
+    # Default: 30
+    min-complexity: 45
+
+  # gomodguard:
+  #   blocked:
+  #     # List of blocked modules.
+  #     # Default: []
+  #     modules:
+  #       - github.com/golang/protobuf:
+  #           recommendations:
+  #             - google.golang.org/protobuf
+  #           reason: "see https://developers.google.com/protocol-buffers/docs/reference/go/faq#modules"
+
+  nakedret:
+    # Make an issue if func has more lines of code than this setting, and it has naked returns.
+    # Default: 30
+    max-func-lines: 0
+
+  nolintlint:
+    # Exclude following linters from requiring an explanation.
+    # Default: []
+    allow-no-explanation: [ gocognit ]
+    # Enable to require an explanation of nonzero length after each nolint directive.
+    # Default: false
+    require-explanation: true
+    # Enable to require nolint directives to mention the specific linter being suppressed.
+    # Default: false
+    require-specific: true
+
+  rowserrcheck:
+    # database/sql is always checked
+    # Default: []
+    packages:
+      - github.com/jmoiron/sqlx
+
+  tenv:
+    # The option `all` will run against whole test files (`_test.go`) regardless of method/function signatures.
+    # Otherwise, only methods that take `*testing.T`, `*testing.B`, and `testing.TB` as arguments are checked.
+    # Default: false
+    all: true
+
+
+linters:
+  disable-all: true
+  enable:
+    ## enabled by default
+    - errcheck # checking for unchecked errors, these unchecked errors can be critical bugs in some cases
+    - gosimple # specializes in simplifying a code
+    - govet # reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
+    - ineffassign # detects when assignments to existing variables are not used
+    - staticcheck # is a go vet on steroids, applying a ton of static analysis checks
+    - typecheck # like the front-end of a Go compiler, parses and type-checks Go code
+    - unused # checks for unused constants, variables, functions and types
+
+    ## disabled by default
+    - bidichk # checks for dangerous unicode character sequences
+    - bodyclose # checks whether HTTP response body is closed successfully
+    - cyclop # checks function and package cyclomatic complexity
+    - durationcheck # checks for two durations multiplied together
+    - errname # checks that sentinel errors are prefixed with the Err and error types are suffixed with the Error
+    - execinquery # checks query string in Query function which reads your Go src files and warning it finds
+    - exhaustive # checks exhaustiveness of enum switch statements
+    - gocognit # computes and checks the cognitive complexity of functions
+    - gocyclo # computes and checks the cyclomatic complexity of functions
+    - gomoddirectives # manages the use of 'replace', 'retract', and 'excludes' directives in go.mod
+    - gomodguard # allow and block lists linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations
+    - goprintffuncname # checks that printf-like functions are named with f at the end
+    - nakedret # finds naked returns in functions greater than a specified function length
+    - nestif # reports deeply nested if statements
+    - nilerr # finds the code that returns nil even if it checks that the error is not nil
+    - noctx # finds sending http request without context.Context
+    - nolintlint # reports ill-formed or insufficient nolint directives
+    - nosprintfhostport # checks for misuse of Sprintf to construct a host with port in a URL
+    - predeclared # finds code that shadows one of Go's predeclared identifiers
+    - reassign # checks that package variables are not reassigned
+    - rowserrcheck # checks whether Err of rows is checked successfully
+    - sqlclosecheck # checks that sql.Rows and sql.Stmt are closed
+    - tenv # detects using os.Setenv instead of t.Setenv since Go1.17
+    - tparallel # detects inappropriate usage of t.Parallel() method in your Go test codes
+    - unconvert # removes unnecessary type conversions
+    - unparam # reports unused function parameters
+    - usestdlibvars # detects the possibility to use variables/constants from the Go standard library
+    - wastedassign # finds wasted assignment statements
+    - whitespace # detects leading and trailing whitespace
+    - misspell # finds commonly misspelled English words in comments
+
+issues:
+  # Maximum count of issues with the same text.
+  # Set to 0 to disable.
+  # Default: 3
+  max-same-issues: 50
+  
+  exclude:
+    - 'declaration of "(err|ctx)" shadows declaration at'
+
+  exclude-rules:
+    - source: "^//\\s*go:generate\\s"
+      linters: [ lll ]
+    - source: "(noinspection|TODO)"
+      linters: [ godot ]
+    - source: "//noinspection"
+      linters: [ gocritic ]
+    - source: "^\\s+if _, ok := err\\.\\([^.]+\\.InternalError\\); ok {"
+      linters: [ errorlint ]
+    - path: "_test\\.go"
+      linters:
+        - bodyclose
+        - dupl
+        - funlen
+        - goconst
+        - gosec
+        - noctx
+        - wrapcheck

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,12 @@
 {
   "terminal.integrated.defaultProfile.linux": "bash",
-  "go.formatTool": "gofmt",
+  "go.useLanguageServer": true,
+  "gopls": {
+    "formatting.gofumpt": true,
+  },
+  "go.formatTool": "gofumpt",
   "go.inferGopath": false,
-  "go.lintFlags": ["-checks=all,-ST1000"],
   "go.lintOnSave": "workspace",
+  "go.lintTool": "golangci-lint",
+  "cSpell.enabled": false
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,12 @@ We rely on contributors to test changes before they are submitted as pull reques
 
 ### Design Patterns
 
+#### Environment Variables
+
+Substation uses environment variables to customize runtime settings of the system (e.g., concurrency is controlled by `SUBSTATION_CONCURRENCY`). 
+
+Custom applications should implement their own runtime settings as required; for example, the [AWS Lambda application](/cmd/aws/lambda/substation/) uses `SUBSTATION_HANDLER` to manage [invocation settings](https://docs.aws.amazon.com/lambda/latest/dg/lambda-invocation.html).
+
 ##### Configurations
 
 Substation uses a single configuration pattern for all components in the system (see `Config` in [config/config.go](/config/config.go)). This pattern is highly reusable and should be nested to create complex configurations supported by Jsonnet. Below is an example that shows how configurations should be designed:
@@ -85,12 +91,6 @@ Substation relies on [factory methods](https://refactoring.guru/design-patterns/
 Factories are the preferred method for allowing users to customize the system. Example factories can be seen in [condition](/condition/condition.go) and [process](/process/process.go).
 
 ### Naming Conventions
-
-#### Environment Variables
-
-Substation uses environment variables to customize runtime settings of the system (e.g., concurrency is controlled by `SUBSTATION_CONCURRENCY`). 
-
-Custom applications should implement their own runtime settings as required; for example, the [AWS Lambda application](/cmd/aws/lambda/substation/) uses `SUBSTATION_HANDLER` to manage [invocation settings](https://docs.aws.amazon.com/lambda/latest/dg/lambda-invocation.html).
 
 #### Errors
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,10 @@ Environment variable keys and values specific to the Substation application shou
 
 Any environment variable that changes a default runtime setting should always start with SUBSTATION (for example, SUBSTATION_CONCURRENCY).
 
+#### Application Variables
+
+Variable names should always follow conventions from [Effective Go](https://go.dev/doc/effective_go#names), the [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments#variable-names) and avoid [predeclared identifiers](https://go.dev/ref/spec#Predeclared_identifiers). For example `capsule` is used instead of `cap` to avoid shadowing the capacity function, modifiers and plural usage are `newCapsule`, and `capsules`.
+
 #### Source Metadata
 
 Sources that [add metadata during encapsulation](/config/README.md) should use lowerCamelCase for their JSON keys.

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -75,8 +75,8 @@ func (sub *Substation) Concurrency() int {
 }
 
 // Send writes encapsulated data into the Transform channel.
-func (sub *Substation) Send(cap config.Capsule) {
-	sub.Channels.Transform.Send(cap)
+func (sub *Substation) Send(capsule config.Capsule) {
+	sub.Channels.Transform.Send(capsule)
 }
 
 /*

--- a/cmd/aws/lambda/autoscaling/main.go
+++ b/cmd/aws/lambda/autoscaling/main.go
@@ -19,8 +19,10 @@ const (
 	autoscalePercentage = 50.0
 )
 
-var cloudwatchAPI cloudwatch.API
-var kinesisAPI kinesis.API
+var (
+	cloudwatchAPI cloudwatch.API
+	kinesisAPI    kinesis.API
+)
 
 func init() {
 	cloudwatchAPI.Setup()
@@ -55,7 +57,8 @@ func handler(ctx context.Context, snsEvent events.SNSEvent) error {
 	if err != nil {
 		return fmt.Errorf("handler: %v", err)
 	}
-	log.WithField("alarm", alarmName).WithField("stream", stream).WithField("count", shards).Info("retrieved active shard count")
+	log.WithField("alarm", alarmName).WithField("stream", stream).WithField("count", shards).
+		Info("retrieved active shard count")
 
 	var newShards int64
 	if strings.Contains(alarmName, "upscale") {
@@ -126,10 +129,10 @@ func handler(ctx context.Context, snsEvent events.SNSEvent) error {
 	return nil
 }
 
-func downscale(shards float64, pct float64) int64 {
+func downscale(shards, pct float64) int64 {
 	return int64(math.Ceil(shards - (shards * (pct / 100))))
 }
 
-func upscale(shards float64, pct float64) int64 {
+func upscale(shards, pct float64) int64 {
 	return int64(math.Ceil(shards + (shards * (pct / 100))))
 }

--- a/condition/condition.go
+++ b/condition/condition.go
@@ -11,7 +11,7 @@ import (
 // errInvalidFactoryInput is returned when an unsupported Inspector is referenced in InspectorFactory.
 const errInvalidFactoryInput = errors.Error("invalid factory input")
 
-// errOperatorMissingInspectors is returned when an Operator that requres Inspectors is created with no inspectors.
+// errOperatorMissingInspectors is returned when an Operator that requires Inspectors is created with no inspectors.
 const errOperatorMissingInspectors = errors.Error("missing inspectors")
 
 // Inspector is the interface shared by all inspector methods.
@@ -21,10 +21,10 @@ type Inspector interface {
 
 // InspectByte is a convenience function for applying an Inspector to bytes.
 func InspectByte(ctx context.Context, data []byte, inspect Inspector) (bool, error) {
-	cap := config.NewCapsule()
-	cap.SetData(data)
+	capsule := config.NewCapsule()
+	capsule.SetData(data)
 
-	return inspect.Inspect(ctx, cap)
+	return inspect.Inspect(ctx, capsule)
 }
 
 // MakeInspectors accepts multiple inspector configs and returns populated Inspectors. This is a convenience function for generating many Inspectors.
@@ -46,35 +46,35 @@ func InspectorFactory(cfg config.Config) (Inspector, error) {
 	switch cfg.Type {
 	case "content":
 		var i Content
-		config.Decode(cfg.Settings, &i)
+		_ = config.Decode(cfg.Settings, &i)
 		return i, nil
 	case "ip":
 		var i IP
-		config.Decode(cfg.Settings, &i)
+		_ = config.Decode(cfg.Settings, &i)
 		return i, nil
 	case "json_schema":
 		var i JSONSchema
-		config.Decode(cfg.Settings, &i)
+		_ = config.Decode(cfg.Settings, &i)
 		return i, nil
 	case "json_valid":
 		var i JSONValid
-		config.Decode(cfg.Settings, &i)
+		_ = config.Decode(cfg.Settings, &i)
 		return i, nil
 	case "length":
 		var i Length
-		config.Decode(cfg.Settings, &i)
+		_ = config.Decode(cfg.Settings, &i)
 		return i, nil
 	case "random":
 		var i Random
-		config.Decode(cfg.Settings, &i)
+		_ = config.Decode(cfg.Settings, &i)
 		return i, nil
 	case "regexp":
 		var i RegExp
-		config.Decode(cfg.Settings, &i)
+		_ = config.Decode(cfg.Settings, &i)
 		return i, nil
 	case "strings":
 		var i Strings
-		config.Decode(cfg.Settings, &i)
+		_ = config.Decode(cfg.Settings, &i)
 		return i, nil
 	default:
 		return nil, fmt.Errorf("condition inspectorfactory: settings %+v: %v", cfg.Settings, errInvalidFactoryInput)
@@ -92,14 +92,13 @@ type AND struct {
 }
 
 // Operate returns true if all Inspectors return true, otherwise it returns false.
-func (o AND) Operate(ctx context.Context, cap config.Capsule) (bool, error) {
+func (o AND) Operate(ctx context.Context, capsule config.Capsule) (bool, error) {
 	if len(o.Inspectors) == 0 {
 		return false, fmt.Errorf("condition operate: inspectors %+v: %v", o, errOperatorMissingInspectors)
 	}
 
 	for _, i := range o.Inspectors {
-		ok, err := i.Inspect(ctx, cap)
-
+		ok, err := i.Inspect(ctx, capsule)
 		if err != nil {
 			return false, err
 		}
@@ -120,13 +119,13 @@ type OR struct {
 }
 
 // Operate returns true if any Inspectors return true, otherwise it returns false.
-func (o OR) Operate(ctx context.Context, cap config.Capsule) (bool, error) {
+func (o OR) Operate(ctx context.Context, capsule config.Capsule) (bool, error) {
 	if len(o.Inspectors) == 0 {
 		return false, fmt.Errorf("condition operate: inspectors %+v: %v", o, errOperatorMissingInspectors)
 	}
 
 	for _, i := range o.Inspectors {
-		ok, err := i.Inspect(ctx, cap)
+		ok, err := i.Inspect(ctx, capsule)
 		if err != nil {
 			return false, err
 		}
@@ -147,13 +146,13 @@ type NAND struct {
 }
 
 // Operate returns true if all Inspectors return false, otherwise it returns true.
-func (o NAND) Operate(ctx context.Context, cap config.Capsule) (bool, error) {
+func (o NAND) Operate(ctx context.Context, capsule config.Capsule) (bool, error) {
 	if len(o.Inspectors) == 0 {
 		return false, fmt.Errorf("condition operate: inspectors %+v: %v", o, errOperatorMissingInspectors)
 	}
 
 	for _, i := range o.Inspectors {
-		ok, err := i.Inspect(ctx, cap)
+		ok, err := i.Inspect(ctx, capsule)
 		if err != nil {
 			return false, err
 		}
@@ -174,13 +173,13 @@ type NOR struct {
 }
 
 // Operate returns true if any Inspectors return false, otherwise it returns true.
-func (o NOR) Operate(ctx context.Context, cap config.Capsule) (bool, error) {
+func (o NOR) Operate(ctx context.Context, capsule config.Capsule) (bool, error) {
 	if len(o.Inspectors) == 0 {
 		return false, fmt.Errorf("condition operate: inspectors %+v: %v", o, errOperatorMissingInspectors)
 	}
 
 	for _, i := range o.Inspectors {
-		ok, err := i.Inspect(ctx, cap)
+		ok, err := i.Inspect(ctx, capsule)
 		if err != nil {
 			return false, err
 		}
@@ -199,7 +198,7 @@ func (o NOR) Operate(ctx context.Context, cap config.Capsule) (bool, error) {
 type Default struct{}
 
 // Operate always returns true. This is the default operator returned by  OperatorFactory.
-func (o Default) Operate(ctx context.Context, cap config.Capsule) (bool, error) {
+func (o Default) Operate(ctx context.Context, capsule config.Capsule) (bool, error) {
 	return true, nil
 }
 

--- a/condition/condition_test.go
+++ b/condition/condition_test.go
@@ -51,7 +51,7 @@ var conditionANDTests = []struct {
 				},
 			},
 		},
-		[]byte{80, 75, 03, 04},
+		[]byte{80, 75, 3, 4},
 		false,
 	},
 	{
@@ -93,10 +93,10 @@ var conditionANDTests = []struct {
 
 func TestAND(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 
 	for _, test := range conditionANDTests {
-		cap.SetData(test.test)
+		capsule.SetData(test.test)
 
 		cfg := Config{
 			Operator:   "and",
@@ -105,39 +105,36 @@ func TestAND(t *testing.T) {
 
 		op, err := OperatorFactory(cfg)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
-		ok, err := op.Operate(ctx, cap)
+		ok, err := op.Operate(ctx, capsule)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		if ok != test.expected {
-			t.Logf("expected %v, got %v", test.expected, ok)
-			t.Fail()
+			t.Errorf("expected %v, got %v", test.expected, ok)
 		}
 	}
 }
 
-func benchmarkAND(b *testing.B, conf []config.Config, cap config.Capsule) {
+func benchmarkAND(b *testing.B, conf []config.Config, capsule config.Capsule) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
 		inspectors, _ := MakeInspectors(conf)
 		op := AND{inspectors}
-		op.Operate(ctx, cap)
+		_, _ = op.Operate(ctx, capsule)
 	}
 }
 
 func BenchmarkAND(b *testing.B) {
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range conditionANDTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				cap.SetData(test.test)
-				benchmarkAND(b, test.conf, cap)
+				capsule.SetData(test.test)
+				benchmarkAND(b, test.conf, capsule)
 			},
 		)
 	}
@@ -224,10 +221,10 @@ var conditionORTests = []struct {
 
 func TestOR(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 
 	for _, test := range conditionORTests {
-		cap.SetData(test.test)
+		capsule.SetData(test.test)
 
 		cfg := Config{
 			Operator:   "or",
@@ -236,39 +233,36 @@ func TestOR(t *testing.T) {
 
 		op, err := OperatorFactory(cfg)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
-		ok, err := op.Operate(ctx, cap)
+		ok, err := op.Operate(ctx, capsule)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		if ok != test.expected {
-			t.Logf("expected %v, got %v", test.expected, ok)
-			t.Fail()
+			t.Errorf("expected %v, got %v", test.expected, ok)
 		}
 	}
 }
 
-func benchmarkOR(b *testing.B, conf []config.Config, cap config.Capsule) {
+func benchmarkOR(b *testing.B, conf []config.Config, capsule config.Capsule) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
 		inspectors, _ := MakeInspectors(conf)
 		op := OR{inspectors}
-		op.Operate(ctx, cap)
+		_, _ = op.Operate(ctx, capsule)
 	}
 }
 
 func BenchmarkOR(b *testing.B) {
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range conditionORTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				cap.SetData(test.test)
-				benchmarkOR(b, test.conf, cap)
+				capsule.SetData(test.test)
+				benchmarkOR(b, test.conf, capsule)
 			},
 		)
 	}
@@ -327,10 +321,10 @@ var conditionNANDTests = []struct {
 
 func TestNAND(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 
 	for _, test := range conditionNANDTests {
-		cap.SetData(test.test)
+		capsule.SetData(test.test)
 
 		cfg := Config{
 			Operator:   "nand",
@@ -339,39 +333,36 @@ func TestNAND(t *testing.T) {
 
 		op, err := OperatorFactory(cfg)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
-		ok, err := op.Operate(ctx, cap)
+		ok, err := op.Operate(ctx, capsule)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		if ok != test.expected {
-			t.Logf("expected %v, got %v", test.expected, ok)
-			t.Fail()
+			t.Errorf("expected %v, got %v", test.expected, ok)
 		}
 	}
 }
 
-func benchmarkNAND(b *testing.B, conf []config.Config, cap config.Capsule) {
+func benchmarkNAND(b *testing.B, conf []config.Config, capsule config.Capsule) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
 		inspectors, _ := MakeInspectors(conf)
 		op := NAND{inspectors}
-		op.Operate(ctx, cap)
+		_, _ = op.Operate(ctx, capsule)
 	}
 }
 
 func BenchmarkNAND(b *testing.B) {
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range conditionNORTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				cap.SetData(test.test)
-				benchmarkNAND(b, test.conf, cap)
+				capsule.SetData(test.test)
+				benchmarkNAND(b, test.conf, capsule)
 			},
 		)
 	}
@@ -430,10 +421,10 @@ var conditionNORTests = []struct {
 
 func TestNOR(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 
 	for _, test := range conditionNORTests {
-		cap.SetData(test.test)
+		capsule.SetData(test.test)
 
 		cfg := Config{
 			Operator:   "nor",
@@ -442,39 +433,36 @@ func TestNOR(t *testing.T) {
 
 		op, err := OperatorFactory(cfg)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
-		ok, err := op.Operate(ctx, cap)
+		ok, err := op.Operate(ctx, capsule)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		if ok != test.expected {
-			t.Logf("expected %v, got %v", test.expected, ok)
-			t.Fail()
+			t.Errorf("expected %v, got %v", test.expected, ok)
 		}
 	}
 }
 
-func benchmarkNOR(b *testing.B, conf []config.Config, cap config.Capsule) {
+func benchmarkNOR(b *testing.B, conf []config.Config, capsule config.Capsule) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
 		inspectors, _ := MakeInspectors(conf)
 		op := NOR{inspectors}
-		op.Operate(ctx, cap)
+		_, _ = op.Operate(ctx, capsule)
 	}
 }
 
 func BenchmarkNOR(b *testing.B) {
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range conditionNORTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				cap.SetData(test.test)
-				benchmarkNOR(b, test.conf, cap)
+				capsule.SetData(test.test)
+				benchmarkNOR(b, test.conf, capsule)
 			},
 		)
 	}
@@ -484,21 +472,20 @@ func TestFactory(t *testing.T) {
 	for _, test := range conditionANDTests {
 		_, err := InspectorFactory(test.conf[0])
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 	}
 }
 
 func benchmarkFactory(b *testing.B, conf config.Config) {
 	for i := 0; i < b.N; i++ {
-		InspectorFactory(conf)
+		_, _ = InspectorFactory(conf)
 	}
 }
 
 func BenchmarkFactory(b *testing.B) {
 	for _, test := range conditionANDTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
 				benchmarkFactory(b, test.conf[0])
 			},

--- a/condition/content.go
+++ b/condition/content.go
@@ -11,6 +11,7 @@ import (
 Content evaluates data by its content type. This inspector uses the standard library's net/http package to identify the content type of data (more information is available here: https://pkg.go.dev/net/http#DetectContentType). When used in Substation pipelines, it is most effective when using processors that change the format of data (e.g., process/gzip). The inspector supports MIME types that follow this specification: https://mimesniff.spec.whatwg.org/.
 
 The inspector has these settings:
+
 	Type:
 		MIME type used during inspection
 	Negate (optional):
@@ -18,10 +19,12 @@ The inspector has these settings:
 		defaults to false
 
 The inspector supports these patterns:
+
 	data:
 		[31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 74, 203, 207, 7, 4, 0, 0, 255, 255, 33, 101, 115, 140, 3, 0, 0, 0] == application/x-gzip
 
 When loaded with a factory, the inspector uses this JSON configuration:
+
 	{
 		"type": "content",
 		"settings": {
@@ -35,10 +38,10 @@ type Content struct {
 }
 
 // Inspect evaluates encapsulated data with the Content inspector.
-func (c Content) Inspect(ctx context.Context, cap config.Capsule) (output bool, err error) {
+func (c Content) Inspect(ctx context.Context, capsule config.Capsule) (output bool, err error) {
 	matched := false
 
-	content := http.DetectContentType(cap.Data())
+	content := http.DetectContentType(capsule.Data())
 	if content == c.Type {
 		matched = true
 	}

--- a/condition/content_test.go
+++ b/condition/content_test.go
@@ -47,7 +47,7 @@ var contentTests = []struct {
 		Content{
 			Type: "application/zip",
 		},
-		[]byte{80, 75, 03, 04},
+		[]byte{80, 75, 0o3, 0o4},
 		true,
 	},
 	// matching Gzip against valid Zip header
@@ -65,45 +65,43 @@ var contentTests = []struct {
 		Content{
 			Type: "application/zip",
 		},
-		[]byte{04, 75, 03, 80},
+		[]byte{0o4, 75, 0o3, 80},
 		false,
 	},
 }
 
 func TestContent(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 
 	for _, test := range contentTests {
-		cap.SetData(test.test)
+		capsule.SetData(test.test)
 
-		check, err := test.inspector.Inspect(ctx, cap)
+		check, err := test.inspector.Inspect(ctx, capsule)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		if test.expected != check {
-			t.Logf("expected %v, got %v", test.expected, check)
-			t.Fail()
+			t.Errorf("expected %v, got %v", test.expected, check)
 		}
 	}
 }
 
-func benchmarkContentByte(b *testing.B, inspector Content, cap config.Capsule) {
+func benchmarkContentByte(b *testing.B, inspector Content, capsule config.Capsule) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
-		inspector.Inspect(ctx, cap)
+		_, _ = inspector.Inspect(ctx, capsule)
 	}
 }
 
 func BenchmarkContentByte(b *testing.B) {
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range contentTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				cap.SetData(test.test)
-				benchmarkContentByte(b, test.inspector, cap)
+				capsule.SetData(test.test)
+				benchmarkContentByte(b, test.inspector, capsule)
 			},
 		)
 	}

--- a/condition/ip.go
+++ b/condition/ip.go
@@ -16,6 +16,7 @@ const errIPInvalidType = errors.Error("invalid type")
 IP evaluates IP addresses by their type and usage. This inspector uses the standard library's net package to identify the type and usage of the address (more information is available here: https://pkg.go.dev/net#IP).
 
 The inspector has these settings:
+
 	Type:
 		IP address type used during inspection
 		must be one of:
@@ -33,6 +34,7 @@ The inspector has these settings:
 		defaults to false
 
 The inspector supports these patterns:
+
 	JSON:
 		{"ip_address":"10.0.0.1"} == private
 
@@ -40,6 +42,7 @@ The inspector supports these patterns:
 		10.0.0.1 == private
 
 When loaded with a factory, the inspector uses this JSON configuration:
+
 	{
 		"type": "ip",
 		"settings": {
@@ -54,12 +57,12 @@ type IP struct {
 }
 
 // Inspect evaluates encapsulated data with the IP inspector.
-func (c IP) Inspect(ctx context.Context, cap config.Capsule) (output bool, err error) {
+func (c IP) Inspect(ctx context.Context, capsule config.Capsule) (output bool, err error) {
 	var check string
 	if c.Key == "" {
-		check = string(cap.Data())
+		check = string(capsule.Data())
 	} else {
-		check = cap.Get(c.Key).String()
+		check = capsule.Get(c.Key).String()
 	}
 
 	ip := net.ParseIP(check)

--- a/condition/ip_test.go
+++ b/condition/ip_test.go
@@ -82,38 +82,36 @@ var ipTests = []struct {
 
 func TestIP(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 
 	for _, test := range ipTests {
-		cap.SetData(test.test)
+		capsule.SetData(test.test)
 
-		check, err := test.inspector.Inspect(ctx, cap)
+		check, err := test.inspector.Inspect(ctx, capsule)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		if test.expected != check {
-			t.Logf("expected %v, got %v, %v", test.expected, check, string(test.test))
-			t.Fail()
+			t.Errorf("expected %v, got %v, %v", test.expected, check, string(test.test))
 		}
 	}
 }
 
-func benchmarkIPByte(b *testing.B, inspector IP, cap config.Capsule) {
+func benchmarkIPByte(b *testing.B, inspector IP, capsule config.Capsule) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
-		inspector.Inspect(ctx, cap)
+		_, _ = inspector.Inspect(ctx, capsule)
 	}
 }
 
 func BenchmarkIPByte(b *testing.B) {
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range ipTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				cap.SetData(test.test)
-				benchmarkIPByte(b, test.inspector, cap)
+				capsule.SetData(test.test)
+				benchmarkIPByte(b, test.inspector, capsule)
 			},
 		)
 	}

--- a/condition/json.go
+++ b/condition/json.go
@@ -11,6 +11,7 @@ import (
 JSONSchema evaluates JSON objects against a minimal schema parser.
 
 The inspector has these settings:
+
 	Schema.Key:
 		JSON key-value to retrieve for inspection
 	Schema.Type:
@@ -25,10 +26,12 @@ The inspector has these settings:
 		defaults to false
 
 The inspector supports these patterns:
+
 	JSON:
 		{"foo":"bar","baz":123} == string,number
 
 When loaded with a factory, the inspector uses this JSON configuration:
+
 	{
 		"type": "json_schema",
 		"settings": {
@@ -54,11 +57,11 @@ type JSONSchema struct {
 }
 
 // Inspect evaluates encapsulated data with the JSONSchema inspector.
-func (c JSONSchema) Inspect(ctx context.Context, cap config.Capsule) (output bool, err error) {
+func (c JSONSchema) Inspect(ctx context.Context, capsule config.Capsule) (output bool, err error) {
 	matched := true
 
 	for _, schema := range c.Schema {
-		result := cap.Get(schema.Key)
+		result := capsule.Get(schema.Key)
 		rtype := json.Types[result.Type]
 
 		// Null values don't exist in the JSON
@@ -95,16 +98,19 @@ func (c JSONSchema) Inspect(ctx context.Context, cap config.Capsule) (output boo
 JSONValid evaluates JSON objects for validity.
 
 The inspector has these settings:
+
 	Negate (optional):
 		if set to true, then the inspection is negated (i.e., true becomes false, false becomes true)
 		defaults to false
 
 The inspector supports these patterns:
+
 	data:
 		{"foo":"bar","baz":123} == valid
 		foo == invalid
 
 When loaded with a factory, the inspector uses this JSON configuration:
+
 	{
 		"type": "json_valid"
 	}
@@ -114,8 +120,8 @@ type JSONValid struct {
 }
 
 // Inspect evaluates encapsulated data with the JSONValid inspector.
-func (c JSONValid) Inspect(ctx context.Context, cap config.Capsule) (output bool, err error) {
-	matched := json.Valid(cap.Data())
+func (c JSONValid) Inspect(ctx context.Context, capsule config.Capsule) (output bool, err error) {
+	matched := json.Valid(capsule.Data())
 
 	if c.Negate {
 		return !matched, nil

--- a/condition/json_test.go
+++ b/condition/json_test.go
@@ -59,38 +59,36 @@ var jsonSchemaTests = []struct {
 
 func TestJSONSchema(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 
 	for _, test := range jsonSchemaTests {
-		cap.SetData(test.test)
+		capsule.SetData(test.test)
 
-		check, err := test.inspector.Inspect(ctx, cap)
+		check, err := test.inspector.Inspect(ctx, capsule)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		if test.expected != check {
-			t.Logf("expected %v, got %v, %v", test.expected, check, string(test.test))
-			t.Fail()
+			t.Errorf("expected %v, got %v, %v", test.expected, check, string(test.test))
 		}
 	}
 }
 
-func benchmarkJSONSchemaByte(b *testing.B, inspector JSONSchema, cap config.Capsule) {
+func benchmarkJSONSchemaByte(b *testing.B, inspector JSONSchema, capsule config.Capsule) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
-		inspector.Inspect(ctx, cap)
+		_, _ = inspector.Inspect(ctx, capsule)
 	}
 }
 
 func BenchmarkJSONSchemaByte(b *testing.B) {
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range jsonSchemaTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				cap.SetData(test.test)
-				benchmarkJSONSchemaByte(b, test.inspector, cap)
+				capsule.SetData(test.test)
+				benchmarkJSONSchemaByte(b, test.inspector, capsule)
 			},
 		)
 	}
@@ -134,38 +132,36 @@ var jsonValidTests = []struct {
 
 func TestJSONValid(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 
 	for _, test := range jsonValidTests {
-		cap.SetData(test.test)
+		capsule.SetData(test.test)
 
-		check, err := test.inspector.Inspect(ctx, cap)
+		check, err := test.inspector.Inspect(ctx, capsule)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		if test.expected != check {
-			t.Logf("expected %v, got %v, %v", test.expected, check, string(test.test))
-			t.Fail()
+			t.Errorf("expected %v, got %v, %v", test.expected, check, string(test.test))
 		}
 	}
 }
 
-func benchmarkJSONValidByte(b *testing.B, inspector JSONValid, cap config.Capsule) {
+func benchmarkJSONValidByte(b *testing.B, inspector JSONValid, capsule config.Capsule) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
-		inspector.Inspect(ctx, cap)
+		_, _ = inspector.Inspect(ctx, capsule)
 	}
 }
 
 func BenchmarkJSONValidByte(b *testing.B) {
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range jsonValidTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				cap.SetData(test.test)
-				benchmarkJSONValidByte(b, test.inspector, cap)
+				capsule.SetData(test.test)
+				benchmarkJSONValidByte(b, test.inspector, capsule)
 			},
 		)
 	}

--- a/condition/length.go
+++ b/condition/length.go
@@ -16,6 +16,7 @@ const errLengthInvalidFunction = errors.Error("invalid function")
 Length evaluates data using len functions. This inspector supports evaluating byte and rune (character) length of strings. If a JSON array is input, then the length is evaluated against the number of elements in the array.
 
 The inspector has these settings:
+
 	Function:
 		length evaluation function used during inspection
 		must be one of:
@@ -25,7 +26,7 @@ The inspector has these settings:
 	Value:
 		length value used during inspection
 	Type (optional):
-		length type used during inpsection
+		length type used during inspection
 		must be one of:
 			byte (number of bytes)
 			rune (number of characters)
@@ -37,6 +38,7 @@ The inspector has these settings:
 		defaults to false
 
 The inspector supports these patterns:
+
 	JSON:
 		{"foo":"bar"} == 3
 		{"foo":["bar","baz","qux"]} == 3
@@ -44,6 +46,7 @@ The inspector supports these patterns:
 		bar == 3
 
 When loaded with a factory, the inspector uses this JSON configuration:
+
 	{
 		"type": "length",
 		"settings": {
@@ -61,12 +64,12 @@ type Length struct {
 }
 
 // Inspect evaluates encapsulated data with the Length inspector.
-func (c Length) Inspect(ctx context.Context, cap config.Capsule) (output bool, err error) {
+func (c Length) Inspect(ctx context.Context, capsule config.Capsule) (output bool, err error) {
 	var check string
 	if c.Key == "" {
-		check = string(cap.Data())
+		check = string(capsule.Data())
 	} else {
-		result := cap.Get(c.Key)
+		result := capsule.Get(c.Key)
 		if result.IsArray() {
 			return c.match(len(result.Array()))
 		}

--- a/condition/length_test.go
+++ b/condition/length_test.go
@@ -215,40 +215,38 @@ var lengthTests = []struct {
 
 func TestLength(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 
 	for _, test := range lengthTests {
-		cap.SetData(test.test)
+		capsule.SetData(test.test)
 
-		check, err := test.inspector.Inspect(ctx, cap)
+		check, err := test.inspector.Inspect(ctx, capsule)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		if test.expected != check {
-			t.Logf("expected %v, got %v", test.expected, check)
-			t.Logf("settings: %+v", test.inspector)
-			t.Logf("test: %+v", string(test.test))
-			t.Fail()
+			t.Errorf("expected %v, got %v", test.expected, check)
+			t.Errorf("settings: %+v", test.inspector)
+			t.Errorf("test: %+v", string(test.test))
 		}
 	}
 }
 
-func benchmarkLengthByte(b *testing.B, inspector Length, cap config.Capsule) {
+func benchmarkLengthByte(b *testing.B, inspector Length, capsule config.Capsule) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
-		inspector.Inspect(ctx, cap)
+		_, _ = inspector.Inspect(ctx, capsule)
 	}
 }
 
 func BenchmarkLengthByte(b *testing.B) {
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range lengthTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				cap.SetData(test.test)
-				benchmarkLengthByte(b, test.inspector, cap)
+				capsule.SetData(test.test)
+				benchmarkLengthByte(b, test.inspector, capsule)
 			},
 		)
 	}

--- a/condition/random.go
+++ b/condition/random.go
@@ -16,6 +16,7 @@ func init() {
 Random evaluates data based on a random choice. This inspector uses the standard library's rand package. This is best paired with the drop processor and can be used to integration test new configurations and deployments.
 
 When loaded with a factory, the inspector uses this JSON configuration:
+
 	{
 		"type": "random"
 	}
@@ -23,7 +24,7 @@ When loaded with a factory, the inspector uses this JSON configuration:
 type Random struct{}
 
 // Inspect evaluates encapsulated data with the Random inspector.
-func (c Random) Inspect(ctx context.Context, cap config.Capsule) (output bool, err error) {
+func (c Random) Inspect(ctx context.Context, capsule config.Capsule) (output bool, err error) {
 	matched := rand.Intn(2) == 1
 	return matched, nil
 }

--- a/condition/regexp.go
+++ b/condition/regexp.go
@@ -12,6 +12,7 @@ import (
 RegExp evaluates data using a regular expression. This inspector uses a regexp cache provided by internal/regexp.
 
 The inspector has these settings:
+
 	Expression:
 		regular expression to use during inspection
 	Key (optional):
@@ -21,12 +22,14 @@ The inspector has these settings:
 		defaults to false
 
 The inspector supports these patterns:
+
 	JSON:
 		{"foo":"bar"} == ^bar
 	data:
 		bar == ^bar
 
 When loaded with a factory, the inspector uses this JSON configuration:
+
 	{
 		"type": "regexp",
 		"settings": {
@@ -41,7 +44,7 @@ type RegExp struct {
 }
 
 // Inspect evaluates encapsulated data with the RegExp inspector.
-func (c RegExp) Inspect(ctx context.Context, cap config.Capsule) (output bool, err error) {
+func (c RegExp) Inspect(ctx context.Context, capsule config.Capsule) (output bool, err error) {
 	re, err := regexp.Compile(c.Expression)
 	if err != nil {
 		return false, fmt.Errorf("condition regexp: %v", err)
@@ -49,9 +52,9 @@ func (c RegExp) Inspect(ctx context.Context, cap config.Capsule) (output bool, e
 
 	var matched bool
 	if c.Key == "" {
-		matched = re.Match(cap.Data())
+		matched = re.Match(capsule.Data())
 	} else {
-		res := cap.Get(c.Key).String()
+		res := capsule.Get(c.Key).String()
 		matched = re.MatchString(res)
 	}
 

--- a/condition/regexp_test.go
+++ b/condition/regexp_test.go
@@ -51,38 +51,36 @@ var regexpTests = []struct {
 
 func TestRegExp(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 
 	for _, test := range regexpTests {
-		cap.SetData(test.test)
+		capsule.SetData(test.test)
 
-		check, err := test.inspector.Inspect(ctx, cap)
+		check, err := test.inspector.Inspect(ctx, capsule)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		if test.expected != check {
-			t.Logf("expected %v, got %v", test.expected, check)
-			t.Fail()
+			t.Errorf("expected %v, got %v", test.expected, check)
 		}
 	}
 }
 
-func benchmarkRegExpByte(b *testing.B, inspector RegExp, cap config.Capsule) {
+func benchmarkRegExpByte(b *testing.B, inspector RegExp, capsule config.Capsule) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
-		inspector.Inspect(ctx, cap)
+		_, _ = inspector.Inspect(ctx, capsule)
 	}
 }
 
 func BenchmarkRegExpByte(b *testing.B) {
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range regexpTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				cap.SetData(test.test)
-				benchmarkRegExpByte(b, test.inspector, cap)
+				capsule.SetData(test.test)
+				benchmarkRegExpByte(b, test.inspector, capsule)
 			},
 		)
 	}

--- a/condition/strings.go
+++ b/condition/strings.go
@@ -16,6 +16,7 @@ const errStringsInvalidFunction = errors.Error("invalid function")
 Strings evaluates data using string functions. This inspector uses the standard library's strings package.
 
 The inspector has these settings:
+
 	Function:
 		string evaluation function to use during inspection
 		must be one of:
@@ -32,12 +33,14 @@ The inspector has these settings:
 		defaults to false
 
 The inspector supports these patterns:
+
 	JSON:
 		{"foo":"bar"} == bar
 	data:
 		bar == bar
 
 When loaded with a factory, the inspector uses this JSON configuration:
+
 	{
 		"type": "strings",
 		"settings": {
@@ -54,12 +57,12 @@ type Strings struct {
 }
 
 // Inspect evaluates encapsulated data with the Strings inspector.
-func (c Strings) Inspect(ctx context.Context, cap config.Capsule) (output bool, err error) {
+func (c Strings) Inspect(ctx context.Context, capsule config.Capsule) (output bool, err error) {
 	var check string
 	if c.Key == "" {
-		check = string(cap.Data())
+		check = string(capsule.Data())
 	} else {
-		check = cap.Get(c.Key).String()
+		check = capsule.Get(c.Key).String()
 	}
 
 	var matched bool

--- a/condition/strings_test.go
+++ b/condition/strings_test.go
@@ -139,38 +139,36 @@ var stringsTests = []struct {
 
 func TestStrings(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 
 	for _, test := range stringsTests {
-		cap.SetData(test.test)
+		capsule.SetData(test.test)
 
-		check, err := test.inspector.Inspect(ctx, cap)
+		check, err := test.inspector.Inspect(ctx, capsule)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		if test.expected != check {
-			t.Logf("expected %v, got %v", test.expected, check)
-			t.Fail()
+			t.Errorf("expected %v, got %v", test.expected, check)
 		}
 	}
 }
 
-func benchmarkStringsByte(b *testing.B, inspector Strings, cap config.Capsule) {
+func benchmarkStringsByte(b *testing.B, inspector Strings, capsule config.Capsule) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
-		inspector.Inspect(ctx, cap)
+		_, _ = inspector.Inspect(ctx, capsule)
 	}
 }
 
 func BenchmarkStringsByte(b *testing.B) {
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range stringsTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				cap.SetData(test.test)
-				benchmarkStringsByte(b, test.inspector, cap)
+				capsule.SetData(test.test)
+				benchmarkStringsByte(b, test.inspector, capsule)
 			},
 		)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -19,7 +19,7 @@ type Config struct {
 }
 
 // Decode marshals and unmarshals an input interface into the output interface using the standard library's json package. This should be used when decoding JSON configurations (i.e., Config) in Substation interface factories.
-func Decode(input interface{}, output interface{}) error {
+func Decode(input, output interface{}) error {
 	b, err := gojson.Marshal(input)
 	if err != nil {
 		return err
@@ -39,8 +39,9 @@ Each capsule contains two unexported fields that are accessed by getters and set
 Values in the metadata field are accessed using the pattern "!metadata [key]". JSON values can be freely moved between the data and metadata fields.
 
 Capsules can be created and initialized using this pattern, where b is a []byte and v is an interface{}:
-	cap := NewCapsule()
-	cap.SetData(b).SetMetadata(v)
+
+	capsule := NewCapsule()
+	capsule.SetData(b).SetMetadata(v)
 
 Substation applications follow these rules when handling capsules:
 
@@ -207,10 +208,12 @@ func (c *Channel) Close() {
 }
 
 // Send writes capsule data to a channel and relies on goroutine recovery to prevent panicking if writes are attempted on a closed channel. Read more about recovery here: https://go.dev/blog/defer-panic-and-recover.
-func (c *Channel) Send(cap Capsule) {
+func (c *Channel) Send(capsule Capsule) {
 	defer func() {
+		//nolint: errcheck // we expect this recover to happen and have no error handling
+		// to do.
 		recover()
 	}()
 
-	c.C <- cap
+	c.C <- capsule
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -20,16 +20,15 @@ func TestConfig(t *testing.T) {
 	// simulates loading a JSON configuration file structured as a Config template
 	config := `{"type":"test", "settings":{"foo":"bar", "baz":1}}`
 	var cfg Config
-	json.Unmarshal([]byte(config), &cfg)
+	_ = json.Unmarshal([]byte(config), &cfg)
 
 	// simulates how the interface factories are designed
 	if cfg.Type == "test" {
 		var instance Test
-		Decode(cfg.Settings, &instance)
+		_ = Decode(cfg.Settings, &instance)
 
 		if instance != expected {
-			t.Logf("expected %+v, got %+v", expected, instance)
-			t.Fail()
+			t.Errorf("expected %+v, got %+v", expected, instance)
 		}
 	} else {
 		t.Fail()
@@ -47,7 +46,7 @@ func BenchmarkDecode(b *testing.B) {
 	var instance Test
 
 	for i := 0; i < b.N; i++ {
-		Decode(BenchmarkCfg.Settings, &instance)
+		_ = Decode(BenchmarkCfg.Settings, &instance)
 	}
 }
 
@@ -109,32 +108,31 @@ var capsuleDeleteTests = []struct {
 }
 
 func TestCapsuleDelete(t *testing.T) {
-	cap := NewCapsule()
+	capsule := NewCapsule()
 	for _, test := range capsuleDeleteTests {
-		cap.SetData(test.data).SetMetadata(test.metadata)
-		cap.Delete(test.key)
+		_, _ = capsule.SetData(test.data).SetMetadata(test.metadata)
+		_ = capsule.Delete(test.key)
 
-		if !bytes.Equal(cap.Data(), test.dataExpected) &&
-			!bytes.Equal(cap.Metadata(), test.metadataExpected) {
-			t.Logf("expected %s %s, got %s %s", test.dataExpected, test.metadataExpected, cap.Data(), cap.Metadata())
-			t.Fail()
+		if !bytes.Equal(capsule.Data(), test.dataExpected) &&
+			!bytes.Equal(capsule.Metadata(), test.metadataExpected) {
+			t.Errorf("expected %s %s, got %s %s", test.dataExpected, test.metadataExpected, capsule.Data(), capsule.Metadata())
 		}
 	}
 }
 
-func benchmarkTestCapsuleDelete(b *testing.B, key string, cap Capsule) {
+func benchmarkTestCapsuleDelete(b *testing.B, key string, capsule Capsule) {
 	for i := 0; i < b.N; i++ {
-		cap.Delete(key)
+		_ = capsule.Delete(key)
 	}
 }
 
 func BenchmarkTestCapsuleDelete(b *testing.B) {
-	cap := NewCapsule()
+	capsule := NewCapsule()
 	for _, test := range capsuleSetTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				cap.SetData(test.data).SetMetadata(test.metadata)
-				benchmarkTestCapsuleDelete(b, test.key, cap)
+				_, _ = capsule.SetData(test.data).SetMetadata(test.metadata)
+				benchmarkTestCapsuleDelete(b, test.key, capsule)
 			},
 		)
 	}
@@ -190,31 +188,30 @@ var capsuleGetTests = []struct {
 }
 
 func TestCapsuleGet(t *testing.T) {
-	cap := NewCapsule()
+	capsule := NewCapsule()
 	for _, test := range capsuleGetTests {
-		cap.SetData(test.data).SetMetadata(test.metadata)
+		_, _ = capsule.SetData(test.data).SetMetadata(test.metadata)
 
-		result := cap.Get(test.key).String()
+		result := capsule.Get(test.key).String()
 		if result != test.expected {
-			t.Logf("expected %s, got %s", test.expected, result)
-			t.Fail()
+			t.Errorf("expected %s, got %s", test.expected, result)
 		}
 	}
 }
 
-func benchmarkTestCapsuleGet(b *testing.B, key string, cap Capsule) {
+func benchmarkTestCapsuleGet(b *testing.B, key string, capsule Capsule) {
 	for i := 0; i < b.N; i++ {
-		cap.Get(key)
+		capsule.Get(key)
 	}
 }
 
 func BenchmarkTestCapsuleGet(b *testing.B) {
-	cap := NewCapsule()
+	capsule := NewCapsule()
 	for _, test := range capsuleGetTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				cap.SetData(test.data).SetMetadata(test.metadata)
-				benchmarkTestCapsuleGet(b, test.key, cap)
+				_, _ = capsule.SetData(test.data).SetMetadata(test.metadata)
+				benchmarkTestCapsuleGet(b, test.key, capsule)
 			},
 		)
 	}
@@ -269,31 +266,30 @@ var capsuleSetTests = []struct {
 
 func TestCapsuleSet(t *testing.T) {
 	for _, test := range capsuleSetTests {
-		cap := NewCapsule()
-		cap.SetData(test.data).SetMetadata(test.metadata)
+		capsule := NewCapsule()
+		_, _ = capsule.SetData(test.data).SetMetadata(test.metadata)
 
-		cap.Set(test.key, test.value)
-		if !bytes.Equal(cap.Data(), test.dataExpected) &&
-			!bytes.Equal(cap.Metadata(), test.metadataExpected) {
-			t.Logf("expected %s %s, got %s %s", test.dataExpected, test.metadataExpected, cap.Data(), cap.Metadata())
-			t.Fail()
+		_ = capsule.Set(test.key, test.value)
+		if !bytes.Equal(capsule.Data(), test.dataExpected) &&
+			!bytes.Equal(capsule.Metadata(), test.metadataExpected) {
+			t.Errorf("expected %s %s, got %s %s", test.dataExpected, test.metadataExpected, capsule.Data(), capsule.Metadata())
 		}
 	}
 }
 
-func benchmarkTestCapsuleSet(b *testing.B, key string, val interface{}, cap Capsule) {
+func benchmarkTestCapsuleSet(b *testing.B, key string, val interface{}, capsule Capsule) {
 	for i := 0; i < b.N; i++ {
-		cap.Set(key, val)
+		_ = capsule.Set(key, val)
 	}
 }
 
 func BenchmarkTestCapsuleSet(b *testing.B) {
-	cap := NewCapsule()
+	capsule := NewCapsule()
 	for _, test := range capsuleSetTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				cap.SetData(test.data).SetMetadata(test.metadata)
-				benchmarkTestCapsuleSet(b, test.key, test.value, cap)
+				_, _ = capsule.SetData(test.data).SetMetadata(test.metadata)
+				benchmarkTestCapsuleSet(b, test.key, test.value, capsule)
 			},
 		)
 	}
@@ -347,32 +343,31 @@ var capsuleSetRawTests = []struct {
 }
 
 func TestCapsuleSetRaw(t *testing.T) {
-	cap := NewCapsule()
+	capsule := NewCapsule()
 	for _, test := range capsuleSetRawTests {
-		cap.SetData(test.data).SetMetadata(test.metadata)
-		cap.Set(test.key, test.value)
+		_, _ = capsule.SetData(test.data).SetMetadata(test.metadata)
+		_ = capsule.Set(test.key, test.value)
 
-		if !bytes.Equal(cap.Data(), test.dataExpected) &&
-			!bytes.Equal(cap.Metadata(), test.metadataExpected) {
-			t.Logf("expected %s %s, got %s %s", test.dataExpected, test.metadataExpected, cap.Data(), cap.Metadata())
-			t.Fail()
+		if !bytes.Equal(capsule.Data(), test.dataExpected) &&
+			!bytes.Equal(capsule.Metadata(), test.metadataExpected) {
+			t.Errorf("expected %s %s, got %s %s", test.dataExpected, test.metadataExpected, capsule.Data(), capsule.Metadata())
 		}
 	}
 }
 
-func benchmarkTestCapsuleSetRaw(b *testing.B, key string, val interface{}, cap Capsule) {
+func benchmarkTestCapsuleSetRaw(b *testing.B, key string, val interface{}, capsule Capsule) {
 	for i := 0; i < b.N; i++ {
-		cap.SetRaw(key, val)
+		_ = capsule.SetRaw(key, val)
 	}
 }
 
 func BenchmarkTestCapsuleSetRaw(b *testing.B) {
-	cap := NewCapsule()
+	capsule := NewCapsule()
 	for _, test := range capsuleSetRawTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				cap.SetData(test.data).SetMetadata(test.metadata)
-				benchmarkTestCapsuleSetRaw(b, test.key, test.value, cap)
+				_, _ = capsule.SetData(test.data).SetMetadata(test.metadata)
+				benchmarkTestCapsuleSetRaw(b, test.key, test.value, capsule)
 			},
 		)
 	}
@@ -400,29 +395,28 @@ var capsuleSetDataTests = []struct {
 }
 
 func TestCapsuleSetData(t *testing.T) {
-	cap := NewCapsule()
+	capsule := NewCapsule()
 	for _, test := range capsuleSetDataTests {
-		cap.SetData(test.data)
+		capsule.SetData(test.data)
 
-		if !bytes.Equal(cap.Data(), test.expected) {
-			t.Logf("expected %s, got %s", test.expected, cap.Metadata())
-			t.Fail()
+		if !bytes.Equal(capsule.Data(), test.expected) {
+			t.Errorf("expected %s, got %s", test.expected, capsule.Metadata())
 		}
 	}
 }
 
-func benchmarkTestCapsuleSetData(b *testing.B, val []byte, cap Capsule) {
+func benchmarkTestCapsuleSetData(b *testing.B, val []byte, capsule Capsule) {
 	for i := 0; i < b.N; i++ {
-		cap.SetData(val)
+		capsule.SetData(val)
 	}
 }
 
 func BenchmarkTestCapsuleSetData(b *testing.B) {
-	cap := NewCapsule()
+	capsule := NewCapsule()
 	for _, test := range capsuleSetDataTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				benchmarkTestCapsuleSetData(b, test.data, cap)
+				benchmarkTestCapsuleSetData(b, test.data, capsule)
 			},
 		)
 	}
@@ -455,29 +449,28 @@ var capsuleSetMetadataTests = []struct {
 }
 
 func TestCapsuleSetMetadata(t *testing.T) {
-	cap := NewCapsule()
+	capsule := NewCapsule()
 	for _, test := range capsuleSetMetadataTests {
-		cap.SetMetadata(test.metadata)
+		_, _ = capsule.SetMetadata(test.metadata)
 
-		if !bytes.Equal(cap.Metadata(), test.expected) {
-			t.Logf("expected %s, got %s", test.expected, cap.Metadata())
-			t.Fail()
+		if !bytes.Equal(capsule.Metadata(), test.expected) {
+			t.Errorf("expected %s, got %s", test.expected, capsule.Metadata())
 		}
 	}
 }
 
-func benchmarkTestCapsuleSetMetadata(b *testing.B, val interface{}, cap Capsule) {
+func benchmarkTestCapsuleSetMetadata(b *testing.B, val interface{}, capsule Capsule) {
 	for i := 0; i < b.N; i++ {
-		cap.SetMetadata(val)
+		_, _ = capsule.SetMetadata(val)
 	}
 }
 
 func BenchmarkTestCapsuleSetMetadata(b *testing.B) {
-	cap := NewCapsule()
+	capsule := NewCapsule()
 	for _, test := range capsuleSetMetadataTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				benchmarkTestCapsuleSetMetadata(b, test.metadata, cap)
+				benchmarkTestCapsuleSetMetadata(b, test.metadata, capsule)
 			},
 		)
 	}

--- a/examples/condition/encapsulation/main.go
+++ b/examples/condition/encapsulation/main.go
@@ -19,13 +19,13 @@ func main() {
 		panic(err)
 	}
 
-	var caps []config.Capsule
-	cap := config.NewCapsule()
+	var capsules []config.Capsule
+	capsule := config.NewCapsule()
 
 	scanner := bufio.NewScanner(open)
 	for scanner.Scan() {
-		cap.SetData(scanner.Bytes())
-		caps = append(caps, cap)
+		capsule.SetData(scanner.Bytes())
+		capsules = append(capsules, capsule)
 	}
 
 	// read config file and create a new inspector
@@ -45,16 +45,16 @@ func main() {
 	}
 
 	// apply inspector to encapsulated data
-	for _, cap := range caps {
-		ok, err := inspector.Inspect(context.TODO(), cap)
+	for _, capsule := range capsules {
+		ok, err := inspector.Inspect(context.TODO(), capsule)
 		if err != nil {
 			panic(err)
 		}
 
 		if ok {
-			fmt.Printf("passed inspection: %s\n", cap.Data())
+			fmt.Printf("passed inspection: %s\n", capsule.Data())
 		} else {
-			fmt.Printf("failed inspection: %s\n", cap.Data())
+			fmt.Printf("failed inspection: %s\n", capsule.Data())
 		}
 	}
 }

--- a/examples/process/encapsulation/main.go
+++ b/examples/process/encapsulation/main.go
@@ -20,13 +20,13 @@ func main() {
 		panic(err)
 	}
 
-	var caps []config.Capsule
-	cap := config.NewCapsule()
+	var capsules []config.Capsule
+	capsule := config.NewCapsule()
 
 	scanner := bufio.NewScanner(open)
 	for scanner.Scan() {
-		cap.SetData(scanner.Bytes())
-		caps = append(caps, cap)
+		capsule.SetData(scanner.Bytes())
+		capsules = append(capsules, capsule)
 	}
 
 	// read config file and create a new batch processor
@@ -46,12 +46,12 @@ func main() {
 	}
 
 	// apply batch processor to encapsulated data
-	caps, err = process.ApplyBatch(context.TODO(), caps, proc)
+	capsules, err = process.ApplyBatch(context.TODO(), capsules, proc)
 	if err != nil {
 		panic(err)
 	}
 
-	for _, cap := range caps {
-		fmt.Printf("%s\n", cap.Data())
+	for _, capsule := range capsules {
+		fmt.Printf("%s\n", capsule.Data())
 	}
 }

--- a/internal/aws/appconfig/appconfig.go
+++ b/internal/aws/appconfig/appconfig.go
@@ -3,7 +3,7 @@ package appconfig
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/brexhq/substation/internal/errors"
@@ -34,7 +34,7 @@ func GetPrefetch(ctx context.Context) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("getprefetch read URL %s: %v", local, err)
 	}

--- a/internal/aws/cloudwatch/cloudwatch.go
+++ b/internal/aws/cloudwatch/cloudwatch.go
@@ -21,9 +21,9 @@ const (
 )
 
 var (
-	// By default, AWS Kinesis streams must be below the lower threshold for 95% of the evaluation period (57 minutes) to scale down. This value can be overriden by the environment variable SUBSTATION_AUTOSCALING_DOWNSCALE_DATAPOINTS, but it cannot exceed 60 minutes.
+	// By default, AWS Kinesis streams must be below the lower threshold for 95% of the evaluation period (57 minutes) to scale down. This value can be overridden by the environment variable SUBSTATION_AUTOSCALING_DOWNSCALE_DATAPOINTS, but it cannot exceed 60 minutes.
 	kinesisDownscaleDatapoints = 57
-	// By default, AWS Kinesis streams must be above the upper threshold for 100% of the evaluation period (5 minutes) to scale up. This value can be overriden by the environment variable SUBSTATION_AUTOSCALING_UPSCALE_DATAPOINTS, but it cannot exceed 5 minutes.
+	// By default, AWS Kinesis streams must be above the upper threshold for 100% of the evaluation period (5 minutes) to scale up. This value can be overridden by the environment variable SUBSTATION_AUTOSCALING_UPSCALE_DATAPOINTS, but it cannot exceed 5 minutes.
 	kinesisUpscaleDatapoints = 5
 )
 

--- a/internal/aws/dynamodb/dynamodb_test.go
+++ b/internal/aws/dynamodb/dynamodb_test.go
@@ -21,7 +21,7 @@ func (m mockedPutItem) PutItemWithContext(ctx aws.Context, input *dynamodb.PutIt
 }
 
 func TestPutItem(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		resp     dynamodb.PutItemOutput
 		expected string
 	}{
@@ -58,8 +58,7 @@ func TestPutItem(t *testing.T) {
 		}
 
 		if item["foo"] != test.expected {
-			t.Logf("expected %+v, got %s", item["foo"], test.expected)
-			t.Fail()
+			t.Errorf("expected %+v, got %s", item["foo"], test.expected)
 		}
 	}
 }
@@ -74,7 +73,7 @@ func (m mockedQuery) QueryWithContext(ctx aws.Context, input *dynamodb.QueryInpu
 }
 
 func TestQuery(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		resp     dynamodb.QueryOutput
 		expected string
 	}{
@@ -116,8 +115,7 @@ func TestQuery(t *testing.T) {
 		}
 
 		if items[0]["foo"] != test.expected {
-			t.Logf("expected %+v, got %s", items[0]["foo"], test.expected)
-			t.Fail()
+			t.Errorf("expected %+v, got %s", items[0]["foo"], test.expected)
 		}
 	}
 }

--- a/internal/aws/firehose/firehose.go
+++ b/internal/aws/firehose/firehose.go
@@ -63,7 +63,6 @@ func (a *API) PutRecord(ctx aws.Context, data []byte, stream string) (*firehose.
 			DeliveryStreamName: aws.String(stream),
 			Record:             &firehose.Record{Data: data},
 		})
-
 	if err != nil {
 		return nil, fmt.Errorf("putrecord stream %s: %v", stream, err)
 	}
@@ -100,7 +99,7 @@ func (a *API) PutRecordBatch(ctx aws.Context, data [][]byte, stream string) (*fi
 		}
 
 		if len(retryData) > 0 {
-			a.PutRecordBatch(ctx, retryData, stream)
+			_, _ = a.PutRecordBatch(ctx, retryData, stream)
 		}
 	}
 

--- a/internal/aws/firehose/firehose_test.go
+++ b/internal/aws/firehose/firehose_test.go
@@ -20,7 +20,7 @@ func (m mockedPutRecord) PutRecordWithContext(ctx aws.Context, in *firehose.PutR
 }
 
 func TestPutRecord(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		resp     firehose.PutRecordOutput
 		expected string
 	}{
@@ -45,8 +45,7 @@ func TestPutRecord(t *testing.T) {
 		}
 
 		if *resp.RecordId != test.expected {
-			t.Logf("expected %+v, got %s", test.expected, *resp.RecordId)
-			t.Fail()
+			t.Errorf("expected %+v, got %s", test.expected, *resp.RecordId)
 		}
 	}
 }
@@ -61,7 +60,7 @@ func (m mockedPutRecordBatch) PutRecordBatchWithContext(ctx aws.Context, in *fir
 }
 
 func TestPutRecordBatch(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		resp     firehose.PutRecordBatchOutput
 		expected []string
 	}{
@@ -99,8 +98,7 @@ func TestPutRecordBatch(t *testing.T) {
 
 		for idx, resp := range resp.RequestResponses {
 			if *resp.RecordId != test.expected[idx] {
-				t.Logf("expected %+v, got %s", test.expected[idx], *resp.RecordId)
-				t.Fail()
+				t.Errorf("expected %+v, got %s", test.expected[idx], *resp.RecordId)
 			}
 		}
 	}

--- a/internal/aws/kinesis/kinesis.go
+++ b/internal/aws/kinesis/kinesis.go
@@ -15,7 +15,7 @@ import (
 	"github.com/aws/aws-xray-sdk-go/xray"
 	rec "github.com/awslabs/kinesis-aggregation/go/records"
 
-	//lint:ignore SA1019 not ready to switch package
+	//nolint: staticcheck // not ready to switch package
 	"github.com/golang/protobuf/proto"
 )
 
@@ -67,7 +67,7 @@ func varIntSize(i int) int {
 	var needed int
 	for i > 0 {
 		needed++
-		i = i >> 1
+		i >>= 1
 	}
 
 	bytes := needed / 7
@@ -82,13 +82,13 @@ func (a *Aggregate) calculateRecordSize(data []byte, partitionKey string) int {
 	var recordSize int
 	// https://github.com/awslabs/kinesis-aggregation/blob/398fbd4b430d4bf590431b301d03cbbc94279cef/python/aws_kinesis_agg/aggregator.py#L344-L349
 	pkSize := 1 + varIntSize(len(partitionKey)) + len(partitionKey)
-	recordSize = recordSize + pkSize
+	recordSize += pkSize
 	// https://github.com/awslabs/kinesis-aggregation/blob/398fbd4b430d4bf590431b301d03cbbc94279cef/python/aws_kinesis_agg/aggregator.py#L362-L364
 	pkiSize := 1 + varIntSize(a.Count)
-	recordSize = recordSize + pkiSize
+	recordSize += pkiSize
 	// https://github.com/awslabs/kinesis-aggregation/blob/398fbd4b430d4bf590431b301d03cbbc94279cef/python/aws_kinesis_agg/aggregator.py#L371-L374
 	dataSize := 1 + varIntSize(len(data)) + len(data)
-	recordSize = recordSize + dataSize
+	recordSize += dataSize
 	// https://github.com/awslabs/kinesis-aggregation/blob/398fbd4b430d4bf590431b301d03cbbc94279cef/python/aws_kinesis_agg/aggregator.py#L376-L378
 	recordSize = recordSize + 1 + varIntSize(pkiSize+dataSize)
 
@@ -215,7 +215,6 @@ func (a *API) PutRecord(ctx aws.Context, data []byte, stream, partitionKey strin
 			StreamName:   aws.String(stream),
 			PartitionKey: aws.String(partitionKey),
 		})
-
 	if err != nil {
 		return nil, fmt.Errorf("putrecord stream %s partitionkey %s: %v", stream, partitionKey, err)
 	}

--- a/internal/aws/kinesis/kinesis_test.go
+++ b/internal/aws/kinesis/kinesis_test.go
@@ -21,7 +21,7 @@ func (m mockedReceiveMsgs) PutRecordWithContext(ctx aws.Context, in *kinesis.Put
 }
 
 func TestPutRecord(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		resp     kinesis.PutRecordOutput
 		expected string
 	}{
@@ -47,8 +47,7 @@ func TestPutRecord(t *testing.T) {
 		}
 
 		if *resp.SequenceNumber != test.expected {
-			t.Logf("expected %+v, got %s", resp.SequenceNumber, test.expected)
-			t.Fail()
+			t.Errorf("expected %+v, got %s", resp.SequenceNumber, test.expected)
 		}
 	}
 }
@@ -63,7 +62,7 @@ func (m mockedGetTags) ListTagsForStreamWithContext(ctx aws.Context, in *kinesis
 }
 
 func TestGetTags(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		resp     kinesis.ListTagsForStreamOutput
 		expected []*kinesis.Tag
 	}{
@@ -123,7 +122,7 @@ func TestGetTags(t *testing.T) {
 
 // tests that the calculated record size matches the size of returned data
 func TestSize(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		data   []byte
 		repeat int
 		pk     string
@@ -155,8 +154,7 @@ func TestSize(t *testing.T) {
 
 		data := rec.Get()
 		if check != len(data) {
-			t.Logf("expected %v, got %v", len(data), check)
-			t.Fail()
+			t.Errorf("expected %v, got %v", len(data), check)
 		}
 	}
 }

--- a/internal/aws/lambda/lambda_test.go
+++ b/internal/aws/lambda/lambda_test.go
@@ -21,7 +21,7 @@ func (m mockedInvoke) InvokeWithContext(ctx aws.Context, input *lambda.InvokeInp
 }
 
 func TestPutItem(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		resp     lambda.InvokeOutput
 		expected []byte
 	}{
@@ -46,8 +46,7 @@ func TestPutItem(t *testing.T) {
 		}
 
 		if c := bytes.Compare(resp.Payload, test.expected); c != 0 {
-			t.Logf("expected %+v, got %s", resp.Payload, test.expected)
-			t.Fail()
+			t.Errorf("expected %+v, got %s", resp.Payload, test.expected)
 		}
 	}
 }

--- a/internal/aws/s3manager/s3manager_test.go
+++ b/internal/aws/s3manager/s3manager_test.go
@@ -21,7 +21,7 @@ func (m mockedDownload) DownloadWithContext(ctx aws.Context, w io.WriterAt, inpu
 }
 
 func TestDownload(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		resp  int64
 		input struct {
 			bucket string
@@ -55,8 +55,7 @@ func TestDownload(t *testing.T) {
 		}
 
 		if size != test.expected {
-			t.Logf("expected %d, got %d", size, test.expected)
-			t.Fail()
+			t.Errorf("expected %d, got %d", size, test.expected)
 		}
 	}
 }
@@ -71,7 +70,7 @@ func (m mockedUpload) UploadWithContext(ctx aws.Context, input *s3manager.Upload
 }
 
 func TestUpload(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		resp  s3manager.UploadOutput
 		input struct {
 			buffer []byte
@@ -110,8 +109,7 @@ func TestUpload(t *testing.T) {
 		}
 
 		if resp.Location != test.expected {
-			t.Logf("expected %s, got %s", resp.Location, test.expected)
-			t.Fail()
+			t.Errorf("expected %s, got %s", resp.Location, test.expected)
 		}
 	}
 }

--- a/internal/aws/secretsmanager/secretsmanager_test.go
+++ b/internal/aws/secretsmanager/secretsmanager_test.go
@@ -20,7 +20,7 @@ func (m mockedGetSecret) GetSecretValueWithContext(ctx aws.Context, input *secre
 }
 
 func TestGetSecret(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		resp     secretsmanager.GetSecretValueOutput
 		input    string
 		expected string
@@ -47,8 +47,7 @@ func TestGetSecret(t *testing.T) {
 		}
 
 		if resp != test.expected {
-			t.Logf("expected %+v, got %s", resp, test.expected)
-			t.Fail()
+			t.Errorf("expected %+v, got %s", resp, test.expected)
 		}
 	}
 }

--- a/internal/aws/sqs/sqs.go
+++ b/internal/aws/sqs/sqs.go
@@ -71,7 +71,6 @@ func (a *API) SendMessage(ctx aws.Context, data []byte, queue string) (*sqs.Send
 			MessageBody: aws.String(string(data)),
 			QueueUrl:    url.QueueUrl,
 		})
-
 	if err != nil {
 		return nil, fmt.Errorf("sendmessage queue %s: %v", queue, err)
 	}
@@ -121,7 +120,7 @@ func (a *API) SendMessageBatch(ctx aws.Context, data [][]byte, queue string) (*s
 		}
 
 		if len(retryData) > 0 {
-			a.SendMessageBatch(ctx, retryData, queue)
+			_, _ = a.SendMessageBatch(ctx, retryData, queue)
 		}
 	}
 

--- a/internal/aws/sqs/sqs_test.go
+++ b/internal/aws/sqs/sqs_test.go
@@ -27,7 +27,7 @@ func (m mockedSendMessage) GetQueueUrlWithContext(ctx aws.Context, in *sqs.GetQu
 }
 
 func TestSendMessage(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		resp     sqs.SendMessageOutput
 		expected string
 	}{
@@ -52,8 +52,7 @@ func TestSendMessage(t *testing.T) {
 		}
 
 		if *resp.MessageId != test.expected {
-			t.Logf("expected %+v, got %s", test.expected, *resp.MessageId)
-			t.Fail()
+			t.Errorf("expected %+v, got %s", test.expected, *resp.MessageId)
 		}
 	}
 }
@@ -75,7 +74,7 @@ func (m mockedSendMessageBatch) GetQueueUrlWithContext(ctx aws.Context, in *sqs.
 }
 
 func TestSendMessageBatch(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		resp     sqs.SendMessageBatchOutput
 		expected []string
 	}{
@@ -111,8 +110,7 @@ func TestSendMessageBatch(t *testing.T) {
 
 		for idx, resp := range resp.Successful {
 			if *resp.MessageId != test.expected[idx] {
-				t.Logf("expected %+v, got %s", test.expected[idx], *resp.MessageId)
-				t.Fail()
+				t.Errorf("expected %+v, got %s", test.expected[idx], *resp.MessageId)
 			}
 		}
 	}

--- a/internal/aws/ssm/ssm_test.go
+++ b/internal/aws/ssm/ssm_test.go
@@ -20,7 +20,7 @@ func (m mockedGetParameter) GetParameterWithContext(ctx aws.Context, input *ssm.
 }
 
 func TestGetParameter(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		resp     ssm.GetParameterOutput
 		input    string
 		expected string
@@ -49,8 +49,7 @@ func TestGetParameter(t *testing.T) {
 		}
 
 		if resp != test.expected {
-			t.Logf("expected %+v, got %s", resp, test.expected)
-			t.Fail()
+			t.Errorf("expected %+v, got %s", resp, test.expected)
 		}
 	}
 }

--- a/internal/base64/base64_test.go
+++ b/internal/base64/base64_test.go
@@ -26,27 +26,25 @@ func TestBase64Decode(t *testing.T) {
 	for _, test := range decodeTests {
 		result, err := Decode(test.test)
 		if err != nil {
-			t.Logf("got error %v", err)
-			t.Fail()
+			t.Errorf("got error %v", err)
 			return
 		}
 
 		if c := bytes.Compare(result, test.expected); c != 0 {
-			t.Logf("expected %s, got %s", test.expected, result)
-			t.Fail()
+			t.Errorf("expected %s, got %s", test.expected, result)
 		}
 	}
 }
 
 func benchmarkBase64Decode(b *testing.B, test []byte) {
 	for i := 0; i < b.N; i++ {
-		Decode(test)
+		_, _ = Decode(test)
 	}
 }
 
 func BenchmarkBase64Decode(b *testing.B) {
 	for _, test := range encodeTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
 				benchmarkBase64Decode(b, test.test)
 			},
@@ -76,8 +74,7 @@ func TestBase64Encode(t *testing.T) {
 		result := Encode(test.test)
 
 		if c := bytes.Compare(result, test.expected); c != 0 {
-			t.Logf("expected %s, got %s", test.expected, result)
-			t.Fail()
+			t.Errorf("expected %s, got %s", test.expected, result)
 		}
 	}
 }
@@ -90,7 +87,7 @@ func benchmarkBase64Encode(b *testing.B, test []byte) {
 
 func BenchmarkBase64Encode(b *testing.B) {
 	for _, test := range encodeTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
 				benchmarkBase64Encode(b, test.test)
 			},

--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/aws/aws-xray-sdk-go/xray"
@@ -85,7 +84,7 @@ func (h *HTTP) Post(ctx context.Context, url string, payload interface{}, header
 	if err != nil {
 		return nil, fmt.Errorf("http post URL %s: %v", url, err)
 	}
-	io.Copy(ioutil.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 	defer resp.Body.Close()
 
 	return resp, nil

--- a/internal/http/http_test.go
+++ b/internal/http/http_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -13,7 +13,7 @@ import (
 )
 
 func TestPost(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		payload  interface{}
 		expected error
 	}{
@@ -29,7 +29,7 @@ func TestPost(t *testing.T) {
 
 	serv := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(200)
+			w.WriteHeader(http.StatusOK)
 		}))
 	defer serv.Close()
 
@@ -42,13 +42,13 @@ func TestPost(t *testing.T) {
 	for _, test := range tests {
 		_, err := h.Post(ctx, serv.URL, test.payload)
 		if !errors.Is(err, test.expected) {
-			t.Logf("expected %+v, got %+v", test.expected, err)
-			t.Fail()
+			t.Errorf("expected %+v, got %+v", test.expected, err)
 		}
 	}
 }
+
 func TestGet(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		expected []byte
 	}{
 		{
@@ -58,7 +58,7 @@ func TestGet(t *testing.T) {
 
 	serv := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.Write([]byte("foo"))
+			_, _ = w.Write([]byte("foo"))
 		}))
 	defer serv.Close()
 
@@ -75,13 +75,13 @@ func TestGet(t *testing.T) {
 		}
 
 		defer resp.Body.Close()
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
 
 		if c := bytes.Compare(body, test.expected); c != 0 {
-			t.Logf("expected %+v, got %+v", test.expected, body)
+			t.Errorf("expected %+v, got %+v", test.expected, body)
 		}
 	}
 }

--- a/internal/json/json_test.go
+++ b/internal/json/json_test.go
@@ -58,8 +58,7 @@ func TestGetJson(t *testing.T) {
 		result := Get(test.test, test.key)
 
 		if result.Value() != test.expected {
-			t.Logf("expected %v, got %v", test.expected, result)
-			t.Fail()
+			t.Errorf("expected %v, got %v", test.expected, result)
 		}
 	}
 }
@@ -72,7 +71,7 @@ func benchmarkGetJSON(b *testing.B, test []byte, key string) {
 
 func BenchmarkGetJSON(b *testing.B) {
 	for _, test := range getTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
 				benchmarkGetJSON(b, test.test, test.key)
 			},
@@ -142,27 +141,25 @@ func TestSetJson(t *testing.T) {
 	for _, test := range setTests {
 		result, err := Set(test.test, test.key, test.value)
 		if err != nil {
-			t.Logf("got error %v", err)
-			t.Fail()
+			t.Errorf("got error %v", err)
 			return
 		}
 
 		if c := bytes.Compare(result, test.expected); c != 0 {
-			t.Logf("expected %s, got %s", test.expected, result)
-			t.Fail()
+			t.Errorf("expected %s, got %s", test.expected, result)
 		}
 	}
 }
 
 func benchmarkSetJSON(b *testing.B, test []byte, key string, value interface{}) {
 	for i := 0; i < b.N; i++ {
-		Set(test, key, value)
+		_, _ = Set(test, key, value)
 	}
 }
 
 func BenchmarkSetJSON(b *testing.B) {
 	for _, test := range setTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
 				benchmarkSetJSON(b, test.test, test.key, test.value)
 			},
@@ -190,27 +187,25 @@ func TestSetRawJson(t *testing.T) {
 	for _, test := range setRawTests {
 		result, err := SetRaw(test.test, test.key, test.value)
 		if err != nil {
-			t.Logf("got error %v", err)
-			t.Fail()
+			t.Errorf("got error %v", err)
 			return
 		}
 
 		if c := bytes.Compare(result, test.expected); c != 0 {
-			t.Logf("expected %s, got %s", test.expected, result)
-			t.Fail()
+			t.Errorf("expected %s, got %s", test.expected, result)
 		}
 	}
 }
 
 func benchmarkSetRawJSON(b *testing.B, test []byte, key string, value interface{}) {
 	for i := 0; i < b.N; i++ {
-		Set(test, key, value)
+		_, _ = Set(test, key, value)
 	}
 }
 
 func BenchmarkSetRawJSON(b *testing.B) {
 	for _, test := range setRawTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
 				benchmarkSetRawJSON(b, test.test, test.key, test.value)
 			},
@@ -250,8 +245,7 @@ func TestValidJson(t *testing.T) {
 		result := Valid(test.test)
 
 		if result != test.expected {
-			t.Logf("expected %v, got %v", test.expected, result)
-			t.Fail()
+			t.Errorf("expected %v, got %v", test.expected, result)
 		}
 	}
 }
@@ -264,7 +258,7 @@ func benchmarkValidJSON(b *testing.B, test interface{}) {
 
 func BenchmarkValidJSON(b *testing.B) {
 	for _, test := range validTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
 				benchmarkValidJSON(b, test.test)
 			},

--- a/internal/regexp/regexp_test.go
+++ b/internal/regexp/regexp_test.go
@@ -23,11 +23,9 @@ func TestRegexp(t *testing.T) {
 	for _, test := range regexpTests {
 		_, err := Compile(test.test)
 		if test.expected == nil && err != nil {
-			t.Logf("expected %+v, got %+v", test.expected, err)
-			t.Fail()
+			t.Errorf("expected %+v, got %+v", test.expected, err)
 		} else if test.expected != nil && err == nil {
-			t.Logf("expected %+v, got %+v", test.expected, err)
-			t.Fail()
+			t.Errorf("expected %+v, got %+v", test.expected, err)
 		}
 	}
 }

--- a/internal/sink/dynamodb.go
+++ b/internal/sink/dynamodb.go
@@ -21,6 +21,7 @@ const errDynamoDBJSON = errors.Error("input must be JSON")
 DynamoDB sinks JSON data to an AWS DynamoDB table. This sink supports sinking multiple rows from the same event to a table.
 
 The sink has these settings:
+
 	Table:
 		DynamoDB table that data is written to
 	ItemsKey:
@@ -38,6 +39,7 @@ The sink has these settings:
 			]
 
 When loaded with a factory, the sink uses this JSON configuration:
+
 	{
 		"type": "dynamodb",
 		"settings": {
@@ -58,16 +60,16 @@ func (sink *DynamoDB) Send(ctx context.Context, ch *config.Channel) error {
 	}
 
 	var count int
-	for cap := range ch.C {
+	for capsule := range ch.C {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
-			if !json.Valid(cap.Data()) {
+			if !json.Valid(capsule.Data()) {
 				return fmt.Errorf("sink dynamodb table %s: %v", sink.Table, errDynamoDBJSON)
 			}
 
-			items := cap.Get(sink.ItemsKey).Array()
+			items := capsule.Get(sink.ItemsKey).Array()
 			for _, item := range items {
 				cache := make(map[string]interface{})
 				for k, v := range item.Map() {

--- a/internal/sink/http.go
+++ b/internal/sink/http.go
@@ -16,6 +16,7 @@ var httpClient http.HTTP
 HTTP sinks JSON data to an HTTP(S) endpoint.
 
 The sink has these settings:
+
 	URL:
 		HTTP(S) endpoint that data is sent to
 	Headers (optional):
@@ -34,6 +35,7 @@ The sink has these settings:
 			]
 
 When loaded with a factory, the sink uses this JSON configuration:
+
 	{
 		"type": "http",
 		"settings": {
@@ -59,14 +61,14 @@ func (sink *HTTP) Send(ctx context.Context, ch *config.Channel) error {
 		}
 	}
 
-	for cap := range ch.C {
+	for capsule := range ch.C {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
 			var headers []http.Header
 
-			if json.Valid(cap.Data()) {
+			if json.Valid(capsule.Data()) {
 				headers = append(headers, http.Header{
 					Key:   "Content-Type",
 					Value: "application/json",
@@ -83,7 +85,7 @@ func (sink *HTTP) Send(ctx context.Context, ch *config.Channel) error {
 			}
 
 			if sink.HeadersKey != "" {
-				h := cap.Get(sink.HeadersKey).Array()
+				h := capsule.Get(sink.HeadersKey).Array()
 				for _, header := range h {
 					for k, v := range header.Map() {
 						headers = append(headers, http.Header{
@@ -94,7 +96,7 @@ func (sink *HTTP) Send(ctx context.Context, ch *config.Channel) error {
 				}
 			}
 
-			_, err := httpClient.Post(ctx, sink.URL, string(cap.Data()), headers...)
+			_, err := httpClient.Post(ctx, sink.URL, string(capsule.Data()), headers...)
 			if err != nil {
 				// Post err returns metadata
 				return fmt.Errorf("sink http: %v", err)

--- a/internal/sink/sink.go
+++ b/internal/sink/sink.go
@@ -21,35 +21,35 @@ func Factory(cfg config.Config) (Sink, error) {
 	switch t := cfg.Type; t {
 	case "dynamodb":
 		var s DynamoDB
-		config.Decode(cfg.Settings, &s)
+		_ = config.Decode(cfg.Settings, &s)
 		return &s, nil
 	case "http":
 		var s HTTP
-		config.Decode(cfg.Settings, &s)
+		_ = config.Decode(cfg.Settings, &s)
 		return &s, nil
 	case "firehose":
 		var s Firehose
-		config.Decode(cfg.Settings, &s)
+		_ = config.Decode(cfg.Settings, &s)
 		return &s, nil
 	case "kinesis":
 		var s Kinesis
-		config.Decode(cfg.Settings, &s)
+		_ = config.Decode(cfg.Settings, &s)
 		return &s, nil
 	case "s3":
 		var s S3
-		config.Decode(cfg.Settings, &s)
+		_ = config.Decode(cfg.Settings, &s)
 		return &s, nil
 	case "sqs":
 		var s SQS
-		config.Decode(cfg.Settings, &s)
+		_ = config.Decode(cfg.Settings, &s)
 		return &s, nil
 	case "stdout":
 		var s Stdout
-		config.Decode(cfg.Settings, &s)
+		_ = config.Decode(cfg.Settings, &s)
 		return &s, nil
 	case "sumologic":
 		var s SumoLogic
-		config.Decode(cfg.Settings, &s)
+		_ = config.Decode(cfg.Settings, &s)
 		return &s, nil
 	default:
 		return nil, fmt.Errorf("sink settings %v: %v", cfg.Settings, errInvalidFactoryInput)

--- a/internal/sink/stdout.go
+++ b/internal/sink/stdout.go
@@ -11,6 +11,7 @@ import (
 Stdout sinks data to stdout.
 
 When loaded with a factory, the sink uses this JSON configuration:
+
 	{
 		"type": "stdout"
 	}
@@ -20,12 +21,12 @@ type Stdout struct{}
 // Send sinks a channel of encapsulated data with the Stdout sink.
 func (sink *Stdout) Send(ctx context.Context, ch *config.Channel) error {
 	var count int
-	for cap := range ch.C {
+	for capsule := range ch.C {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
-			fmt.Println(string(cap.Data()))
+			fmt.Println(string(capsule.Data()))
 			count++
 		}
 	}

--- a/internal/transform/transfer.go
+++ b/internal/transform/transfer.go
@@ -11,6 +11,7 @@ import (
 Transfer transforms data without modification. This transform should be used when data needs to be moved from a source to a sink without processing.
 
 When loaded with a factory, the transform uses this JSON configuration:
+
 	{
 		"type": "transfer"
 	}
@@ -18,26 +19,26 @@ When loaded with a factory, the transform uses this JSON configuration:
 type Transfer struct{}
 
 // Transform processes a channel of encapsulated data with the Transfer transform.
-func (transform *Transfer) Transform(ctx context.Context, in *config.Channel, out *config.Channel) error {
+func (transform *Transfer) Transform(ctx context.Context, in, out *config.Channel) error {
 	var count int
 
 	// read and write encapsulated data from input and to output channels
-	for cap := range in.C {
+	for capsule := range in.C {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
-			out.Send(cap)
+			out.Send(capsule)
 			count++
 		}
 	}
 
-	metrics.Generate(ctx, metrics.Data{
+	_ = metrics.Generate(ctx, metrics.Data{
 		Name:  "CapsulesReceived",
 		Value: count,
 	})
 
-	metrics.Generate(ctx, metrics.Data{
+	_ = metrics.Generate(ctx, metrics.Data{
 		Name:  "CapsulesSent",
 		Value: count,
 	})

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -21,11 +21,11 @@ func Factory(cfg config.Config) (Transformer, error) {
 	switch t := cfg.Type; t {
 	case "batch":
 		var t Batch
-		config.Decode(cfg.Settings, &t)
+		_ = config.Decode(cfg.Settings, &t)
 		return &t, nil
 	case "transfer":
 		var t Transfer
-		config.Decode(cfg.Settings, &t)
+		_ = config.Decode(cfg.Settings, &t)
 		return &t, nil
 	default:
 		return nil, fmt.Errorf("transform settings %v: %v", cfg.Settings, errInvalidFactoryInput)

--- a/process/aggregate.go
+++ b/process/aggregate.go
@@ -103,7 +103,7 @@ func (p Aggregate) ApplyBatch(ctx context.Context, capsules []config.Capsule) ([
 		return nil, fmt.Errorf("process aggregate: %v", err)
 	}
 
-	newCaps := newBatch(&capsules)
+	newCapsules := newBatch(&capsules)
 	for _, capsule := range capsules {
 		ok, err := op.Operate(ctx, capsule)
 		if err != nil {
@@ -111,7 +111,7 @@ func (p Aggregate) ApplyBatch(ctx context.Context, capsules []config.Capsule) ([
 		}
 
 		if !ok {
-			newCaps = append(newCaps, capsule)
+			newCapsules = append(newCapsules, capsule)
 			continue
 		}
 
@@ -144,7 +144,7 @@ func (p Aggregate) ApplyBatch(ctx context.Context, capsules []config.Capsule) ([
 			continue
 		}
 
-		newCap := config.NewCapsule()
+		newCapsule := config.NewCapsule()
 		elements := buffer[aggregateKey].Get()
 		if p.OutputKey != "" {
 			var value []byte
@@ -157,13 +157,13 @@ func (p Aggregate) ApplyBatch(ctx context.Context, capsules []config.Capsule) ([
 				}
 			}
 
-			newCap.SetData(value)
-			newCaps = append(newCaps, newCap)
+			newCapsule.SetData(value)
+			newCapsules = append(newCapsules, newCapsule)
 		} else {
 			value := bytes.Join(elements, []byte(p.Options.Separator))
 
-			newCap.SetData(value)
-			newCaps = append(newCaps, newCap)
+			newCapsule.SetData(value)
+			newCapsules = append(newCapsules, newCapsule)
 		}
 
 		// by this point, addition of the failed data is guaranteed to
@@ -176,7 +176,7 @@ func (p Aggregate) ApplyBatch(ctx context.Context, capsules []config.Capsule) ([
 	}
 
 	// remaining items must be drained from the buffer, otherwise data is lost
-	newCap := config.NewCapsule()
+	newCapsule := config.NewCapsule()
 	for _, key := range aggregateKeys {
 		if buffer[key].Count() == 0 {
 			continue
@@ -194,15 +194,15 @@ func (p Aggregate) ApplyBatch(ctx context.Context, capsules []config.Capsule) ([
 				}
 			}
 
-			newCap.SetData(value)
-			newCaps = append(newCaps, newCap)
+			newCapsule.SetData(value)
+			newCapsules = append(newCapsules, newCapsule)
 		} else {
 			value := bytes.Join(elements, []byte(p.Options.Separator))
 
-			newCap.SetData(value)
-			newCaps = append(newCaps, newCap)
+			newCapsule.SetData(value)
+			newCapsules = append(newCapsules, newCapsule)
 		}
 	}
 
-	return newCaps, nil
+	return newCapsules, nil
 }

--- a/process/aggregate_test.go
+++ b/process/aggregate_test.go
@@ -173,50 +173,48 @@ var aggregateTests = []struct {
 
 func TestAggregate(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 
 	for _, test := range aggregateTests {
-		var caps []config.Capsule
+		var capsules []config.Capsule
 		for _, t := range test.test {
-			cap.SetData(t)
-			caps = append(caps, cap)
+			capsule.SetData(t)
+			capsules = append(capsules, capsule)
 		}
 
-		result, err := test.proc.ApplyBatch(ctx, caps)
+		result, err := test.proc.ApplyBatch(ctx, capsules)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		for i, res := range result {
 			expected := test.expected[i]
 			if !bytes.Equal(expected, res.Data()) {
-				t.Logf("expected %s, got %s", expected, string(res.Data()))
-				t.Fail()
+				t.Errorf("expected %s, got %s", expected, string(res.Data()))
 			}
 		}
 	}
 }
 
-func benchmarkAggregate(b *testing.B, batcher Aggregate, caps []config.Capsule) {
+func benchmarkAggregate(b *testing.B, batcher Aggregate, capsules []config.Capsule) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
-		batcher.ApplyBatch(ctx, caps)
+		_, _ = batcher.ApplyBatch(ctx, capsules)
 	}
 }
 
 func BenchmarkAggregate(b *testing.B) {
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range aggregateTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				var caps []config.Capsule
+				var capsules []config.Capsule
 				for _, t := range test.test {
-					cap.SetData(t)
-					caps = append(caps, cap)
+					_ = capsule.SetData(t)
+					capsules = append(capsules, capsule)
 				}
 
-				benchmarkAggregate(b, test.proc, caps)
+				benchmarkAggregate(b, test.proc, capsules)
 			},
 		)
 	}

--- a/process/base64.go
+++ b/process/base64.go
@@ -2,9 +2,8 @@ package process
 
 import (
 	"context"
-	"unicode/utf8"
-
 	"fmt"
+	"unicode/utf8"
 
 	"github.com/brexhq/substation/condition"
 	"github.com/brexhq/substation/config"
@@ -17,12 +16,14 @@ const errBase64DecodedBinary = errors.Error("cannot write binary as JSON")
 
 /*
 Base64 processes data by converting it to and from base64 encoding. The processor supports these patterns:
+
 	JSON:
 	  	{"base64":"Zm9v"} >>> {"base64":"foo"}
 	data:
 		Zm9v >>> foo
 
 When loaded with a factory, the processor uses this JSON configuration:
+
 	{
 		"type": "base64",
 		"settings": {
@@ -43,6 +44,7 @@ type Base64 struct {
 
 /*
 Base64Options contains custom options for the Base64 processor:
+
 	Direction:
 		direction of the encoding
 		must be one of:
@@ -54,30 +56,30 @@ type Base64Options struct {
 }
 
 // ApplyBatch processes a slice of encapsulated data with the Base64 processor. Conditions are optionally applied to the data to enable processing.
-func (p Base64) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.Capsule, error) {
+func (p Base64) ApplyBatch(ctx context.Context, capsules []config.Capsule) ([]config.Capsule, error) {
 	op, err := condition.OperatorFactory(p.Condition)
 	if err != nil {
 		return nil, fmt.Errorf("process base64: %v", err)
 	}
 
-	caps, err = conditionallyApplyBatch(ctx, caps, op, p)
+	capsules, err = conditionallyApplyBatch(ctx, capsules, op, p)
 	if err != nil {
 		return nil, fmt.Errorf("process base64: %v", err)
 	}
 
-	return caps, nil
+	return capsules, nil
 }
 
 // Apply processes encapsulated data with the Base64 processor.
-func (p Base64) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, error) {
+func (p Base64) Apply(ctx context.Context, capsule config.Capsule) (config.Capsule, error) {
 	// error early if required options are missing
 	if p.Options.Direction == "" {
-		return cap, fmt.Errorf("process base64: options %+v: %v", p.Options, errMissingRequiredOptions)
+		return capsule, fmt.Errorf("process base64: options %+v: %v", p.Options, errMissingRequiredOptions)
 	}
 
 	// JSON processing
 	if p.InputKey != "" && p.OutputKey != "" {
-		result := cap.Get(p.InputKey).String()
+		result := capsule.Get(p.InputKey).String()
 		tmp := []byte(result)
 
 		var value []byte
@@ -85,25 +87,25 @@ func (p Base64) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, 
 		case "from":
 			decode, err := base64.Decode(tmp)
 			if err != nil {
-				return cap, fmt.Errorf("process base64: %v", err)
+				return capsule, fmt.Errorf("process base64: %v", err)
 			}
 
 			if !utf8.Valid(decode) {
-				return cap, fmt.Errorf("process base64: %v", errBase64DecodedBinary)
+				return capsule, fmt.Errorf("process base64: %v", errBase64DecodedBinary)
 			}
 
 			value = decode
 		case "to":
 			value = base64.Encode(tmp)
 		default:
-			return cap, fmt.Errorf("process base64: direction %s: %v", p.Options.Direction, errInvalidDirection)
+			return capsule, fmt.Errorf("process base64: direction %s: %v", p.Options.Direction, errInvalidDirection)
 		}
 
-		if err := cap.Set(p.OutputKey, value); err != nil {
-			return cap, fmt.Errorf("process base64: %v", err)
+		if err := capsule.Set(p.OutputKey, value); err != nil {
+			return capsule, fmt.Errorf("process base64: %v", err)
 		}
 
-		return cap, nil
+		return capsule, nil
 	}
 
 	// data processing
@@ -111,21 +113,21 @@ func (p Base64) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, 
 		var value []byte
 		switch p.Options.Direction {
 		case "from":
-			decode, err := base64.Decode(cap.Data())
+			decode, err := base64.Decode(capsule.Data())
 			if err != nil {
-				return cap, fmt.Errorf("process base64: %v", err)
+				return capsule, fmt.Errorf("process base64: %v", err)
 			}
 
 			value = decode
 		case "to":
-			value = base64.Encode(cap.Data())
+			value = base64.Encode(capsule.Data())
 		default:
-			return cap, fmt.Errorf("process base64: direction %s: %v", p.Options.Direction, errInvalidDirection)
+			return capsule, fmt.Errorf("process base64: direction %s: %v", p.Options.Direction, errInvalidDirection)
 		}
 
-		cap.SetData(value)
-		return cap, nil
+		capsule.SetData(value)
+		return capsule, nil
 	}
 
-	return cap, fmt.Errorf("process base64: inputkey %s outputkey %s: %v", p.InputKey, p.OutputKey, errInvalidDataPattern)
+	return capsule, fmt.Errorf("process base64: inputkey %s outputkey %s: %v", p.InputKey, p.OutputKey, errInvalidDataPattern)
 }

--- a/process/base64_test.go
+++ b/process/base64_test.go
@@ -54,20 +54,18 @@ var base64Tests = []struct {
 
 func TestBase64(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 
 	for _, test := range base64Tests {
-		cap.SetData(test.test)
+		capsule.SetData(test.test)
 
-		result, err := test.proc.Apply(ctx, cap)
+		result, err := test.proc.Apply(ctx, capsule)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		if !bytes.Equal(result.Data(), test.expected) {
-			t.Logf("expected %s, got %s", test.expected, result.Data())
-			t.Fail()
+			t.Errorf("expected %s, got %s", test.expected, result.Data())
 		}
 	}
 }
@@ -75,17 +73,17 @@ func TestBase64(t *testing.T) {
 func benchmarkBase64(b *testing.B, applicator Base64, test config.Capsule) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
-		applicator.Apply(ctx, test)
+		_, _ = applicator.Apply(ctx, test)
 	}
 }
 
 func BenchmarkBase64(b *testing.B) {
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range base64Tests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				cap.SetData(test.test)
-				benchmarkBase64(b, test.proc, cap)
+				capsule.SetData(test.test)
+				benchmarkBase64(b, test.proc, capsule)
 			},
 		)
 	}

--- a/process/capture.go
+++ b/process/capture.go
@@ -130,7 +130,7 @@ func (p Capture) Apply(ctx context.Context, capsule config.Capsule) (config.Caps
 
 			return capsule, nil
 		case "named_group":
-			newCap := config.NewCapsule()
+			newCapsule := config.NewCapsule()
 
 			names := re.SubexpNames()
 			matches := re.FindSubmatch(capsule.Data())
@@ -139,12 +139,12 @@ func (p Capture) Apply(ctx context.Context, capsule config.Capsule) (config.Caps
 					continue
 				}
 
-				if err := newCap.Set(names[i], m); err != nil {
+				if err := newCapsule.Set(names[i], m); err != nil {
 					return capsule, fmt.Errorf("process capture: %v", err)
 				}
 			}
 
-			return newCap, nil
+			return newCapsule, nil
 		}
 	}
 

--- a/process/capture_test.go
+++ b/process/capture_test.go
@@ -72,20 +72,18 @@ var captureTests = []struct {
 
 func TestCapture(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 
 	for _, test := range captureTests {
-		cap.SetData(test.test)
+		capsule.SetData(test.test)
 
-		result, err := test.proc.Apply(ctx, cap)
+		result, err := test.proc.Apply(ctx, capsule)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		if !bytes.Equal(result.Data(), test.expected) {
-			t.Logf("expected %s, got %s", test.expected, result.Data())
-			t.Fail()
+			t.Errorf("expected %s, got %s", test.expected, result.Data())
 		}
 	}
 }
@@ -93,17 +91,17 @@ func TestCapture(t *testing.T) {
 func benchmarkCapture(b *testing.B, applicator Capture, test config.Capsule) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
-		applicator.Apply(ctx, test)
+		_, _ = applicator.Apply(ctx, test)
 	}
 }
 
 func BenchmarkCapture(b *testing.B) {
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range captureTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				cap.SetData(test.test)
-				benchmarkCapture(b, test.proc, cap)
+				capsule.SetData(test.test)
+				benchmarkCapture(b, test.proc, capsule)
 			},
 		)
 	}

--- a/process/case_test.go
+++ b/process/case_test.go
@@ -58,20 +58,18 @@ var caseTests = []struct {
 
 func TestCase(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 
 	for _, test := range caseTests {
-		cap.SetData(test.test)
+		capsule.SetData(test.test)
 
-		result, err := test.proc.Apply(ctx, cap)
+		result, err := test.proc.Apply(ctx, capsule)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		if !bytes.Equal(result.Data(), test.expected) {
-			t.Logf("expected %s, got %s", test.expected, result.Data())
-			t.Fail()
+			t.Errorf("expected %s, got %s", test.expected, result.Data())
 		}
 	}
 }
@@ -79,17 +77,17 @@ func TestCase(t *testing.T) {
 func benchmarkCase(b *testing.B, applicator Case, test config.Capsule) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
-		applicator.Apply(ctx, test)
+		_, _ = applicator.Apply(ctx, test)
 	}
 }
 
 func BenchmarkCase(b *testing.B) {
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range caseTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				cap.SetData(test.test)
-				benchmarkCase(b, test.proc, cap)
+				capsule.SetData(test.test)
+				benchmarkCase(b, test.proc, capsule)
 			},
 		)
 	}

--- a/process/concat_test.go
+++ b/process/concat_test.go
@@ -32,20 +32,18 @@ var concatTests = []struct {
 
 func TestConcat(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 
 	for _, test := range concatTests {
-		cap.SetData(test.test)
+		capsule.SetData(test.test)
 
-		result, err := test.proc.Apply(ctx, cap)
+		result, err := test.proc.Apply(ctx, capsule)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		if !bytes.Equal(result.Data(), test.expected) {
-			t.Logf("expected %s, got %s", test.expected, result.Data())
-			t.Fail()
+			t.Errorf("expected %s, got %s", test.expected, result.Data())
 		}
 	}
 }
@@ -53,17 +51,17 @@ func TestConcat(t *testing.T) {
 func benchmarkConcat(b *testing.B, applicator Concat, test config.Capsule) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
-		applicator.Apply(ctx, test)
+		_, _ = applicator.Apply(ctx, test)
 	}
 }
 
 func BenchmarkConcat(b *testing.B) {
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range concatTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				cap.SetData(test.test)
-				benchmarkConcat(b, test.proc, cap)
+				capsule.SetData(test.test)
+				benchmarkConcat(b, test.proc, capsule)
 			},
 		)
 	}

--- a/process/convert_test.go
+++ b/process/convert_test.go
@@ -110,20 +110,18 @@ var convertTests = []struct {
 
 func TestConvert(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 
 	for _, test := range convertTests {
-		cap.SetData(test.test)
+		capsule.SetData(test.test)
 
-		result, err := test.proc.Apply(ctx, cap)
+		result, err := test.proc.Apply(ctx, capsule)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		if !bytes.Equal(result.Data(), test.expected) {
-			t.Logf("expected %s, got %s", test.expected, result.Data())
-			t.Fail()
+			t.Errorf("expected %s, got %s", test.expected, result.Data())
 		}
 	}
 }
@@ -131,17 +129,17 @@ func TestConvert(t *testing.T) {
 func benchmarkConvert(b *testing.B, applicator Convert, test config.Capsule) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
-		applicator.Apply(ctx, test)
+		_, _ = applicator.Apply(ctx, test)
 	}
 }
 
 func BenchmarkConvert(b *testing.B) {
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range convertTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				cap.SetData(test.test)
-				benchmarkConvert(b, test.proc, cap)
+				capsule.SetData(test.test)
+				benchmarkConvert(b, test.proc, capsule)
 			},
 		)
 	}

--- a/process/copy.go
+++ b/process/copy.go
@@ -11,12 +11,12 @@ import (
 /*
 Copy processes data by copying it. The processor supports these patterns:
 
-		JSON:
-		  	{"hello":"world"} >>> {"hello":"world","goodbye":"world"}
-		from JSON:
-	  		{"hello":"world"} >>> world
-		to JSON:
-	  		world >>> {"hello":"world"}
+	JSON:
+		{"hello":"world"} >>> {"hello":"world","goodbye":"world"}
+	from JSON:
+		{"hello":"world"} >>> world
+	to JSON:
+		world >>> {"hello":"world"}
 
 When loaded with a factory, the processor uses this JSON configuration:
 

--- a/process/copy.go
+++ b/process/copy.go
@@ -10,14 +10,16 @@ import (
 
 /*
 Copy processes data by copying it. The processor supports these patterns:
-	JSON:
-	  	{"hello":"world"} >>> {"hello":"world","goodbye":"world"}
-	from JSON:
-  		{"hello":"world"} >>> world
-	to JSON:
-  		world >>> {"hello":"world"}
+
+		JSON:
+		  	{"hello":"world"} >>> {"hello":"world","goodbye":"world"}
+		from JSON:
+	  		{"hello":"world"} >>> world
+		to JSON:
+	  		world >>> {"hello":"world"}
 
 When loaded with a factory, the processor uses this JSON configuration:
+
 	{
 		"type": "copy",
 		"settings": {
@@ -33,47 +35,47 @@ type Copy struct {
 }
 
 // ApplyBatch processes a slice of encapsulated data with the Copy processor. Conditions are optionally applied to the data to enable processing.
-func (p Copy) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.Capsule, error) {
+func (p Copy) ApplyBatch(ctx context.Context, capsules []config.Capsule) ([]config.Capsule, error) {
 	op, err := condition.OperatorFactory(p.Condition)
 	if err != nil {
 		return nil, fmt.Errorf("process copy: %v", err)
 	}
 
-	caps, err = conditionallyApplyBatch(ctx, caps, op, p)
+	capsules, err = conditionallyApplyBatch(ctx, capsules, op, p)
 	if err != nil {
 		return nil, fmt.Errorf("process copy: %v", err)
 	}
 
-	return caps, nil
+	return capsules, nil
 }
 
 // Apply processes encapsulated data with the Copy processor.
-func (p Copy) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, error) {
+func (p Copy) Apply(ctx context.Context, capsule config.Capsule) (config.Capsule, error) {
 	// JSON processing
 	if p.InputKey != "" && p.OutputKey != "" {
-		if err := cap.Set(p.OutputKey, cap.Get(p.InputKey)); err != nil {
-			return cap, fmt.Errorf("process copy: %v", err)
+		if err := capsule.Set(p.OutputKey, capsule.Get(p.InputKey)); err != nil {
+			return capsule, fmt.Errorf("process copy: %v", err)
 		}
 
-		return cap, nil
+		return capsule, nil
 	}
 
 	// from JSON processing
 	if p.InputKey != "" && p.OutputKey == "" {
-		result := cap.Get(p.InputKey).String()
+		result := capsule.Get(p.InputKey).String()
 
-		cap.SetData([]byte(result))
-		return cap, nil
+		capsule.SetData([]byte(result))
+		return capsule, nil
 	}
 
 	// to JSON processing
 	if p.InputKey == "" && p.OutputKey != "" {
-		if err := cap.Set(p.OutputKey, cap.Data()); err != nil {
-			return cap, fmt.Errorf("process copy: %v", err)
+		if err := capsule.Set(p.OutputKey, capsule.Data()); err != nil {
+			return capsule, fmt.Errorf("process copy: %v", err)
 		}
 
-		return cap, nil
+		return capsule, nil
 	}
 
-	return cap, fmt.Errorf("process copy: inputkey %s outputkey %s: %w", p.InputKey, p.OutputKey, errInvalidDataPattern)
+	return capsule, fmt.Errorf("process copy: inputkey %s outputkey %s: %w", p.InputKey, p.OutputKey, errInvalidDataPattern)
 }

--- a/process/copy_test.go
+++ b/process/copy_test.go
@@ -75,20 +75,18 @@ var copyTests = []struct {
 
 func TestCopy(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 
 	for _, test := range copyTests {
-		cap.SetData(test.test)
+		capsule.SetData(test.test)
 
-		result, err := test.proc.Apply(ctx, cap)
+		result, err := test.proc.Apply(ctx, capsule)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		if !bytes.Equal(result.Data(), test.expected) {
-			t.Logf("expected %s, got %s", test.expected, result.Data())
-			t.Fail()
+			t.Errorf("expected %s, got %s", test.expected, result.Data())
 		}
 	}
 }
@@ -96,17 +94,17 @@ func TestCopy(t *testing.T) {
 func benchmarkCopy(b *testing.B, applicator Copy, test config.Capsule) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
-		applicator.Apply(ctx, test)
+		_, _ = applicator.Apply(ctx, test)
 	}
 }
 
 func BenchmarkCopy(b *testing.B) {
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range copyTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				cap.SetData(test.test)
-				benchmarkCopy(b, test.proc, cap)
+				capsule.SetData(test.test)
+				benchmarkCopy(b, test.proc, capsule)
 			},
 		)
 	}

--- a/process/count.go
+++ b/process/count.go
@@ -11,6 +11,7 @@ import (
 Count processes data by counting it.
 
 When loaded with a factory, the processor uses this JSON configuration:
+
 	{
 		"type": "count"
 	}
@@ -18,10 +19,10 @@ When loaded with a factory, the processor uses this JSON configuration:
 type Count struct{}
 
 // ApplyBatch processes a slice of encapsulated data with the Count processor. Conditions are optionally applied to the data to enable processing.
-func (p Count) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.Capsule, error) {
+func (p Count) ApplyBatch(ctx context.Context, capsules []config.Capsule) ([]config.Capsule, error) {
 	newCap := config.NewCapsule()
-	if err := newCap.Set("count", len(caps)); err != nil {
-		return caps, fmt.Errorf("process count: : %v", err)
+	if err := newCap.Set("count", len(capsules)); err != nil {
+		return capsules, fmt.Errorf("process count: : %v", err)
 	}
 
 	newCaps := make([]config.Capsule, 0, 1)

--- a/process/count.go
+++ b/process/count.go
@@ -20,12 +20,12 @@ type Count struct{}
 
 // ApplyBatch processes a slice of encapsulated data with the Count processor. Conditions are optionally applied to the data to enable processing.
 func (p Count) ApplyBatch(ctx context.Context, capsules []config.Capsule) ([]config.Capsule, error) {
-	newCap := config.NewCapsule()
-	if err := newCap.Set("count", len(capsules)); err != nil {
+	newCapsule := config.NewCapsule()
+	if err := newCapsule.Set("count", len(capsules)); err != nil {
 		return capsules, fmt.Errorf("process count: : %v", err)
 	}
 
-	newCaps := make([]config.Capsule, 0, 1)
-	newCaps = append(newCaps, newCap)
-	return newCaps, nil
+	newCapsules := make([]config.Capsule, 0, 1)
+	newCapsules = append(newCapsules, newCapsule)
+	return newCapsules, nil
 }

--- a/process/count_test.go
+++ b/process/count_test.go
@@ -30,48 +30,46 @@ var countTests = []struct {
 
 func TestCount(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 
 	for _, test := range countTests {
-		var caps []config.Capsule
+		var capsules []config.Capsule
 		for _, t := range test.test {
-			cap.SetData(t)
-			caps = append(caps, cap)
+			capsule.SetData(t)
+			capsules = append(capsules, capsule)
 		}
 
-		result, err := test.proc.ApplyBatch(ctx, caps)
+		result, err := test.proc.ApplyBatch(ctx, capsules)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		count := result[0].Data()
 		if !bytes.Equal(count, test.expected) {
-			t.Logf("expected %s, got %s", test.expected, count)
-			t.Fail()
+			t.Errorf("expected %s, got %s", test.expected, count)
 		}
 	}
 }
 
-func benchmarkCount(b *testing.B, applicator Count, caps []config.Capsule) {
+func benchmarkCount(b *testing.B, applicator Count, capsules []config.Capsule) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
-		applicator.ApplyBatch(ctx, caps)
+		_, _ = applicator.ApplyBatch(ctx, capsules)
 	}
 }
 
 func BenchmarkCount(b *testing.B) {
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range countTests {
-		var caps []config.Capsule
+		var capsules []config.Capsule
 		for _, t := range test.test {
-			cap.SetData(t)
-			caps = append(caps, cap)
+			capsule.SetData(t)
+			capsules = append(capsules, capsule)
 		}
 
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				benchmarkCount(b, test.proc, caps)
+				benchmarkCount(b, test.proc, capsules)
 			},
 		)
 	}

--- a/process/delete.go
+++ b/process/delete.go
@@ -10,10 +10,12 @@ import (
 
 /*
 Delete processes data by deleting JSON keys. The processor supports these patterns:
+
 	JSON:
 	  	{"foo":"bar","baz":"qux"} >>> {"foo":"bar"}
 
 When loaded with a factory, the processor uses this JSON configuration:
+
 	{
 		"type": "delete",
 		"settings": {
@@ -27,31 +29,30 @@ type Delete struct {
 }
 
 // ApplyBatch processes a slice of encapsulated data with the Delete processor. Conditions are optionally applied to the data to enable processing.
-func (p Delete) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.Capsule, error) {
+func (p Delete) ApplyBatch(ctx context.Context, capsules []config.Capsule) ([]config.Capsule, error) {
 	op, err := condition.OperatorFactory(p.Condition)
 	if err != nil {
 		return nil, fmt.Errorf("process delete: %v", err)
 	}
 
-	caps, err = conditionallyApplyBatch(ctx, caps, op, p)
+	capsules, err = conditionallyApplyBatch(ctx, capsules, op, p)
 	if err != nil {
 		return nil, fmt.Errorf("process delete: %v", err)
 	}
 
-	return caps, nil
-
+	return capsules, nil
 }
 
 // Apply processes encapsulated data with the Delete processor.
-func (p Delete) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, error) {
+func (p Delete) Apply(ctx context.Context, capsule config.Capsule) (config.Capsule, error) {
 	// only supports JSON, error early if there are no keys
 	if p.InputKey == "" {
-		return cap, fmt.Errorf("process delete: inputkey %s: %v", p.InputKey, errInvalidDataPattern)
+		return capsule, fmt.Errorf("process delete: inputkey %s: %v", p.InputKey, errInvalidDataPattern)
 	}
 
-	if err := cap.Delete(p.InputKey); err != nil {
-		return cap, fmt.Errorf("process delete: %v", err)
+	if err := capsule.Delete(p.InputKey); err != nil {
+		return capsule, fmt.Errorf("process delete: %v", err)
 	}
 
-	return cap, nil
+	return capsule, nil
 }

--- a/process/delete_test.go
+++ b/process/delete_test.go
@@ -37,20 +37,18 @@ var deleteTests = []struct {
 
 func TestDelete(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 
 	for _, test := range convertTests {
-		cap.SetData(test.test)
+		capsule.SetData(test.test)
 
-		result, err := test.proc.Apply(ctx, cap)
+		result, err := test.proc.Apply(ctx, capsule)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		if !bytes.Equal(result.Data(), test.expected) {
-			t.Logf("expected %s, got %s", test.expected, result.Data())
-			t.Fail()
+			t.Errorf("expected %s, got %s", test.expected, result.Data())
 		}
 	}
 }
@@ -58,17 +56,17 @@ func TestDelete(t *testing.T) {
 func benchmarkDelete(b *testing.B, applicator Delete, test config.Capsule) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
-		applicator.Apply(ctx, test)
+		_, _ = applicator.Apply(ctx, test)
 	}
 }
 
 func BenchmarkDelete(b *testing.B) {
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range deleteTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				cap.SetData(test.test)
-				benchmarkDelete(b, test.proc, cap)
+				capsule.SetData(test.test)
+				benchmarkDelete(b, test.proc, capsule)
 			},
 		)
 	}

--- a/process/domain_test.go
+++ b/process/domain_test.go
@@ -83,20 +83,18 @@ var domainTests = []struct {
 
 func TestDomain(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 
 	for _, test := range domainTests {
-		cap.SetData(test.test)
+		capsule.SetData(test.test)
 
-		result, err := test.proc.Apply(ctx, cap)
+		result, err := test.proc.Apply(ctx, capsule)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		if !bytes.Equal(result.Data(), test.expected) {
-			t.Logf("expected %s, got %s", test.expected, result.Data())
-			t.Fail()
+			t.Errorf("expected %s, got %s", test.expected, result.Data())
 		}
 	}
 }
@@ -104,17 +102,17 @@ func TestDomain(t *testing.T) {
 func benchmarkDomain(b *testing.B, applicator Domain, test config.Capsule) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
-		applicator.Apply(ctx, test)
+		_, _ = applicator.Apply(ctx, test)
 	}
 }
 
 func BenchmarkDomain(b *testing.B) {
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range domainTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				cap.SetData(test.test)
-				benchmarkDomain(b, test.proc, cap)
+				capsule.SetData(test.test)
+				benchmarkDomain(b, test.proc, capsule)
 			},
 		)
 	}

--- a/process/drop.go
+++ b/process/drop.go
@@ -12,6 +12,7 @@ import (
 Drop processes data by "dropping" it -- the data is entirely removed and not emitted.
 
 When loaded with a factory, the processor uses this JSON configuration:
+
 	{
 		type: "drop"
 	}
@@ -21,21 +22,21 @@ type Drop struct {
 }
 
 // ApplyBatch processes a slice of encapsulated data with the Drop processor. Conditions are optionally applied to the data to enable processing.
-func (p Drop) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.Capsule, error) {
+func (p Drop) ApplyBatch(ctx context.Context, capsules []config.Capsule) ([]config.Capsule, error) {
 	op, err := condition.OperatorFactory(p.Condition)
 	if err != nil {
 		return nil, fmt.Errorf("process drop: %v", err)
 	}
 
-	newCaps := newBatch(&caps)
-	for _, cap := range caps {
-		ok, err := op.Operate(ctx, cap)
+	newCaps := newBatch(&capsules)
+	for _, capsule := range capsules {
+		ok, err := op.Operate(ctx, capsule)
 		if err != nil {
 			return nil, fmt.Errorf("process drop: %v", err)
 		}
 
 		if !ok {
-			newCaps = append(newCaps, cap)
+			newCaps = append(newCaps, capsule)
 			continue
 		}
 	}

--- a/process/drop.go
+++ b/process/drop.go
@@ -28,7 +28,7 @@ func (p Drop) ApplyBatch(ctx context.Context, capsules []config.Capsule) ([]conf
 		return nil, fmt.Errorf("process drop: %v", err)
 	}
 
-	newCaps := newBatch(&capsules)
+	newCapsules := newBatch(&capsules)
 	for _, capsule := range capsules {
 		ok, err := op.Operate(ctx, capsule)
 		if err != nil {
@@ -36,10 +36,10 @@ func (p Drop) ApplyBatch(ctx context.Context, capsules []config.Capsule) ([]conf
 		}
 
 		if !ok {
-			newCaps = append(newCaps, capsule)
+			newCapsules = append(newCapsules, capsule)
 			continue
 		}
 	}
 
-	return newCaps, nil
+	return newCapsules, nil
 }

--- a/process/drop_test.go
+++ b/process/drop_test.go
@@ -27,48 +27,46 @@ var dropTests = []struct {
 
 func TestDrop(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 
 	for _, test := range dropTests {
-		var caps []config.Capsule
+		var capsules []config.Capsule
 		for _, t := range test.test {
-			cap.SetData(t)
-			caps = append(caps, cap)
+			capsule.SetData(t)
+			capsules = append(capsules, capsule)
 		}
 
-		result, err := test.proc.ApplyBatch(ctx, caps)
+		result, err := test.proc.ApplyBatch(ctx, capsules)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		length := len(result)
 		if length != 0 {
-			t.Logf("got %d", length)
-			t.Fail()
+			t.Errorf("got %d", length)
 		}
 	}
 }
 
-func benchmarkDrop(b *testing.B, applicator Drop, caps []config.Capsule) {
+func benchmarkDrop(b *testing.B, applicator Drop, capsules []config.Capsule) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
-		applicator.ApplyBatch(ctx, caps)
+		_, _ = applicator.ApplyBatch(ctx, capsules)
 	}
 }
 
 func BenchmarkDrop(b *testing.B) {
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range dropTests {
-		var caps []config.Capsule
+		var capsules []config.Capsule
 		for _, t := range test.test {
-			cap.SetData(t)
-			caps = append(caps, cap)
+			capsule.SetData(t)
+			capsules = append(capsules, capsule)
 		}
 
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				benchmarkDrop(b, test.proc, caps)
+				benchmarkDrop(b, test.proc, capsules)
 			},
 		)
 	}

--- a/process/dynamodb_test.go
+++ b/process/dynamodb_test.go
@@ -61,21 +61,19 @@ var dynamodbTests = []struct {
 
 func TestDynamoDB(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 
 	for _, test := range dynamodbTests {
 		dynamodbAPI = test.api
-		cap.SetData(test.test)
+		capsule.SetData(test.test)
 
-		result, err := test.proc.Apply(ctx, cap)
+		result, err := test.proc.Apply(ctx, capsule)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		if !bytes.Equal(result.Data(), test.expected) {
-			t.Logf("expected %s, got %s", test.expected, result.Data())
-			t.Fail()
+			t.Errorf("expected %s, got %s", test.expected, result.Data())
 		}
 	}
 }
@@ -83,18 +81,18 @@ func TestDynamoDB(t *testing.T) {
 func benchmarkDynamoDB(b *testing.B, applicator DynamoDB, test config.Capsule) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
-		applicator.Apply(ctx, test)
+		_, _ = applicator.Apply(ctx, test)
 	}
 }
 
 func BenchmarkDynamoDB(b *testing.B) {
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range dynamodbTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
 				dynamodbAPI = test.api
-				cap.SetData(test.test)
-				benchmarkDynamoDB(b, test.proc, cap)
+				capsule.SetData(test.test)
+				benchmarkDynamoDB(b, test.proc, capsule)
 			},
 		)
 	}

--- a/process/expand.go
+++ b/process/expand.go
@@ -38,7 +38,7 @@ func (p Expand) ApplyBatch(ctx context.Context, capsules []config.Capsule) ([]co
 		return nil, fmt.Errorf("process expand: %v", err)
 	}
 
-	newCaps := newBatch(&capsules)
+	newCapsules := newBatch(&capsules)
 	for _, capsule := range capsules {
 		ok, err := op.Operate(ctx, capsule)
 		if err != nil {
@@ -46,7 +46,7 @@ func (p Expand) ApplyBatch(ctx context.Context, capsules []config.Capsule) ([]co
 		}
 
 		if !ok {
-			newCaps = append(newCaps, capsule)
+			newCapsules = append(newCapsules, capsule)
 			continue
 		}
 
@@ -78,7 +78,7 @@ func (p Expand) ApplyBatch(ctx context.Context, capsules []config.Capsule) ([]co
 		}
 
 		// retains metadata from the original capsule
-		newCap := capsule
+		newCapsule := capsule
 		for _, res := range result.Array() {
 			var err error
 
@@ -94,10 +94,10 @@ func (p Expand) ApplyBatch(ctx context.Context, capsules []config.Capsule) ([]co
 				}
 			}
 
-			newCap.SetData(expand)
-			newCaps = append(newCaps, newCap)
+			newCapsule.SetData(expand)
+			newCapsules = append(newCapsules, newCapsule)
 		}
 	}
 
-	return newCaps, nil
+	return newCapsules, nil
 }

--- a/process/expand_test.go
+++ b/process/expand_test.go
@@ -52,24 +52,22 @@ var expandTests = []struct {
 
 func TestExpand(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 
 	for _, test := range expandTests {
 		slice := make([]config.Capsule, 1)
-		cap.SetData(test.test)
-		slice[0] = cap
+		capsule.SetData(test.test)
+		slice[0] = capsule
 
 		result, err := test.proc.ApplyBatch(ctx, slice)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		for i, res := range result {
 			expected := test.expected[i]
 			if !bytes.Equal(expected, res.Data()) {
-				t.Logf("expected %s, got %s", expected, res)
-				t.Fail()
+				t.Errorf("expected %s, got %s", expected, res)
 			}
 		}
 	}
@@ -78,18 +76,18 @@ func TestExpand(t *testing.T) {
 func benchmarkExpand(b *testing.B, slicer Expand, slice []config.Capsule) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
-		slicer.ApplyBatch(ctx, slice)
+		_, _ = slicer.ApplyBatch(ctx, slice)
 	}
 }
 
 func BenchmarkExpand(b *testing.B) {
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range expandTests {
 		slice := make([]config.Capsule, 1)
-		cap.SetData(test.test)
-		slice[0] = cap
+		capsule.SetData(test.test)
+		slice[0] = capsule
 
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
 				benchmarkExpand(b, test.proc, slice)
 			},

--- a/process/flatten.go
+++ b/process/flatten.go
@@ -10,10 +10,12 @@ import (
 
 /*
 Flatten processes data by flattening JSON arrays. The processor supports these patterns:
+
 	JSON:
 		{"flatten":["foo",["bar"]]} >>> {"flatten":["foo","bar"]}
 
 When loaded with a factory, the processor uses this JSON configuration:
+
 	{
 		"type": "flatten",
 		"settings": {
@@ -31,6 +33,7 @@ type Flatten struct {
 
 /*
 FlattenOptions contains custom options settings for the Flatten processor:
+
 	Deep (optional):
 		deeply flattens nested arrays
 */
@@ -39,37 +42,37 @@ type FlattenOptions struct {
 }
 
 // ApplyBatch processes a slice of encapsulated data with the Flatten processor. Conditions are optionally applied to the data to enable processing.
-func (p Flatten) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.Capsule, error) {
+func (p Flatten) ApplyBatch(ctx context.Context, capsules []config.Capsule) ([]config.Capsule, error) {
 	op, err := condition.OperatorFactory(p.Condition)
 	if err != nil {
 		return nil, fmt.Errorf("process flatten: %v", err)
 	}
 
-	caps, err = conditionallyApplyBatch(ctx, caps, op, p)
+	capsules, err = conditionallyApplyBatch(ctx, capsules, op, p)
 	if err != nil {
 		return nil, fmt.Errorf("process flatten: %v", err)
 	}
 
-	return caps, nil
+	return capsules, nil
 }
 
 // Apply processes encapsulated data with the Flatten processor.
-func (p Flatten) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, error) {
+func (p Flatten) Apply(ctx context.Context, capsule config.Capsule) (config.Capsule, error) {
 	// only supports JSON, error early if there are no keys
 	if p.InputKey == "" && p.OutputKey == "" {
-		return cap, fmt.Errorf("process flatten: inputkey %s outputkey %s: %v", p.InputKey, p.OutputKey, errInvalidDataPattern)
+		return capsule, fmt.Errorf("process flatten: inputkey %s outputkey %s: %v", p.InputKey, p.OutputKey, errInvalidDataPattern)
 	}
 
 	var value interface{}
 	if p.Options.Deep {
-		value = cap.Get(p.InputKey + `|@flatten:{"deep":true}`)
+		value = capsule.Get(p.InputKey + `|@flatten:{"deep":true}`)
 	} else {
-		value = cap.Get(p.InputKey + `|@flatten`)
+		value = capsule.Get(p.InputKey + `|@flatten`)
 	}
 
-	if err := cap.Set(p.OutputKey, value); err != nil {
-		return cap, fmt.Errorf("process flatten: %v", err)
+	if err := capsule.Set(p.OutputKey, value); err != nil {
+		return capsule, fmt.Errorf("process flatten: %v", err)
 	}
 
-	return cap, nil
+	return capsule, nil
 }

--- a/process/flatten_test.go
+++ b/process/flatten_test.go
@@ -42,20 +42,18 @@ var flattenTests = []struct {
 
 func TestFlatten(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 
 	for _, test := range flattenTests {
-		cap.SetData(test.test)
+		capsule.SetData(test.test)
 
-		result, err := test.proc.Apply(ctx, cap)
+		result, err := test.proc.Apply(ctx, capsule)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		if !bytes.Equal(result.Data(), test.expected) {
-			t.Logf("expected %s, got %s", test.expected, result.Data())
-			t.Fail()
+			t.Errorf("expected %s, got %s", test.expected, result.Data())
 		}
 	}
 }
@@ -63,17 +61,17 @@ func TestFlatten(t *testing.T) {
 func benchmarkFlatten(b *testing.B, applicator Flatten, test config.Capsule) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
-		applicator.Apply(ctx, test)
+		_, _ = applicator.Apply(ctx, test)
 	}
 }
 
 func BenchmarkFlatten(b *testing.B) {
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range flattenTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				cap.SetData(test.test)
-				benchmarkFlatten(b, test.proc, cap)
+				capsule.SetData(test.test)
+				benchmarkFlatten(b, test.proc, capsule)
 			},
 		)
 	}

--- a/process/for_each_test.go
+++ b/process/for_each_test.go
@@ -321,20 +321,18 @@ var foreachTests = []struct {
 
 func TestForEach(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 
 	for _, test := range foreachTests {
-		cap.SetData(test.test)
+		capsule.SetData(test.test)
 
-		result, err := test.proc.Apply(ctx, cap)
+		result, err := test.proc.Apply(ctx, capsule)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		if !bytes.Equal(result.Data(), test.expected) {
-			t.Logf("expected %s, got %s", test.expected, result.Data())
-			t.Fail()
+			t.Errorf("expected %s, got %s", test.expected, result.Data())
 		}
 	}
 }
@@ -342,17 +340,17 @@ func TestForEach(t *testing.T) {
 func benchmarkForEach(b *testing.B, applicator ForEach, test config.Capsule) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
-		applicator.Apply(ctx, test)
+		_, _ = applicator.Apply(ctx, test)
 	}
 }
 
 func BenchmarkForEach(b *testing.B) {
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range foreachTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				cap.SetData(test.test)
-				benchmarkForEach(b, test.proc, cap)
+				capsule.SetData(test.test)
+				benchmarkForEach(b, test.proc, capsule)
 			},
 		)
 	}

--- a/process/group_test.go
+++ b/process/group_test.go
@@ -42,20 +42,18 @@ var groupTests = []struct {
 
 func TestGroup(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 
 	for _, test := range groupTests {
-		cap.SetData(test.test)
+		capsule.SetData(test.test)
 
-		result, err := test.proc.Apply(ctx, cap)
+		result, err := test.proc.Apply(ctx, capsule)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		if !bytes.Equal(result.Data(), test.expected) {
-			t.Logf("expected %s, got %s", test.expected, result.Data())
-			t.Fail()
+			t.Errorf("expected %s, got %s", test.expected, result.Data())
 		}
 	}
 }
@@ -63,17 +61,17 @@ func TestGroup(t *testing.T) {
 func benchmarkGroup(b *testing.B, applicator Group, test config.Capsule) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
-		applicator.Apply(ctx, test)
+		_, _ = applicator.Apply(ctx, test)
 	}
 }
 
 func BenchmarkGroup(b *testing.B) {
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range groupTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				cap.SetData(test.test)
-				benchmarkGroup(b, test.proc, cap)
+				capsule.SetData(test.test)
+				benchmarkGroup(b, test.proc, capsule)
 			},
 		)
 	}

--- a/process/gzip_test.go
+++ b/process/gzip_test.go
@@ -41,20 +41,18 @@ var gzipTests = []struct {
 
 func TestGzip(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 
 	for _, test := range gzipTests {
-		cap.SetData(test.test)
+		capsule.SetData(test.test)
 
-		result, err := test.proc.Apply(ctx, cap)
+		result, err := test.proc.Apply(ctx, capsule)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		if !bytes.Equal(result.Data(), test.expected) {
-			t.Logf("expected %s, got %s", test.expected, result.Data())
-			t.Fail()
+			t.Errorf("expected %s, got %s", test.expected, result.Data())
 		}
 	}
 }
@@ -62,17 +60,17 @@ func TestGzip(t *testing.T) {
 func benchmarkGzip(b *testing.B, applicator Gzip, test config.Capsule) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
-		applicator.Apply(ctx, test)
+		_, _ = applicator.Apply(ctx, test)
 	}
 }
 
 func BenchmarkGzip(b *testing.B) {
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range gzipTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				cap.SetData(test.test)
-				benchmarkGzip(b, test.proc, cap)
+				capsule.SetData(test.test)
+				benchmarkGzip(b, test.proc, capsule)
 			},
 		)
 	}

--- a/process/hash_test.go
+++ b/process/hash_test.go
@@ -80,20 +80,18 @@ var hashTests = []struct {
 
 func TestHash(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 
 	for _, test := range hashTests {
-		cap.SetData(test.test)
+		capsule.SetData(test.test)
 
-		result, err := test.proc.Apply(ctx, cap)
+		result, err := test.proc.Apply(ctx, capsule)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		if !bytes.Equal(result.Data(), test.expected) {
-			t.Logf("expected %s, got %s", test.expected, result.Data())
-			t.Fail()
+			t.Errorf("expected %s, got %s", test.expected, result.Data())
 		}
 	}
 }
@@ -101,17 +99,17 @@ func TestHash(t *testing.T) {
 func benchmarkHash(b *testing.B, applicator Hash, test config.Capsule) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
-		applicator.Apply(ctx, test)
+		_, _ = applicator.Apply(ctx, test)
 	}
 }
 
 func BenchmarkHash(b *testing.B) {
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range hashTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				cap.SetData(test.test)
-				benchmarkHash(b, test.proc, cap)
+				capsule.SetData(test.test)
+				benchmarkHash(b, test.proc, capsule)
 			},
 		)
 	}

--- a/process/insert.go
+++ b/process/insert.go
@@ -10,10 +10,12 @@ import (
 
 /*
 Insert processes data by inserting a value into a JSON object. The processor supports these patterns:
+
 	JSON:
 		{"foo":"bar"} >>> {"foo":"bar","baz":"qux"}
 
 When loaded with a factory, the processor uses this JSON configuration:
+
 	{
 		"type": "insert",
 		"settings": {
@@ -32,6 +34,7 @@ type Insert struct {
 
 /*
 InsertOptions contains custom options for the Insert processor:
+
 	value:
 		value to insert
 */
@@ -40,30 +43,30 @@ type InsertOptions struct {
 }
 
 // ApplyBatch processes a slice of encapsulated data with the Insert processor. Conditions are optionally applied to the data to enable processing.
-func (p Insert) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.Capsule, error) {
+func (p Insert) ApplyBatch(ctx context.Context, capsules []config.Capsule) ([]config.Capsule, error) {
 	op, err := condition.OperatorFactory(p.Condition)
 	if err != nil {
 		return nil, fmt.Errorf("process insert: %v", err)
 	}
 
-	caps, err = conditionallyApplyBatch(ctx, caps, op, p)
+	capsules, err = conditionallyApplyBatch(ctx, capsules, op, p)
 	if err != nil {
 		return nil, fmt.Errorf("process insert: %v", err)
 	}
 
-	return caps, nil
+	return capsules, nil
 }
 
 // Apply processes encapsulated data with the Insert processor.
-func (p Insert) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, error) {
+func (p Insert) Apply(ctx context.Context, capsule config.Capsule) (config.Capsule, error) {
 	// only supports JSON, error early if there are no keys
 	if p.OutputKey == "" {
-		return cap, fmt.Errorf("process insert: outputkey %s: %v", p.OutputKey, errInvalidDataPattern)
+		return capsule, fmt.Errorf("process insert: outputkey %s: %v", p.OutputKey, errInvalidDataPattern)
 	}
 
-	if err := cap.Set(p.OutputKey, p.Options.Value); err != nil {
-		return cap, fmt.Errorf("process insert: %v", err)
+	if err := capsule.Set(p.OutputKey, p.Options.Value); err != nil {
+		return capsule, fmt.Errorf("process insert: %v", err)
 	}
 
-	return cap, nil
+	return capsule, nil
 }

--- a/process/insert_test.go
+++ b/process/insert_test.go
@@ -105,20 +105,18 @@ var insertTests = []struct {
 
 func TestInsert(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 
 	for _, test := range insertTests {
-		cap.SetData(test.test)
+		capsule.SetData(test.test)
 
-		result, err := test.proc.Apply(ctx, cap)
+		result, err := test.proc.Apply(ctx, capsule)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		if !bytes.Equal(result.Data(), test.expected) {
-			t.Logf("expected %s, got %s", test.expected, result.Data())
-			t.Fail()
+			t.Errorf("expected %s, got %s", test.expected, result.Data())
 		}
 	}
 }
@@ -126,17 +124,17 @@ func TestInsert(t *testing.T) {
 func benchmarkInsert(b *testing.B, applicator Insert, test config.Capsule) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
-		applicator.Apply(ctx, test)
+		_, _ = applicator.Apply(ctx, test)
 	}
 }
 
 func BenchmarkInsert(b *testing.B) {
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range insertTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				cap.SetData(test.test)
-				benchmarkInsert(b, test.proc, cap)
+				capsule.SetData(test.test)
+				benchmarkInsert(b, test.proc, capsule)
 			},
 		)
 	}

--- a/process/lambda_test.go
+++ b/process/lambda_test.go
@@ -54,21 +54,19 @@ var lambdaTests = []struct {
 
 func TestLambda(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 
 	for _, test := range lambdaTests {
 		lambdaAPI = test.api
-		cap.SetData(test.test)
+		capsule.SetData(test.test)
 
-		result, err := test.proc.Apply(ctx, cap)
+		result, err := test.proc.Apply(ctx, capsule)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		if !bytes.Equal(result.Data(), test.expected) {
-			t.Logf("expected %s, got %s", test.expected, result.Data())
-			t.Fail()
+			t.Errorf("expected %s, got %s", test.expected, result.Data())
 		}
 	}
 }
@@ -76,17 +74,17 @@ func TestLambda(t *testing.T) {
 func benchmarkLambda(b *testing.B, applicator Lambda, test config.Capsule) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
-		applicator.Apply(ctx, test)
+		_, _ = applicator.Apply(ctx, test)
 	}
 }
 
 func BenchmarkLambda(b *testing.B) {
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range lambdaTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				cap.SetData(test.test)
-				benchmarkLambda(b, test.proc, cap)
+				capsule.SetData(test.test)
+				benchmarkLambda(b, test.proc, capsule)
 			},
 		)
 	}

--- a/process/math_test.go
+++ b/process/math_test.go
@@ -71,20 +71,18 @@ var mathTests = []struct {
 
 func TestMath(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 
 	for _, test := range mathTests {
-		cap.SetData(test.test)
+		capsule.SetData(test.test)
 
-		result, err := test.proc.Apply(ctx, cap)
+		result, err := test.proc.Apply(ctx, capsule)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		if !bytes.Equal(result.Data(), test.expected) {
-			t.Logf("expected %s, got %s", test.expected, result.Data())
-			t.Fail()
+			t.Errorf("expected %s, got %s", test.expected, result.Data())
 		}
 	}
 }
@@ -92,17 +90,17 @@ func TestMath(t *testing.T) {
 func benchmarkMath(b *testing.B, applicator Math, test config.Capsule) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
-		applicator.Apply(ctx, test)
+		_, _ = applicator.Apply(ctx, test)
 	}
 }
 
 func BenchmarkMath(b *testing.B) {
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range mathTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				cap.SetData(test.test)
-				benchmarkMath(b, test.proc, cap)
+				capsule.SetData(test.test)
+				benchmarkMath(b, test.proc, capsule)
 			},
 		)
 	}

--- a/process/pipeline.go
+++ b/process/pipeline.go
@@ -107,15 +107,15 @@ func (p Pipeline) Apply(ctx context.Context, capsule config.Capsule) (config.Cap
 			return capsule, fmt.Errorf("process pipeline: inputkey %s: %v", p.InputKey, errPipelineArrayInput)
 		}
 
-		newCap := config.NewCapsule()
-		newCap.SetData([]byte(result.String()))
+		newCapsule := config.NewCapsule()
+		newCapsule.SetData([]byte(result.String()))
 
-		newCap, err = Apply(ctx, newCap, applicators...)
+		newCapsule, err = Apply(ctx, newCapsule, applicators...)
 		if err != nil {
 			return capsule, fmt.Errorf("process pipeline: %v", err)
 		}
 
-		if err := capsule.Set(p.OutputKey, newCap.Data()); err != nil {
+		if err := capsule.Set(p.OutputKey, newCapsule.Data()); err != nil {
 			return capsule, fmt.Errorf("process pipeline: %v", err)
 		}
 

--- a/process/pipeline_test.go
+++ b/process/pipeline_test.go
@@ -77,20 +77,18 @@ var PipelineTests = []struct {
 
 func TestPipeline(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 
 	for _, test := range PipelineTests {
-		cap.SetData(test.test)
+		capsule.SetData(test.test)
 
-		result, err := test.proc.Apply(ctx, cap)
+		result, err := test.proc.Apply(ctx, capsule)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		if !bytes.Equal(result.Data(), test.expected) {
-			t.Logf("expected %s, got %s", test.expected, result.Data())
-			t.Fail()
+			t.Errorf("expected %s, got %s", test.expected, result.Data())
 		}
 	}
 }
@@ -98,17 +96,17 @@ func TestPipeline(t *testing.T) {
 func benchmarkPipeline(b *testing.B, applicator Pipeline, test config.Capsule) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
-		applicator.Apply(ctx, test)
+		_, _ = applicator.Apply(ctx, test)
 	}
 }
 
 func BenchmarkPipeline(b *testing.B) {
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range PipelineTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				cap.SetData(test.test)
-				benchmarkPipeline(b, test.proc, cap)
+				capsule.SetData(test.test)
+				benchmarkPipeline(b, test.proc, capsule)
 			},
 		)
 	}

--- a/process/pretty_print.go
+++ b/process/pretty_print.go
@@ -107,7 +107,7 @@ func (p PrettyPrint) ApplyBatch(ctx context.Context, capsules []config.Capsule) 
 	var count int
 	var stack []byte
 
-	newCaps := newBatch(&capsules)
+	newCapsules := newBatch(&capsules)
 	for _, capsule := range capsules {
 		ok, err := op.Operate(ctx, capsule)
 		if err != nil {
@@ -115,7 +115,7 @@ func (p PrettyPrint) ApplyBatch(ctx context.Context, capsules []config.Capsule) 
 		}
 
 		if !ok {
-			newCaps = append(newCaps, capsule)
+			newCapsules = append(newCapsules, capsule)
 			continue
 		}
 
@@ -123,7 +123,7 @@ func (p PrettyPrint) ApplyBatch(ctx context.Context, capsules []config.Capsule) 
 		case "to":
 			result := capsule.Get(ppModifier).String()
 			capsule.SetData([]byte(result))
-			newCaps = append(newCaps, capsule)
+			newCapsules = append(newCapsules, capsule)
 
 		case "from":
 			for _, data := range capsule.Data() {
@@ -144,9 +144,9 @@ func (p PrettyPrint) ApplyBatch(ctx context.Context, capsules []config.Capsule) 
 					}
 
 					if json.Valid(buf.Bytes()) {
-						newCap := config.NewCapsule()
-						newCap.SetData(buf.Bytes())
-						newCaps = append(newCaps, newCap)
+						newCapsule := config.NewCapsule()
+						newCapsule.SetData(buf.Bytes())
+						newCapsules = append(newCapsules, newCapsule)
 					}
 
 					stack = []byte{}
@@ -162,7 +162,7 @@ func (p PrettyPrint) ApplyBatch(ctx context.Context, capsules []config.Capsule) 
 		return nil, fmt.Errorf("process pretty_print: %d characters remain: %v", count, errPrettyPrintIncompleteJSON)
 	}
 
-	return newCaps, nil
+	return newCapsules, nil
 }
 
 /*

--- a/process/pretty_print.go
+++ b/process/pretty_print.go
@@ -31,14 +31,15 @@ const errPrettyPrintIncompleteJSON = errors.Error("incomplete JSON object")
 /*
 PrettyPrint processes data by applying or reversing prettyprint formatting to JSON.
 This processor has significant limitations when used to reverse prettyprint, including:
-	- cannot support multi-core processing
-	- invalid input will cause unpredictable results
+  - cannot support multi-core processing
+  - invalid input will cause unpredictable results
 
 It is strongly recommended to _not_ use this processor unless absolutely necessary; a
 more reliable solution is to modify the source application emitting the multi-line JSON
 object so that it outputs a single-line object instead.
 
 The processor supports these patterns:
+
 	data:
 		{
 			"foo": "bar"
@@ -49,6 +50,7 @@ The processor supports these patterns:
 		}
 
 When loaded with a factory, the processor uses this JSON configuration:
+
 	{
 		"type": "pretty_print",
 		"settings": {
@@ -65,6 +67,7 @@ type PrettyPrint struct {
 
 /*
 PrettyPrintOptions contains custom options settings for the PrettyPrint processor:
+
 	Direction:
 		direction of the pretty transformation
 		must be one of:
@@ -90,7 +93,7 @@ and close curly brackets ( { } ) are observed,
 then the stack of bytes has JSON compaction
 applied and the result is emitted as a new object.
 */
-func (p PrettyPrint) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.Capsule, error) {
+func (p PrettyPrint) ApplyBatch(ctx context.Context, capsules []config.Capsule) ([]config.Capsule, error) {
 	// error early if required options are missing
 	if p.Options.Direction == "" {
 		return nil, fmt.Errorf("process pretty_print: options %+v: %v", p.Options, errMissingRequiredOptions)
@@ -104,26 +107,26 @@ func (p PrettyPrint) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]c
 	var count int
 	var stack []byte
 
-	newCaps := newBatch(&caps)
-	for _, cap := range caps {
-		ok, err := op.Operate(ctx, cap)
+	newCaps := newBatch(&capsules)
+	for _, capsule := range capsules {
+		ok, err := op.Operate(ctx, capsule)
 		if err != nil {
 			return nil, fmt.Errorf("process pretty_print: %v", err)
 		}
 
 		if !ok {
-			newCaps = append(newCaps, cap)
+			newCaps = append(newCaps, capsule)
 			continue
 		}
 
 		switch p.Options.Direction {
 		case "to":
-			result := cap.Get(ppModifier).String()
-			cap.SetData([]byte(result))
-			newCaps = append(newCaps, cap)
+			result := capsule.Get(ppModifier).String()
+			capsule.SetData([]byte(result))
+			newCaps = append(newCaps, capsule)
 
 		case "from":
-			for _, data := range cap.Data() {
+			for _, data := range capsule.Data() {
 				stack = append(stack, data)
 
 				if data == ppOpenCurlyBracket {
@@ -174,17 +177,17 @@ This _does not_ support reversing prettyprint formatting;
 this support is unnecessary for multi-line JSON objects
 that are stored in a single byte array.
 */
-func (p PrettyPrint) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, error) {
+func (p PrettyPrint) Apply(ctx context.Context, capsule config.Capsule) (config.Capsule, error) {
 	// error early if required options are missing
 	if p.Options.Direction == "" {
-		return cap, fmt.Errorf("process pretty_print: options %+v: %v", p.Options, errMissingRequiredOptions)
+		return capsule, fmt.Errorf("process pretty_print: options %+v: %v", p.Options, errMissingRequiredOptions)
 	}
 
 	switch p.Options.Direction {
 	case "to":
-		cap.SetData([]byte(cap.Get(ppModifier).String()))
-		return cap, nil
+		capsule.SetData([]byte(capsule.Get(ppModifier).String()))
+		return capsule, nil
 	default:
-		return cap, fmt.Errorf("process pretty_print: direction %s: %v", p.Options.Direction, errInvalidDirection)
+		return capsule, fmt.Errorf("process pretty_print: direction %s: %v", p.Options.Direction, errInvalidDirection)
 	}
 }

--- a/process/pretty_print_test.go
+++ b/process/pretty_print_test.go
@@ -76,48 +76,46 @@ func TestPrettyPrintBatch(t *testing.T) {
 	ctx := context.TODO()
 
 	for _, test := range prettyPrintBatchTests {
-		var caps []config.Capsule
-		cap := config.NewCapsule()
+		var capsules []config.Capsule
+		capsule := config.NewCapsule()
 		for _, t := range test.test {
-			cap.SetData(t)
-			caps = append(caps, cap)
+			capsule.SetData(t)
+			capsules = append(capsules, capsule)
 		}
 
-		result, err := test.proc.ApplyBatch(ctx, caps)
+		result, err := test.proc.ApplyBatch(ctx, capsules)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		for i, res := range result {
 			expected := test.expected[i]
 			if !bytes.Equal(expected, res.Data()) {
-				t.Logf("expected %s, got %s", expected, res)
-				t.Fail()
+				t.Errorf("expected %s, got %s", expected, res.Data())
 			}
 		}
 	}
 }
 
-func benchmarkPrettyPrintBatch(b *testing.B, batcher PrettyPrint, caps []config.Capsule) {
+func benchmarkPrettyPrintBatch(b *testing.B, batcher PrettyPrint, capsules []config.Capsule) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
-		batcher.ApplyBatch(ctx, caps)
+		_, _ = batcher.ApplyBatch(ctx, capsules)
 	}
 }
 
 func BenchmarkPrettyPrintBatch(b *testing.B) {
 	for _, test := range prettyPrintBatchTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				caps := make([]config.Capsule, 1)
+				capsules := make([]config.Capsule, 1)
 				for _, t := range test.test {
-					cap := config.NewCapsule()
-					cap.SetData(t)
-					caps = append(caps, cap)
+					capsule := config.NewCapsule()
+					capsule.SetData(t)
+					capsules = append(capsules, capsule)
 				}
 
-				benchmarkPrettyPrintBatch(b, test.proc, caps)
+				benchmarkPrettyPrintBatch(b, test.proc, capsules)
 			},
 		)
 	}
@@ -148,38 +146,36 @@ var prettyPrintTests = []struct {
 
 func TestPrettyPrint(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 
 	for _, test := range prettyPrintTests {
-		cap.SetData(test.test)
+		capsule.SetData(test.test)
 
-		result, err := test.proc.Apply(ctx, cap)
+		result, err := test.proc.Apply(ctx, capsule)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		if !bytes.Equal(result.Data(), test.expected) {
-			t.Logf("expected %s, got %s", test.expected, result.Data())
-			t.Fail()
+			t.Errorf("expected %s, got %s", test.expected, result.Data())
 		}
 	}
 }
 
-func benchmarkPrettyPrint(b *testing.B, proc PrettyPrint, cap config.Capsule) {
+func benchmarkPrettyPrint(b *testing.B, proc PrettyPrint, capsule config.Capsule) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
-		proc.Apply(ctx, cap)
+		_, _ = proc.Apply(ctx, capsule)
 	}
 }
 
 func BenchmarkPrettyPrint(b *testing.B) {
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range prettyPrintTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				cap.SetData(test.test)
-				benchmarkPrettyPrint(b, test.proc, cap)
+				capsule.SetData(test.test)
+				benchmarkPrettyPrint(b, test.proc, capsule)
 			},
 		)
 	}

--- a/process/process.go
+++ b/process/process.go
@@ -45,12 +45,12 @@ func ApplyByte(ctx context.Context, data []byte, apps ...Applicator) ([]byte, er
 	capsule := config.NewCapsule()
 	capsule.SetData(data)
 
-	newCap, err := Apply(ctx, capsule, apps...)
+	newCapsule, err := Apply(ctx, capsule, apps...)
 	if err != nil {
 		return nil, err
 	}
 
-	return newCap.Data(), nil
+	return newCapsule.Data(), nil
 }
 
 // MakeApplicators accepts multiple processor configs and returns populated Applicators. This is a convenience function for generating many Applicators.
@@ -322,7 +322,7 @@ func newBatch(s *[]config.Capsule) []config.Capsule {
 
 // conditionallyApplyBatch uses conditions to dynamically apply processors to a slice of encapsulated data. This is a convenience function for the ApplyBatch method used in most processors.
 func conditionallyApplyBatch(ctx context.Context, capsules []config.Capsule, op condition.Operator, apps ...Applicator) ([]config.Capsule, error) {
-	newCaps := newBatch(&capsules)
+	newCapsules := newBatch(&capsules)
 
 	for _, capsule := range capsules {
 		ok, err := op.Operate(ctx, capsule)
@@ -331,7 +331,7 @@ func conditionallyApplyBatch(ctx context.Context, capsules []config.Capsule, op 
 		}
 
 		if !ok {
-			newCaps = append(newCaps, capsule)
+			newCapsules = append(newCapsules, capsule)
 			continue
 		}
 
@@ -340,8 +340,8 @@ func conditionallyApplyBatch(ctx context.Context, capsules []config.Capsule, op 
 			return nil, err
 		}
 
-		newCaps = append(newCaps, capsule)
+		newCapsules = append(newCapsules, capsule)
 	}
 
-	return newCaps, nil
+	return newCapsules, nil
 }

--- a/process/process.go
+++ b/process/process.go
@@ -27,25 +27,25 @@ type Applicator interface {
 }
 
 // Apply accepts one or many Applicators and applies processors in series to encapsulated data.
-func Apply(ctx context.Context, cap config.Capsule, apps ...Applicator) (config.Capsule, error) {
+func Apply(ctx context.Context, capsule config.Capsule, apps ...Applicator) (config.Capsule, error) {
 	var err error
 
 	for _, app := range apps {
-		cap, err = app.Apply(ctx, cap)
+		capsule, err = app.Apply(ctx, capsule)
 		if err != nil {
-			return cap, err
+			return capsule, err
 		}
 	}
 
-	return cap, nil
+	return capsule, nil
 }
 
 // ApplyByte is a convenience function for applying one or many Applicators to bytes.
 func ApplyByte(ctx context.Context, data []byte, apps ...Applicator) ([]byte, error) {
-	cap := config.NewCapsule()
-	cap.SetData(data)
+	capsule := config.NewCapsule()
+	capsule.SetData(data)
 
-	newCap, err := Apply(ctx, cap, apps...)
+	newCap, err := Apply(ctx, capsule, apps...)
 	if err != nil {
 		return nil, err
 	}
@@ -73,91 +73,92 @@ func ApplicatorFactory(cfg config.Config) (Applicator, error) {
 	switch t := cfg.Type; t {
 	case "base64":
 		var p Base64
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "capture":
 		var p Capture
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "case":
 		var p Case
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "concat":
 		var p Concat
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "convert":
 		var p Convert
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "copy":
 		var p Copy
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "delete":
 		var p Delete
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "domain":
 		var p Domain
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "dynamodb":
 		var p DynamoDB
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "flatten":
 		var p Flatten
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "for_each":
 		var p ForEach
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "group":
 		var p Group
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "gzip":
 		var p Gzip
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "hash":
 		var p Hash
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "insert":
 		var p Insert
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "lambda":
 		var p Lambda
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "math":
 		var p Math
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "pipeline":
 		var p Pipeline
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "pretty_print":
 		var p PrettyPrint
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "replace":
 		var p Replace
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "split":
 		var p Split
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
+
 		return p, nil
 	case "time":
 		var p Time
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	default:
 		return nil, fmt.Errorf("process settings %+v: %v", cfg.Settings, errInvalidFactoryInput)
@@ -204,107 +205,107 @@ func BatchApplicatorFactory(cfg config.Config) (BatchApplicator, error) {
 	switch t := cfg.Type; t {
 	case "aggregate":
 		var p Aggregate
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "base64":
 		var p Base64
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "capture":
 		var p Capture
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "case":
 		var p Case
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "concat":
 		var p Concat
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "convert":
 		var p Convert
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "copy":
 		var p Copy
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "count":
 		var p Count
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "delete":
 		var p Delete
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "domain":
 		var p Domain
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "drop":
 		var p Drop
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "dynamodb":
 		var p DynamoDB
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "expand":
 		var p Expand
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "flatten":
 		var p Flatten
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "for_each":
 		var p ForEach
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "group":
 		var p Group
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "gzip":
 		var p Gzip
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "hash":
 		var p Hash
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "insert":
 		var p Insert
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "lambda":
 		var p Lambda
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "math":
 		var p Math
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "pipeline":
 		var p Pipeline
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "pretty_print":
 		var p PrettyPrint
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "replace":
 		var p Replace
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "split":
 		var p Split
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	case "time":
 		var p Time
-		config.Decode(cfg.Settings, &p)
+		_ = config.Decode(cfg.Settings, &p)
 		return p, nil
 	default:
 		return nil, fmt.Errorf("process settings %+v: %v", cfg.Settings, errInvalidFactoryInput)
@@ -320,26 +321,26 @@ func newBatch(s *[]config.Capsule) []config.Capsule {
 }
 
 // conditionallyApplyBatch uses conditions to dynamically apply processors to a slice of encapsulated data. This is a convenience function for the ApplyBatch method used in most processors.
-func conditionallyApplyBatch(ctx context.Context, caps []config.Capsule, op condition.Operator, apps ...Applicator) ([]config.Capsule, error) {
-	newCaps := newBatch(&caps)
+func conditionallyApplyBatch(ctx context.Context, capsules []config.Capsule, op condition.Operator, apps ...Applicator) ([]config.Capsule, error) {
+	newCaps := newBatch(&capsules)
 
-	for _, cap := range caps {
-		ok, err := op.Operate(ctx, cap)
+	for _, capsule := range capsules {
+		ok, err := op.Operate(ctx, capsule)
 		if err != nil {
 			return nil, err
 		}
 
 		if !ok {
-			newCaps = append(newCaps, cap)
+			newCaps = append(newCaps, capsule)
 			continue
 		}
 
-		cap, err := Apply(ctx, cap, apps...)
+		capsule, err := Apply(ctx, capsule, apps...)
 		if err != nil {
 			return nil, err
 		}
 
-		newCaps = append(newCaps, cap)
+		newCaps = append(newCaps, capsule)
 	}
 
 	return newCaps, nil

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -130,120 +130,108 @@ var processTests = []struct {
 
 func TestApply(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range processTests {
-		cap.SetData(test.test)
+		capsule.SetData(test.test)
 
 		applicators, err := MakeApplicators(test.conf)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
-		result, err := Apply(ctx, cap, applicators...)
+		result, err := Apply(ctx, capsule, applicators...)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		if !bytes.Equal(result.Data(), test.expected) {
-			t.Logf("expected %v, got %v", test.expected, result)
-			t.Fail()
+			t.Errorf("expected %v, got %v", test.expected, result)
 		}
 	}
 }
 
 func TestApplicatorFactory(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range processTests {
-		cap.SetData(test.test)
+		capsule.SetData(test.test)
 
 		conf := test.conf[0]
 		applicator, err := ApplicatorFactory(conf)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
-		result, err := applicator.Apply(ctx, cap)
+		result, err := applicator.Apply(ctx, capsule)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		if !bytes.Equal(result.Data(), test.expected) {
-			t.Logf("expected %v, got %v", test.expected, result)
-			t.Fail()
+			t.Errorf("expected %v, got %v", test.expected, result)
 		}
 	}
 }
 
 func TestApplyBatch(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range processTests {
-		cap.SetData(test.test)
+		capsule.SetData(test.test)
 
 		batch := make([]config.Capsule, 1)
-		batch[0] = cap
+		batch[0] = capsule
 
 		applicators, err := MakeBatchApplicators(test.conf)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		result, err := ApplyBatch(ctx, batch, applicators...)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		if !bytes.Equal(result[0].Data(), test.expected) {
-			t.Logf("expected %v, got %v", test.expected, result)
-			t.Fail()
+			t.Errorf("expected %v, got %v", test.expected, result)
 		}
 	}
 }
 
 func TestBatchApplicatorFactory(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	batch := make([]config.Capsule, 1)
 
 	for _, test := range processTests {
-		cap.SetData(test.test)
-		batch[0] = cap
+		capsule.SetData(test.test)
+		batch[0] = capsule
 
 		conf := test.conf[0]
 		applicator, err := BatchApplicatorFactory(conf)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		result, err := applicator.ApplyBatch(ctx, batch)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		if !bytes.Equal(result[0].Data(), test.expected) {
-			t.Logf("expected %v, got %v", test.expected, result)
-			t.Fail()
+			t.Errorf("expected %v, got %v", test.expected, result)
 		}
 	}
 }
 
 func BenchmarkApplicatorFactory(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		ApplicatorFactory(processTests[0].conf[0])
+		_, _ = ApplicatorFactory(processTests[0].conf[0])
 	}
 }
 
 func BenchmarkBatchApplicatorFactory(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		BatchApplicatorFactory(processTests[0].conf[0])
+		_, _ = BatchApplicatorFactory(processTests[0].conf[0])
 	}
 }

--- a/process/replace_test.go
+++ b/process/replace_test.go
@@ -45,20 +45,18 @@ var replaceTests = []struct {
 
 func TestReplace(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 
 	for _, test := range replaceTests {
-		cap.SetData(test.test)
+		capsule.SetData(test.test)
 
-		result, err := test.proc.Apply(ctx, cap)
+		result, err := test.proc.Apply(ctx, capsule)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		if !bytes.Equal(result.Data(), test.expected) {
-			t.Logf("expected %s, got %s", test.expected, result.Data())
-			t.Fail()
+			t.Errorf("expected %s, got %s", test.expected, result.Data())
 		}
 	}
 }
@@ -66,17 +64,17 @@ func TestReplace(t *testing.T) {
 func benchmarkReplace(b *testing.B, applicator Replace, test config.Capsule) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
-		applicator.Apply(ctx, test)
+		_, _ = applicator.Apply(ctx, test)
 	}
 }
 
 func BenchmarkReplace(b *testing.B) {
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range replaceTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				cap.SetData(test.test)
-				benchmarkReplace(b, test.proc, cap)
+				capsule.SetData(test.test)
+				benchmarkReplace(b, test.proc, capsule)
 			},
 		)
 	}

--- a/process/split.go
+++ b/process/split.go
@@ -56,7 +56,7 @@ func (p Split) ApplyBatch(ctx context.Context, capsules []config.Capsule) ([]con
 		return nil, fmt.Errorf("process split: %v", err)
 	}
 
-	newCaps := newBatch(&capsules)
+	newCapsules := newBatch(&capsules)
 	for _, capsule := range capsules {
 		ok, err := op.Operate(ctx, capsule)
 		if err != nil {
@@ -64,7 +64,7 @@ func (p Split) ApplyBatch(ctx context.Context, capsules []config.Capsule) ([]con
 		}
 
 		if !ok {
-			newCaps = append(newCaps, capsule)
+			newCapsules = append(newCapsules, capsule)
 			continue
 		}
 
@@ -74,17 +74,17 @@ func (p Split) ApplyBatch(ctx context.Context, capsules []config.Capsule) ([]con
 			if err != nil {
 				return nil, fmt.Errorf("process split: %v", err)
 			}
-			newCaps = append(newCaps, pcap)
+			newCapsules = append(newCapsules, pcap)
 
 			continue
 		}
 
 		// data processing
 		if p.InputKey == "" && p.OutputKey == "" {
-			newCap := config.NewCapsule()
+			newCapsule := config.NewCapsule()
 			for _, x := range bytes.Split(capsule.Data(), []byte(p.Options.Separator)) {
-				newCap.SetData(x)
-				newCaps = append(newCaps, newCap)
+				newCapsule.SetData(x)
+				newCapsules = append(newCapsules, newCapsule)
 			}
 
 			continue
@@ -93,7 +93,7 @@ func (p Split) ApplyBatch(ctx context.Context, capsules []config.Capsule) ([]con
 		return nil, fmt.Errorf("process split: inputkey %s outputkey %s: %v", p.InputKey, p.OutputKey, errInvalidDataPattern)
 	}
 
-	return newCaps, nil
+	return newCapsules, nil
 }
 
 // Apply processes encapsulated data with the Split processor.

--- a/process/split.go
+++ b/process/split.go
@@ -12,6 +12,7 @@ import (
 
 /*
 Split processes data by splitting it into multiple elements or items. The processor supports these patterns:
+
 	JSON:
 		{"split":"foo.bar"} >>> {"split":["foo","bar"]}
 	data:
@@ -19,6 +20,7 @@ Split processes data by splitting it into multiple elements or items. The proces
 		{"foo":"bar"}\n{"baz":"qux"} >>> {"foo":"bar"} {"baz":"qux"}
 
 When loaded with a factory, the processor uses this JSON configuration:
+
 	{
 		"type": "split",
 		"settings": {
@@ -39,6 +41,7 @@ type Split struct {
 
 /*
 SplitOptions contains custom options settings for the Split processor:
+
 	Separator:
 		string that separates aggregated data
 */
@@ -47,27 +50,27 @@ type SplitOptions struct {
 }
 
 // ApplyBatch processes a slice of encapsulated data with the Split processor. Conditions are optionally applied to the data to enable processing.
-func (p Split) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.Capsule, error) {
+func (p Split) ApplyBatch(ctx context.Context, capsules []config.Capsule) ([]config.Capsule, error) {
 	op, err := condition.OperatorFactory(p.Condition)
 	if err != nil {
 		return nil, fmt.Errorf("process split: %v", err)
 	}
 
-	newCaps := newBatch(&caps)
-	for _, cap := range caps {
-		ok, err := op.Operate(ctx, cap)
+	newCaps := newBatch(&capsules)
+	for _, capsule := range capsules {
+		ok, err := op.Operate(ctx, capsule)
 		if err != nil {
 			return nil, fmt.Errorf("process split: %v", err)
 		}
 
 		if !ok {
-			newCaps = append(newCaps, cap)
+			newCaps = append(newCaps, capsule)
 			continue
 		}
 
 		// JSON processing
 		if p.InputKey != "" && p.OutputKey != "" {
-			pcap, err := p.Apply(ctx, cap)
+			pcap, err := p.Apply(ctx, capsule)
 			if err != nil {
 				return nil, fmt.Errorf("process split: %v", err)
 			}
@@ -79,7 +82,7 @@ func (p Split) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.
 		// data processing
 		if p.InputKey == "" && p.OutputKey == "" {
 			newCap := config.NewCapsule()
-			for _, x := range bytes.Split(cap.Data(), []byte(p.Options.Separator)) {
+			for _, x := range bytes.Split(capsule.Data(), []byte(p.Options.Separator)) {
 				newCap.SetData(x)
 				newCaps = append(newCaps, newCap)
 			}
@@ -94,23 +97,23 @@ func (p Split) ApplyBatch(ctx context.Context, caps []config.Capsule) ([]config.
 }
 
 // Apply processes encapsulated data with the Split processor.
-func (p Split) Apply(ctx context.Context, cap config.Capsule) (config.Capsule, error) {
+func (p Split) Apply(ctx context.Context, capsule config.Capsule) (config.Capsule, error) {
 	// error early if required options are missing
 	if p.Options.Separator == "" {
-		return cap, fmt.Errorf("process split: options %+v: %v", p.Options, errMissingRequiredOptions)
+		return capsule, fmt.Errorf("process split: options %+v: %v", p.Options, errMissingRequiredOptions)
 	}
 
 	// only supports JSON, error early if there are no keys
 	if p.InputKey == "" || p.OutputKey == "" {
-		return cap, fmt.Errorf("process split: inputkey %s outputkey %s: %v", p.InputKey, p.OutputKey, errInvalidDataPattern)
+		return capsule, fmt.Errorf("process split: inputkey %s outputkey %s: %v", p.InputKey, p.OutputKey, errInvalidDataPattern)
 	}
 
-	result := cap.Get(p.InputKey).String()
+	result := capsule.Get(p.InputKey).String()
 	value := strings.Split(result, p.Options.Separator)
 
-	if err := cap.Set(p.OutputKey, value); err != nil {
-		return cap, fmt.Errorf("process split: %v", err)
+	if err := capsule.Set(p.OutputKey, value); err != nil {
+		return capsule, fmt.Errorf("process split: %v", err)
 	}
 
-	return cap, nil
+	return capsule, nil
 }

--- a/process/split_test.go
+++ b/process/split_test.go
@@ -32,38 +32,36 @@ var splitTests = []struct {
 
 func TestSplit(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 
 	for _, test := range splitTests {
-		cap.SetData(test.test)
+		capsule.SetData(test.test)
 
-		result, err := test.proc.Apply(ctx, cap)
+		result, err := test.proc.Apply(ctx, capsule)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		if !bytes.Equal(result.Data(), test.expected) {
-			t.Logf("expected %s, got %s", test.expected, result.Data())
-			t.Fail()
+			t.Errorf("expected %s, got %s", test.expected, result.Data())
 		}
 	}
 }
 
-func benchmarkSplit(b *testing.B, proc Split, cap config.Capsule) {
+func benchmarkSplit(b *testing.B, proc Split, capsule config.Capsule) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
-		proc.Apply(ctx, cap)
+		_, _ = proc.Apply(ctx, capsule)
 	}
 }
 
 func BenchmarkSplit(b *testing.B) {
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range splitTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				cap.SetData(test.test)
-				benchmarkSplit(b, test.proc, cap)
+				capsule.SetData(test.test)
+				benchmarkSplit(b, test.proc, capsule)
 			},
 		)
 	}
@@ -97,48 +95,46 @@ var splitBatchTests = []struct {
 
 func TestSplitBatch(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range splitBatchTests {
-		var caps []config.Capsule
+		var capsules []config.Capsule
 		for _, t := range test.test {
-			cap.SetData(t)
-			caps = append(caps, cap)
+			capsule.SetData(t)
+			capsules = append(capsules, capsule)
 		}
 
-		result, err := test.proc.ApplyBatch(ctx, caps)
+		result, err := test.proc.ApplyBatch(ctx, capsules)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		for i, res := range result {
 			expected := test.expected[i]
 			if !bytes.Equal(expected, res.Data()) {
-				t.Logf("expected %s, got %s", expected, string(res.Data()))
-				t.Fail()
+				t.Errorf("expected %s, got %s", expected, string(res.Data()))
 			}
 		}
 	}
 }
 
-func benchmarkSplitBatch(b *testing.B, proc Split, caps []config.Capsule) {
+func benchmarkSplitBatch(b *testing.B, proc Split, capsules []config.Capsule) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
-		proc.ApplyBatch(ctx, caps)
+		_, _ = proc.ApplyBatch(ctx, capsules)
 	}
 }
 
 func BenchmarkSplitBatch(b *testing.B) {
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range splitBatchTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				var caps []config.Capsule
+				var capsules []config.Capsule
 				for _, t := range test.test {
-					cap.SetData(t)
-					caps = append(caps, cap)
+					capsule.SetData(t)
+					capsules = append(capsules, capsule)
 				}
-				benchmarkSplitBatch(b, test.proc, caps)
+				benchmarkSplitBatch(b, test.proc, capsules)
 			},
 		)
 	}

--- a/process/time_test.go
+++ b/process/time_test.go
@@ -190,20 +190,18 @@ var timeTests = []struct {
 
 func TestTime(t *testing.T) {
 	ctx := context.TODO()
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 
 	for _, test := range timeTests {
-		cap.SetData(test.test)
+		capsule.SetData(test.test)
 
-		result, err := test.proc.Apply(ctx, cap)
+		result, err := test.proc.Apply(ctx, capsule)
 		if err != nil {
-			t.Log(err)
-			t.Fail()
+			t.Error(err)
 		}
 
 		if !bytes.Equal(result.Data(), test.expected) {
-			t.Logf("expected %s, got %s", test.expected, result.Data())
-			t.Fail()
+			t.Errorf("expected %s, got %s", test.expected, result.Data())
 		}
 	}
 }
@@ -211,17 +209,17 @@ func TestTime(t *testing.T) {
 func benchmarkTime(b *testing.B, applicator Time, test config.Capsule) {
 	ctx := context.TODO()
 	for i := 0; i < b.N; i++ {
-		applicator.Apply(ctx, test)
+		_, _ = applicator.Apply(ctx, test)
 	}
 }
 
 func BenchmarkTime(b *testing.B) {
-	cap := config.NewCapsule()
+	capsule := config.NewCapsule()
 	for _, test := range timeTests {
-		b.Run(string(test.name),
+		b.Run(test.name,
 			func(b *testing.B) {
-				cap.SetData(test.test)
-				benchmarkTime(b, test.proc, cap)
+				capsule.SetData(test.test)
+				benchmarkTime(b, test.proc, capsule)
 			},
 		)
 	}


### PR DESCRIPTION
This updates the Go code lintng to use the meta-linter [golangci-lint](https://golangci-lint.run) and fixes related lints.

## Description

Changes include: 
* fix: handle or explicitly ignore all errors
* fix: remove redundant function calls (#31) and conversions 
* fix: rename predeclared `caps` identifier
* chore: tools: gofmt -> gofumpt, and staticcheck -> golangci-lint
* docs: update comments to remove grammar mistakes and follow Go comment conventions.

## Motivation and Context

This closes #31, improves error handling and consistency across with project.

## How Has This Been Tested?

Local builds, unit tests, and benchmarks all pass.

## Types of changes

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
