### PR TITLE
fix: ForEach JSON selection

### DIFF
--- a/process/for_each.go
+++ b/process/for_each.go
@@ -91,18 +91,15 @@ func (p ForEach) Apply(ctx context.Context, capsule config.Capsule) (config.Caps
 	// cause errors during iteration
 	conf, _ := gojson.Marshal(p.Options.Processor)
 
-	var inputKey, outputKey string
-	if _, ok := p.Options.Processor.Settings["input_key"]; ok {
-		inputKey = p.Options.Processor.Type + "." + p.Options.Processor.Settings["input_key"].(string)
-	} else {
-		inputKey = p.Options.Processor.Type
+	inputKey := p.Options.Processor.Type
+	if innerKey, ok := p.Options.Processor.Settings["input_key"].(string); ok && innerKey != "" {
+		inputKey = p.Options.Processor.Type + "." + innerKey
 	}
 	conf, _ = json.Set(conf, "settings.input_key", inputKey)
 
-	if _, ok := p.Options.Processor.Settings["output_key"]; ok {
-		outputKey = p.Options.Processor.Type + "." + p.Options.Processor.Settings["output_key"].(string)
-	} else {
-		outputKey = p.Options.Processor.Type
+	outputKey := p.Options.Processor.Type
+	if innerKey, ok := p.Options.Processor.Settings["output_key"].(string); ok && innerKey != "" {
+		outputKey = p.Options.Processor.Type + "." + innerKey
 	}
 	conf, _ = json.Set(conf, "settings.output_key", outputKey)
 


### PR DESCRIPTION
## Description

The ForEach JSON processor when used with the default jsonnet helpers pass an empty value for the inner processors `input_key`, this resulted in inner processor having a selection with a trailing `.` such as `processor_type.`. This fixes the issue by explicitly handling empty strings when checking the input/output keys.

## Motivation and Context

* Fixes usage of the for_each processor when used via jsonnet configurations.

## How Has This Been Tested?

This has been tested with the regression suite, and locally by using configuring a processor via jsonnet as follows and getting the expected result, whereas before this no input would be captured from the input array.

```jsonnet
// input: {"input_key": ["fizz", "buzz"]}
processlib.for_each('input_key', 'output_key', processlib.capture('', '', '(.*)'))
```

## Types of changes

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
