### PR TITLE
refactor!: Standardizing Use of io

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,16 @@ Substation relies on [factory methods](https://refactoring.guru/design-patterns/
 
 Factories are the preferred method for allowing users to customize the system. Example factories can be seen in [condition](/condition/condition.go) and [process](/process/process.go).
 
+##### Reading and Writing Streaming Data
+
+We prefer use of the io package for reading (e.g., io.Reader) and writing (e.g., io.Writer) streams of data. This reduces memory usage and decreases the likelihood that we will need to refactor methods and functions that handle streaming data.
+
+Substation commonly uses these io compatible containers:
+
+- open files that are created by the call `os.CreateTemp("", "substation")`
+
+- bytes buffers that are created by the call `new(bytes.Buffer)`
+
 ### Naming Conventions
 
 #### Errors

--- a/cmd/app_test.go
+++ b/cmd/app_test.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
-	"encoding/json"
 	"sync"
 	"testing"
 
@@ -114,8 +114,9 @@ func TestAppLeaks(t *testing.T) {
 
 	for _, test := range appLeaksTest {
 		sub := New()
-		err := json.Unmarshal(test.config, &sub.Config)
-		if err != nil {
+
+		r := bytes.NewReader(test.config)
+		if err := sub.SetConfig(r); err != nil {
 			t.Fatal(err)
 		}
 

--- a/cmd/aws/lambda/substation/main.go
+++ b/cmd/aws/lambda/substation/main.go
@@ -315,7 +315,10 @@ func s3Handler(ctx context.Context, event events.S3Event) error {
 			scanner := bufio.NewScanner()
 			defer scanner.Close()
 
-			scanner.ReadFile(dst)
+			if err := scanner.ReadFile(dst); err != nil {
+				return fmt.Errorf("s3 handler: %v", err)
+			}
+
 			for scanner.Scan() {
 				switch scanner.Method() {
 				case "bytes":
@@ -420,7 +423,10 @@ func s3SnsHandler(ctx context.Context, event events.SNSEvent) error {
 				scanner := bufio.NewScanner()
 				defer scanner.Close()
 
-				scanner.ReadFile(dst)
+				if err := scanner.ReadFile(dst); err != nil {
+					return fmt.Errorf("s3 sns handler: %v", err)
+				}
+
 				for scanner.Scan() {
 					switch scanner.Method() {
 					case "bytes":

--- a/cmd/file/substation/main.go
+++ b/cmd/file/substation/main.go
@@ -118,7 +118,10 @@ func run(ctx context.Context, input, cfg string) error {
 		scanner := bufio.NewScanner()
 		defer scanner.Close()
 
-		scanner.ReadFile(f)
+		if err := scanner.ReadFile(f); err != nil {
+			return fmt.Errorf("run: %v", err)
+		}
+
 		for scanner.Scan() {
 			switch scanner.Method() {
 			case "bytes":

--- a/condition/content.go
+++ b/condition/content.go
@@ -2,18 +2,18 @@ package condition
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/brexhq/substation/config"
+	"github.com/brexhq/substation/internal/media"
 )
 
 /*
-Content evaluates data by its content type. This inspector uses the standard library's net/http package to identify the content type of data (more information is available here: https://pkg.go.dev/net/http#DetectContentType). When used in Substation pipelines, it is most effective when using processors that change the format of data (e.g., process/gzip). The inspector supports MIME types that follow this specification: https://mimesniff.spec.whatwg.org/.
+Content evaluates data by its content (media, MIME) type. When used in Substation pipelines, it is most effective when using processors that change the format of data (e.g., process/gzip). The inspector supports MIME types that follow this specification: https://mimesniff.spec.whatwg.org/.
 
 The inspector has these settings:
 
 	Type:
-		MIME type used during inspection
+		media type used during inspection
 	Negate (optional):
 		if set to true, then the inspection is negated (i.e., true becomes false, false becomes true)
 		defaults to false
@@ -41,8 +41,8 @@ type Content struct {
 func (c Content) Inspect(ctx context.Context, capsule config.Capsule) (output bool, err error) {
 	matched := false
 
-	content := http.DetectContentType(capsule.Data())
-	if content == c.Type {
+	media := media.Bytes(capsule.Data())
+	if media == c.Type {
 		matched = true
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -1,7 +1,9 @@
+// package config provides capabilities for managing configurations and handling data in Substation applications.
 package config
 
 import (
 	gojson "encoding/json"
+	"os"
 	"strings"
 	"sync"
 
@@ -27,6 +29,15 @@ func Decode(input, output interface{}) error {
 	return gojson.Unmarshal(b, output)
 }
 
+// Get retrieves a configuration location from the SUBSTATION_CONFIG environment variable.
+func Get() string {
+	if v, found := os.LookupEnv("SUBSTATION_CONFIG"); found {
+		return v
+	}
+
+	return ""
+}
+
 /*
 Capsule stores encapsulated data that is used throughout the package's data handling and processing functions.
 
@@ -37,11 +48,6 @@ Each capsule contains two unexported fields that are accessed by getters and set
 - metadata: stores structured metadata that describes the data
 
 Values in the metadata field are accessed using the pattern "!metadata [key]". JSON values can be freely moved between the data and metadata fields.
-
-Capsules can be created and initialized using this pattern, where b is a []byte and v is an interface{}:
-
-	capsule := NewCapsule()
-	capsule.SetData(b).SetMetadata(v)
 
 Substation applications follow these rules when handling capsules:
 
@@ -183,9 +189,7 @@ func (c *Capsule) SetMetadata(i interface{}) (*Capsule, error) {
 	return c, nil
 }
 
-/*
-Channel provides methods for safely writing capsule data to and closing channels. Data should be read directly from the channel (e.g., ch.C).
-*/
+// Channel provides methods for safely writing capsule data to and closing channels. Data should be read directly from the channel (e.g., ch.C).
 type Channel struct {
 	C      chan Capsule
 	mutex  sync.Mutex

--- a/config/example_test.go
+++ b/config/example_test.go
@@ -29,12 +29,15 @@ func ExampleGet_file() {
 func ExampleCapsule_Set() {
 	data := []byte(`{"foo":"bar"}`)
 
-	cap := config.NewCapsule()
-	cap.SetData(data)
+	capsule := config.NewCapsule()
+	capsule.SetData(data)
 
-	cap.Set("baz", "qux")
+	if err := capsule.Set("baz", "qux"); err != nil {
+		// handler error
+		panic(err)
+	}
 
-	d := cap.Data()
+	d := capsule.Data()
 	fmt.Println(string(d))
 	// Output: {"foo":"bar","baz":"qux"}
 }
@@ -42,8 +45,8 @@ func ExampleCapsule_Set() {
 func ExampleCapsule_SetData() {
 	data := []byte(`{"foo":"bar"}`)
 
-	cap := config.NewCapsule()
-	cap.SetData(data)
+	capsule := config.NewCapsule()
+	capsule.SetData(data)
 }
 
 func ExampleCapsule_SetMetadata() {
@@ -53,8 +56,11 @@ func ExampleCapsule_SetMetadata() {
 		baz: "qux",
 	}
 
-	cap := config.NewCapsule()
-	cap.SetMetadata(metadata)
+	capsule := config.NewCapsule()
+	if _, err := capsule.SetMetadata(metadata); err != nil {
+		// handle err
+		panic(err)
+	}
 }
 
 func ExampleCapsule_SetMetadata_chaining() {
@@ -66,6 +72,9 @@ func ExampleCapsule_SetMetadata_chaining() {
 
 	data := []byte(`{"foo":"bar"}`)
 
-	cap := config.NewCapsule()
-	cap.SetData(data).SetMetadata(metadata)
+	capsule := config.NewCapsule()
+	if _, err := capsule.SetData(data).SetMetadata(metadata); err != nil {
+		// handle err
+		panic(err)
+	}
 }

--- a/config/example_test.go
+++ b/config/example_test.go
@@ -1,0 +1,71 @@
+package config_test
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/brexhq/substation/cmd"
+	"github.com/brexhq/substation/config"
+)
+
+func ExampleGet_file() {
+	// cfg is the location of a file on-disk
+	cfg := config.Get()
+
+	f, err := os.Open(cfg)
+	if err != nil {
+		// handle err
+		panic(err)
+	}
+	defer f.Close()
+
+	sub := cmd.New()
+	if err := sub.SetConfig(f); err != nil {
+		// handle err
+		panic(err)
+	}
+}
+
+func ExampleCapsule_Set() {
+	data := []byte(`{"foo":"bar"}`)
+
+	cap := config.NewCapsule()
+	cap.SetData(data)
+
+	cap.Set("baz", "qux")
+
+	d := cap.Data()
+	fmt.Println(string(d))
+	// Output: {"foo":"bar","baz":"qux"}
+}
+
+func ExampleCapsule_SetData() {
+	data := []byte(`{"foo":"bar"}`)
+
+	cap := config.NewCapsule()
+	cap.SetData(data)
+}
+
+func ExampleCapsule_SetMetadata() {
+	metadata := struct {
+		baz string
+	}{
+		baz: "qux",
+	}
+
+	cap := config.NewCapsule()
+	cap.SetMetadata(metadata)
+}
+
+func ExampleCapsule_SetMetadata_chaining() {
+	metadata := struct {
+		baz string
+	}{
+		baz: "qux",
+	}
+
+	data := []byte(`{"foo":"bar"}`)
+
+	cap := config.NewCapsule()
+	cap.SetData(data).SetMetadata(metadata)
+}

--- a/examples/service/main.go
+++ b/examples/service/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"sync"
@@ -17,11 +16,13 @@ import (
 func main() {
 	sub := cmd.New()
 
-	bytes, err := os.ReadFile("./config.json")
+	f, err := os.Open("./config.json")
 	if err != nil {
 		panic(err)
 	}
-	if err := json.Unmarshal(bytes, &sub.Config); err != nil {
+	defer f.Close()
+
+	if err := sub.SetConfig(f); err != nil {
 		panic(err)
 	}
 

--- a/internal/aws/s3manager/s3manager.go
+++ b/internal/aws/s3manager/s3manager.go
@@ -118,7 +118,9 @@ func (a *UploaderAPI) Upload(ctx aws.Context, bucket, key string, src io.Reader)
 		return nil, fmt.Errorf("s3manager upload bucket %s key %s: %v", bucket, key, err)
 	}
 
-	dst.Seek(0, 0)
+	if _, err := dst.Seek(0, 0); err != nil {
+		return nil, fmt.Errorf("s3manager upload bucket %s key %s: %v", bucket, key, err)
+	}
 	input := &s3manager.UploadInput{
 		Bucket:      aws.String(bucket),
 		Key:         aws.String(key),

--- a/internal/aws/s3manager/s3manager_test.go
+++ b/internal/aws/s3manager/s3manager_test.go
@@ -3,6 +3,7 @@ package s3manager
 import (
 	"context"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -49,7 +50,8 @@ func TestDownload(t *testing.T) {
 			mockedDownload{Resp: test.resp},
 		}
 
-		_, size, err := a.Download(ctx, test.input.bucket, test.input.key)
+		var dst io.WriterAt
+		size, err := a.Download(ctx, test.input.bucket, test.input.key, dst)
 		if err != nil {
 			t.Fatalf("%d, unexpected error", err)
 		}
@@ -103,7 +105,8 @@ func TestUpload(t *testing.T) {
 			mockedUpload{Resp: test.resp},
 		}
 
-		resp, err := a.Upload(ctx, test.input.buffer, test.input.bucket, test.input.key)
+		src := strings.NewReader("foo")
+		resp, err := a.Upload(ctx, test.input.bucket, test.input.key, src)
 		if err != nil {
 			t.Fatalf("%d, unexpected error", err)
 		}

--- a/internal/bufio/bufio.go
+++ b/internal/bufio/bufio.go
@@ -76,13 +76,19 @@ func (s *scanner) ReadFile(file *os.File) error {
 	var reader io.ReadCloser
 	s.openHandles = append(s.openHandles, file)
 
-	file.Seek(0, 0)
-	mediaType, err := media.File(file)
-	if err != nil {
-		return fmt.Errorf("readopenfile: %v", err)
+	if _, err := file.Seek(0, 0); err != nil {
+		return fmt.Errorf("readfile: %v", err)
 	}
 
-	file.Seek(0, 0)
+	mediaType, err := media.File(file)
+	if err != nil {
+		return fmt.Errorf("readfile: %v", err)
+	}
+
+	if _, err := file.Seek(0, 0); err != nil {
+		return fmt.Errorf("readfile: %v", err)
+	}
+
 	switch mediaType {
 	case "application/x-bzip2":
 		reader = io.NopCloser(bzip2.NewReader(file))

--- a/internal/bufio/bufio.go
+++ b/internal/bufio/bufio.go
@@ -1,0 +1,157 @@
+// package bufio wraps the standard library's bufio package.
+package bufio
+
+import (
+	"bufio"
+	"compress/bzip2"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+
+	"github.com/brexhq/substation/internal/errors"
+	"github.com/brexhq/substation/internal/media"
+)
+
+// errInvalidMethod is returned when an invalid scanner method is provided.
+const errInvalidMethod = errors.Error("invalid scanner method")
+
+// NewScanner returns a new scanner with default settings provided by scanCapacity and scanMethod.
+func NewScanner() *scanner {
+	s := &scanner{}
+	s.size = scanCapacity()
+	s.method = scanMethod()
+
+	return s
+}
+
+/*
+scanner wraps bufio.scanner and provides methods for scanning data. The caller is responsible for closing the scanner when it is no longer needed.
+*/
+type scanner struct {
+	*bufio.Scanner
+	// openHandles contains all handles that must be closed after scanning is complete.
+	openHandles []io.ReadCloser
+	// size defines the maximum size used to buffer a token during scanning.
+	size int
+	// method defines how tokens should be generated when calling the scanner.
+	method string
+}
+
+// Capacity returns the capacity setting for the scanner.
+func (s *scanner) Capacity() int {
+	return s.size
+}
+
+// SetCapacity sets the maximum buffer size that may be allocated during scanning. This method overrides the default capacity that is set when the scanner is created.
+func (s *scanner) SetCapacity(capacity int) {
+	s.size = capacity
+}
+
+// Method returns the method setting for the scanner.
+func (s *scanner) Method() string {
+	return s.method
+}
+
+// SetMethod sets the method for the scanner. This method overrides the default method that is set when the scanner is created.
+func (s *scanner) SetMethod(m string) error {
+	if m == "bytes" || m == "text" {
+		s.method = m
+
+		return nil
+	}
+
+	return fmt.Errorf("setmethod: %v", errInvalidMethod)
+}
+
+/*
+ReadFile inspects, contextually decompresses, and reads an open file into the scanner. These file formats are optionally supported:
+
+- bzip2 (https://en.wikipedia.org/wiki/Bzip2)
+
+- gzip (https://en.wikipedia.org/wiki/Gzip)
+*/
+func (s *scanner) ReadFile(file *os.File) error {
+	var reader io.ReadCloser
+	s.openHandles = append(s.openHandles, file)
+
+	file.Seek(0, 0)
+	mediaType, err := media.File(file)
+	if err != nil {
+		return fmt.Errorf("readopenfile: %v", err)
+	}
+
+	file.Seek(0, 0)
+	switch mediaType {
+	case "application/x-bzip2":
+		reader = io.NopCloser(bzip2.NewReader(file))
+		s.openHandles = append(s.openHandles, reader)
+	case "application/x-gzip":
+		gzipReader, err := gzip.NewReader(file)
+		if err != nil {
+			return fmt.Errorf("readopenfile: %v", err)
+		}
+
+		reader = gzipReader
+		s.openHandles = append(s.openHandles, reader)
+	default:
+		// file was previously added to openHandles
+		reader = file
+	}
+
+	s.Scanner = bufio.NewScanner(reader)
+	s.Scanner.Buffer([]byte{}, s.size)
+
+	return nil
+}
+
+// Close closes all open handles.
+func (s *scanner) Close() error {
+	for _, h := range s.openHandles {
+		if err := h.Close(); err != nil {
+			return fmt.Errorf("close: %v", err)
+		}
+	}
+
+	return nil
+}
+
+/*
+scanCapacity retrieves a value from the SUBSTATION_SCAN_CAPACITY environment variable. This impacts the maximum size of each token (e.g., line in a text file) that is buffered (read) by bufio scanners that are used throughout the application to read files. More information about capacity can be found in https://pkg.go.dev/bufio#pkg-constants.
+
+If the environment variable is missing, then the default capacity is the value from the bufio package (approximately 65.5 KB).
+*/
+func scanCapacity() int {
+	maxSize := bufio.MaxScanTokenSize
+
+	if val, found := os.LookupEnv("SUBSTATION_SCAN_CAPACITY"); found {
+		v, err := strconv.Atoi(val)
+		if err != nil {
+			return maxSize
+		}
+
+		return v
+	}
+
+	return maxSize
+}
+
+/*
+scanMethod retrieves a value from the SUBSTATION_SCAN_METHOD environment variable. This impacts the read behavior of bufio scanners that are used throughout the application to read files. The options for this variable are:
+
+- "bytes" (https://pkg.go.dev/bufio#Scanner.Bytes)
+
+- "text" (https://pkg.go.dev/bufio#Scanner.Text)
+
+If the environment variable is missing, then the default method is "text".
+*/
+func scanMethod() string {
+	if val, found := os.LookupEnv("SUBSTATION_SCAN_METHOD"); found {
+		if val == "bytes" || val == "text" {
+			return val
+		}
+	}
+
+	return "text"
+}

--- a/internal/bufio/bufio_test.go
+++ b/internal/bufio/bufio_test.go
@@ -1,0 +1,31 @@
+package bufio
+
+import (
+	"os"
+	"testing"
+)
+
+func benchmarkScannerReadFile(b *testing.B, s *scanner, file *os.File) {
+	for i := 0; i < b.N; i++ {
+		s.ReadFile(file)
+		for s.Scan() {
+			s.Text()
+		}
+	}
+}
+
+func BenchmarkScannerReadFile(b *testing.B) {
+	file, _ := os.CreateTemp("", "substation")
+	defer os.Remove(file.Name())
+
+	file.Write([]byte("foo\nbar\nbaz"))
+
+	s := NewScanner()
+	defer s.Close()
+
+	b.Run("scanner_read_file",
+		func(b *testing.B) {
+			benchmarkScannerReadFile(b, s, file)
+		},
+	)
+}

--- a/internal/bufio/bufio_test.go
+++ b/internal/bufio/bufio_test.go
@@ -7,7 +7,7 @@ import (
 
 func benchmarkScannerReadFile(b *testing.B, s *scanner, file *os.File) {
 	for i := 0; i < b.N; i++ {
-		s.ReadFile(file)
+		_ = s.ReadFile(file)
 		for s.Scan() {
 			s.Text()
 		}
@@ -18,7 +18,7 @@ func BenchmarkScannerReadFile(b *testing.B) {
 	file, _ := os.CreateTemp("", "substation")
 	defer os.Remove(file.Name())
 
-	file.Write([]byte("foo\nbar\nbaz"))
+	_, _ = file.Write([]byte("foo\nbar\nbaz"))
 
 	s := NewScanner()
 	defer s.Close()

--- a/internal/bufio/example_test.go
+++ b/internal/bufio/example_test.go
@@ -17,7 +17,10 @@ func ExampleNewScanner_setup() {
 
 	// sets method to "bytes"
 	// defaults to "text"
-	s.SetMethod("bytes")
+	if err := s.SetMethod("bytes"); err != nil {
+		// handle error
+		panic(err)
+	}
 }
 
 func ExampleNewScanner_readFile() {
@@ -25,14 +28,18 @@ func ExampleNewScanner_readFile() {
 	file, _ := os.CreateTemp("", "substation")
 	defer os.Remove(file.Name())
 
-	file.Write([]byte("foo\nbar\nbaz"))
+	_, _ = file.Write([]byte("foo\nbar\nbaz"))
 
 	// scanner closes all open handles, including the open file
 	s := bufio.NewScanner()
 	defer s.Close()
 
 	// scanner automatically decompresses file and chooses appropriate scan method (default is "text")
-	s.ReadFile(file)
+	if err := s.ReadFile(file); err != nil {
+		// handle error
+		panic(err)
+	}
+
 	for s.Scan() {
 		switch s.Method() {
 		case "bytes":

--- a/internal/bufio/example_test.go
+++ b/internal/bufio/example_test.go
@@ -1,0 +1,49 @@
+package bufio_test
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/brexhq/substation/internal/bufio"
+)
+
+func ExampleNewScanner_setup() {
+	s := bufio.NewScanner()
+	defer s.Close()
+
+	// sets maximum capacity to 1024 bytes
+	// defaults to 65536 bytes
+	s.SetCapacity(1024)
+
+	// sets method to "bytes"
+	// defaults to "text"
+	s.SetMethod("bytes")
+}
+
+func ExampleNewScanner_readFile() {
+	// temp file is used to simulate an open file and must be removed after the test completes
+	file, _ := os.CreateTemp("", "substation")
+	defer os.Remove(file.Name())
+
+	file.Write([]byte("foo\nbar\nbaz"))
+
+	// scanner closes all open handles, including the open file
+	s := bufio.NewScanner()
+	defer s.Close()
+
+	// scanner automatically decompresses file and chooses appropriate scan method (default is "text")
+	s.ReadFile(file)
+	for s.Scan() {
+		switch s.Method() {
+		case "bytes":
+			fmt.Println(s.Bytes())
+		case "text":
+			fmt.Println(s.Text())
+		}
+	}
+
+	// Output:
+	// foo
+	// bar
+	// baz
+}

--- a/internal/file/example_test.go
+++ b/internal/file/example_test.go
@@ -16,7 +16,7 @@ func ExampleGet_local() {
 	defer os.Remove(temp.Name())
 	defer temp.Close()
 
-	temp.Write([]byte("foo\nbar\nbaz"))
+	_, _ = temp.Write([]byte("foo\nbar\nbaz"))
 
 	// a local copy of the file is created and must be removed when it's no longer needed, regardless of errors
 	path, err := file.Get(context.TODO(), temp.Name())

--- a/internal/file/example_test.go
+++ b/internal/file/example_test.go
@@ -1,0 +1,82 @@
+package file_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/brexhq/substation/internal/file"
+)
+
+func ExampleGet_local() {
+	// temp file is used to simulate an open file and must be removed after the test completes
+	temp, _ := os.CreateTemp("", "substation")
+	defer os.Remove(temp.Name())
+	defer temp.Close()
+
+	temp.Write([]byte("foo\nbar\nbaz"))
+
+	// a local copy of the file is created and must be removed when it's no longer needed, regardless of errors
+	path, err := file.Get(context.TODO(), temp.Name())
+	defer os.Remove(path)
+
+	if err != nil {
+		// handle err
+		panic(err)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		// handle err
+		panic(err)
+	}
+
+	defer f.Close()
+
+	buf, err := io.ReadAll(f)
+	if err != nil {
+		// handle err
+		panic(err)
+	}
+
+	fmt.Println(string(buf))
+
+	// Output:
+	// foo
+	// bar
+	// baz
+}
+
+func ExampleGet_http() {
+	location := "https://www.gutenberg.org/files/2701/2701-h/2701-h.htm"
+
+	// a local copy of the HTTP body is created and must be removed when it's no longer needed, regardless of errors
+	path, err := file.Get(context.TODO(), location)
+	defer os.Remove(path)
+
+	if err != nil {
+		// handle err
+		panic(err)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		// handle err
+		panic(err)
+	}
+
+	defer f.Close()
+
+	buf := make([]byte, 16)
+	if _, err = f.Read(buf); err != nil {
+		// handle err
+		panic(err)
+	}
+
+	prefix := strings.HasPrefix(string(buf), "<!DOCTYPE")
+	fmt.Println(prefix)
+
+	// Output: true
+}

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -1,3 +1,4 @@
+// package file provides functions that can be used to retrieve files from local and remote locations.
 package file
 
 import (
@@ -14,7 +15,7 @@ import (
 
 var (
 	httpClient   http.HTTP
-	s3managerAPI s3manager.DownloaderAPI
+	s3downloader s3manager.DownloaderAPI
 )
 
 // errEmptyFile is returned when Get is called but finds an empty file.
@@ -32,80 +33,76 @@ Get retrieves a file from these locations (in order):
 
 - AWS S3
 
-If a file is found, then it is saved to disk and the path is returned. The caller is responsible for removing files when they are no longer needed.
+If a file is found, then it is saved as a temporary local file and the name is returned. The caller is responsible for removing files when they are no longer needed; files should be removed even if an error occurs.
 */
-func Get(ctx context.Context, path string) (string, error) {
-	file, err := os.CreateTemp("", "tempfile")
+func Get(ctx context.Context, location string) (string, error) {
+	dst, err := os.CreateTemp("", "substation")
 	if err != nil {
-		return "", fmt.Errorf("file %s: %v", path, err)
+		return "", fmt.Errorf("get %s: %v", location, err)
 	}
+	defer dst.Close()
 
-	if _, err := os.Stat(path); err == nil {
-		buf, err := os.ReadFile(path)
+	if _, err := os.Stat(location); err == nil {
+		src, err := os.Open(location)
 		if err != nil {
-			return "", fmt.Errorf("file %s: %v", path, errEmptyFile)
+			return dst.Name(), fmt.Errorf("get %s: %v", location, err)
+		}
+		defer src.Close()
+
+		size, err := io.Copy(dst, src)
+		if err != nil {
+			return dst.Name(), fmt.Errorf("get %s: %v", location, err)
 		}
 
-		if len(buf) == 0 {
-			return "", fmt.Errorf("file %s: %v", path, errEmptyFile)
+		if size == 0 {
+			return dst.Name(), fmt.Errorf("get %s: %v", location, errEmptyFile)
 		}
 
-		if _, err := file.Write(buf); err != nil {
-			return "", fmt.Errorf("file %s: %v", path, err)
-		}
-
-		return file.Name(), nil
+		return dst.Name(), nil
 	}
 
-	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") { //nolint:nestif // err checking
+	if strings.HasPrefix(location, "http://") || strings.HasPrefix(location, "https://") { //nolint:nestif // err checking
 		if !httpClient.IsEnabled() {
 			httpClient.Setup()
 		}
 
-		resp, err := httpClient.Get(ctx, path)
+		resp, err := httpClient.Get(ctx, location)
 		if err != nil {
-			return "", fmt.Errorf("file %s: %v", path, err)
+			return dst.Name(), fmt.Errorf("get %s: %v", location, err)
 		}
 		defer resp.Body.Close()
 
-		body, err := io.ReadAll(resp.Body)
+		size, err := io.Copy(dst, resp.Body)
 		if err != nil {
-			return "", fmt.Errorf("file %s: %v", path, err)
-		}
-
-		if len(body) == 0 {
-			return "", fmt.Errorf("file %s: %v", path, errEmptyFile)
-		}
-
-		if _, err := file.Write(body); err != nil {
-			return "", fmt.Errorf("file %s: %v", path, err)
-		}
-
-		return file.Name(), nil
-	}
-
-	if strings.HasPrefix(path, "s3://") {
-		if !s3managerAPI.IsEnabled() {
-			s3managerAPI.Setup()
-		}
-
-		// "s3://bucket/key" becomes ["bucket" "key"]
-		paths := strings.SplitN(strings.TrimPrefix(path, "s3://"), "/", 2)
-		buf, size, err := s3managerAPI.Download(ctx, paths[0], paths[1])
-		if err != nil {
-			return "", fmt.Errorf("file %s: %v", path, err)
+			return dst.Name(), fmt.Errorf("get %s: %v", location, err)
 		}
 
 		if size == 0 {
-			return "", fmt.Errorf("file %s: %v", path, errEmptyFile)
+			return dst.Name(), fmt.Errorf("get %s: %v", location, errEmptyFile)
 		}
 
-		if _, err := file.Write(buf); err != nil {
-			return "", fmt.Errorf("file %s: %v", path, err)
-		}
-
-		return file.Name(), nil
+		return dst.Name(), nil
 	}
 
-	return "", fmt.Errorf("file %s: %v", path, errNoFile)
+	if strings.HasPrefix(location, "s3://") {
+		if !s3downloader.IsEnabled() {
+			s3downloader.Setup()
+		}
+
+		// "s3://bucket/key" becomes ["bucket" "key"]
+		paths := strings.SplitN(strings.TrimPrefix(location, "s3://"), "/", 2)
+
+		size, err := s3downloader.Download(ctx, paths[0], paths[1], dst)
+		if err != nil {
+			return dst.Name(), fmt.Errorf("get %s: %v", location, err)
+		}
+
+		if size == 0 {
+			return dst.Name(), fmt.Errorf("get %s: %v", location, errEmptyFile)
+		}
+
+		return dst.Name(), nil
+	}
+
+	return dst.Name(), fmt.Errorf("get %s: %v", location, errNoFile)
 }

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -61,7 +61,7 @@ func Get(ctx context.Context, location string) (string, error) {
 		return dst.Name(), nil
 	}
 
-	if strings.HasPrefix(location, "http://") || strings.HasPrefix(location, "https://") { //nolint:nestif // err checking
+	if strings.HasPrefix(location, "http://") || strings.HasPrefix(location, "https://") {
 		if !httpClient.IsEnabled() {
 			httpClient.Setup()
 		}

--- a/internal/media/example_test.go
+++ b/internal/media/example_test.go
@@ -21,7 +21,7 @@ func ExampleFile() {
 	defer os.Remove(file.Name())
 	defer file.Close()
 
-	file.Write([]byte("\x42\x5a\x68"))
+	_, _ = file.Write([]byte("\x42\x5a\x68"))
 
 	// media.File moves the file offset to zero
 	mediaType, err := media.File(file)

--- a/internal/media/example_test.go
+++ b/internal/media/example_test.go
@@ -1,0 +1,63 @@
+package media_test
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/brexhq/substation/internal/media"
+)
+
+func ExampleBytes() {
+	b := []byte("\x42\x5a\x68")
+	mediaType := media.Bytes(b)
+
+	fmt.Println(mediaType)
+	// Output: application/x-bzip2
+}
+
+func ExampleFile() {
+	// temp file is used to simulate an open file and must be removed after the test completes
+	file, _ := os.CreateTemp("", "substation")
+	defer os.Remove(file.Name())
+	defer file.Close()
+
+	file.Write([]byte("\x42\x5a\x68"))
+
+	// media.File moves the file offset to zero
+	mediaType, err := media.File(file)
+	if err != nil {
+		// handle err
+		panic(err)
+	}
+
+	fmt.Println(mediaType)
+	// Output: application/x-bzip2
+}
+
+func Example_switch() {
+	bytes := [][]byte{
+		// application/x-bzip2
+		[]byte("\x42\x5a\x68"),
+		// application/x-gzip
+		[]byte("\x1f\x8b\x08"),
+		// text/html
+		[]byte("\x3c\x68\x74\x6d\x6c\x3e"),
+	}
+
+	for _, b := range bytes {
+		// use a switch statement to contextually distribute data to other functions
+		switch media.Bytes(b) {
+		case "application/x-bzip2":
+			continue
+			// bzip2(b)
+		case "application/x-gzip":
+			continue
+			// gzip(b)
+		case "text/html; charset=utf-8":
+			continue
+			// html(b)
+		default:
+			continue
+		}
+	}
+}

--- a/internal/media/media.go
+++ b/internal/media/media.go
@@ -1,0 +1,37 @@
+// package media provides capabilities for inspecting the content of data and identifying its media (Multipurpose Internet Mail Extensions, MIME) type.
+package media
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"os"
+)
+
+// Bytes returns the media type of a byte slice.
+func Bytes(b []byte) string {
+	switch {
+	// bzip2 is undetected by http.DetectContentType
+	case bytes.HasPrefix(b, []byte("\x42\x5a\x68")):
+		return "application/x-bzip2"
+	default:
+		return http.DetectContentType(b)
+	}
+}
+
+// File returns the media type of an open file. The caller is responsible for resetting the position of the file.
+func File(f *os.File) (string, error) {
+	f.Seek(0, 0)
+
+	// http.DetectContentType reads the first 512 bytes of data
+	buf := make([]byte, 512)
+	n, err := f.Read(buf)
+	if err != nil {
+		return "", fmt.Errorf("media file: %v", err)
+	}
+
+	// buf is truncated to avoid false positives due to missing bytes
+	buf = buf[:n]
+
+	return Bytes(buf), nil
+}

--- a/internal/media/media.go
+++ b/internal/media/media.go
@@ -21,7 +21,9 @@ func Bytes(b []byte) string {
 
 // File returns the media type of an open file. The caller is responsible for resetting the position of the file.
 func File(f *os.File) (string, error) {
-	f.Seek(0, 0)
+	if _, err := f.Seek(0, 0); err != nil {
+		return "", fmt.Errorf("media file: %v", err)
+	}
 
 	// http.DetectContentType reads the first 512 bytes of data
 	buf := make([]byte, 512)

--- a/internal/media/media_test.go
+++ b/internal/media/media_test.go
@@ -1,0 +1,96 @@
+package media
+
+import (
+	"os"
+	"testing"
+)
+
+var mediaTests = []struct {
+	name     string
+	test     []byte
+	expected string
+}{
+	{
+		"bzip2",
+		[]byte("\x42\x5a\x68"),
+		"application/x-bzip2",
+	},
+	{
+		"gzip",
+		[]byte("\x1f\x8b\x08"),
+		"application/x-gzip",
+	},
+}
+
+func TestBytes(t *testing.T) {
+	for _, test := range mediaTests {
+		mediaType := Bytes(test.test)
+
+		if mediaType != test.expected {
+			t.Errorf("expected %s, got %s", test.expected, mediaType)
+		}
+	}
+}
+
+func benchmarkBytes(b *testing.B, test []byte) {
+	for i := 0; i < b.N; i++ {
+		_ = Bytes(test)
+	}
+}
+
+func BenchmarkBytes(b *testing.B) {
+	for _, test := range mediaTests {
+		b.Run(test.name,
+			func(b *testing.B) {
+				benchmarkBytes(b, test.test)
+			},
+		)
+	}
+}
+
+func TestFile(t *testing.T) {
+	for _, test := range mediaTests {
+		temp, err := os.CreateTemp("", "substation")
+		if err != nil {
+			t.Errorf("got error %v", err)
+		}
+		defer os.Remove(temp.Name())
+		defer temp.Close()
+
+		if _, err := temp.Write(test.test); err != nil {
+			t.Errorf("got error %v", err)
+		}
+
+		mediaType, err := File(temp)
+		if err != nil {
+			t.Errorf("got error %v", err)
+		}
+
+		if mediaType != test.expected {
+			t.Errorf("expected %s, got %s", test.expected, mediaType)
+		}
+	}
+}
+
+func benchmarkFile(b *testing.B, test *os.File) {
+	for i := 0; i < b.N; i++ {
+		_, _ = File(test)
+	}
+}
+
+func BenchmarkFile(b *testing.B) {
+	temp, _ := os.CreateTemp("", "substation")
+	defer os.Remove(temp.Name())
+	defer temp.Close()
+
+	for _, test := range mediaTests {
+		temp.Seek(0, 0)
+		temp.Write(test.test)
+
+		b.Run(test.name,
+			func(b *testing.B) {
+				benchmarkFile(b, temp)
+			},
+		)
+	}
+}

--- a/internal/media/media_test.go
+++ b/internal/media/media_test.go
@@ -84,8 +84,8 @@ func BenchmarkFile(b *testing.B) {
 	defer temp.Close()
 
 	for _, test := range mediaTests {
-		temp.Seek(0, 0)
-		temp.Write(test.test)
+		_, _ = temp.Seek(0, 0)
+		_, _ = temp.Write(test.test)
 
 		b.Run(test.name,
 			func(b *testing.B) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- Updates functions and methods that handle streaming data to use the io package
  - internal/aws/appconfig
  - internal/aws/s3manager
  - internal/file
  - internal/sink/s3
- Adds a `SetConfig` method to the Substation app that accepts an io.Reader
- Adds an internal package for detecting content (media) type of files
- Adds an internal package that wraps bufio and Scanner
- Moves the SUBSTATION_CONFIG handler from app.go to config.go
- Changes and moves the SUBSTATION_SCAN_METHOD handler from app.go to internal/bufio (breaking)
- Changes the Substation app to make the package private, except for the creation of a new app (breaking)
- Changes all published apps (cmd/aws/lambda, cmd/file, examples/service) to support changes made in this PR
  - cmd/file now dynamically retrieves configs from local disk, HTTP(S), or S3
  - cmd/aws/lambda now dynamically retrieves configs from local disk, HTTP(S), S3, or AppConfig
- Updated `CONTRIBUTING.md` with design pattern documentation for reading and writing streaming data

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently the project uses bytes in places where the io package makes more sense, specifically in handling of files. This is most risky when downloading content from cloud buckets and the web -- with bytes all of the content is read into memory at once, but io is more memory efficient because it's streaming data instead of putting it all into memory. Since we're a serverless application and some serverless providers (like AWS Lambda) [charge based on memory allocation](https://aws.amazon.com/lambda/pricing/), there's a tangible benefit to making the application more efficient on memory. More than that, switching to io decreases the likelihood that we'll need to do more refactors in the future. 

While refactoring these methods and functions a few other issues and opportunities came up:
- having a standardized way to create and use a bufio scanner
- having a standardized way to inspect files by media type
- making the core application private

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- All unit tests were converted from supporting bytes to io
- Packages that cannot be easily unit tested are supported by example tests -- these serve the dual function of testing and showing how to use packages
- Integration tested using the cmd/file app
- End to end tested using examples/aws in a development AWS account

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [x] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
