### PR TITLE
feat: process.Replace allow replacing with nothing

### DIFF
--- a/process/replace.go
+++ b/process/replace.go
@@ -74,8 +74,8 @@ func (p Replace) ApplyBatch(ctx context.Context, capsules []config.Capsule) ([]c
 // Apply processes encapsulated data with the Replace processor.
 func (p Replace) Apply(ctx context.Context, capsule config.Capsule) (config.Capsule, error) {
 	// error early if required options are missing
-	if p.Options.Old == "" || p.Options.New == "" {
-		return capsule, fmt.Errorf("process replace: options %+v: %v", p.Options, errMissingRequiredOptions)
+	if p.Options.Old == "" {
+		return capsule, fmt.Errorf("process replace: options %+v: %w", p.Options, errMissingRequiredOptions)
 	}
 
 	// default to replace all

--- a/process/replace_test.go
+++ b/process/replace_test.go
@@ -3,6 +3,7 @@ package process
 import (
 	"bytes"
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/brexhq/substation/config"
@@ -30,6 +31,20 @@ var replaceTests = []struct {
 		nil,
 	},
 	{
+		"json delete",
+		Replace{
+			Options: ReplaceOptions{
+				Old: "z",
+				New: "",
+			},
+			InputKey:  "foo",
+			OutputKey: "foo",
+		},
+		[]byte(`{"foo":"fizz"}`),
+		[]byte(`{"foo":"fi"}`),
+		nil,
+	},
+	{
 		"data",
 		Replace{
 			Options: ReplaceOptions{
@@ -40,6 +55,29 @@ var replaceTests = []struct {
 		[]byte(`bar`),
 		[]byte(`baz`),
 		nil,
+	},
+	{
+		"data delete",
+		Replace{
+			Options: ReplaceOptions{
+				Old: "r",
+				New: "",
+			},
+		},
+		[]byte(`bar`),
+		[]byte(`ba`),
+		nil,
+	},
+	{
+		"data",
+		Replace{
+			Options: ReplaceOptions{
+				New: "z",
+			},
+		},
+		[]byte(`bar`),
+		[]byte(`baz`),
+		errMissingRequiredOptions,
 	},
 }
 
@@ -52,6 +90,9 @@ func TestReplace(t *testing.T) {
 
 		result, err := test.proc.Apply(ctx, capsule)
 		if err != nil {
+			if errors.Is(err, test.err) {
+				continue
+			}
 			t.Error(err)
 		}
 


### PR DESCRIPTION
## Description

This loosens input checks for the replace processor to omitting a "New" value effectively deleting target substrings.

## Motivation and Context

During processing of input keys it's sometimes desirable to delete substrings that cause errors for downstream systems or are generally unwanted. This allows the `replace` processor to delete substrings if no new option is provided.

## How Has This Been Tested?

Tested with a internal pipeline and added further test harnessed to get coverage of the change. 

## Types of changes

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.