### PR TITLE
fix: Static gzip Media Signature

### DIFF
--- a/internal/media/media.go
+++ b/internal/media/media.go
@@ -11,9 +11,12 @@ import (
 // Bytes returns the media type of a byte slice.
 func Bytes(b []byte) string {
 	switch {
-	// bzip2 is undetected by http.DetectContentType
+	// http.DetectContentType cannot detect bzip2
 	case bytes.HasPrefix(b, []byte("\x42\x5a\x68")):
 		return "application/x-bzip2"
+	// http.DetectContentType occasionally (rarely) generates false positive matches for application/vnd.ms-fontobject when the bytes are application/x-gzip
+	case bytes.HasPrefix(b, []byte("\x1f\x8b\x08")):
+		return "application/x-gzip"
 	default:
 		return http.DetectContentType(b)
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- Adds a static media signature for application/x-gzip

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

There is an occasional media identification bug when retrieving compressed CloudTrail files from AWS S3 -- [http.DetectContentType](https://pkg.go.dev/net/http#DetectContentType) incorrectly identifies the media type as `application/vnd.ms-fontobject`. The bug is rare (at Brex we process more than 100k compressed CloudTrail files every day and we see the bug, at most, once every few months) but it needs to be fixed because it results in data loss.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The fix was integration tested with a CloudTrail file known to trigger the false match. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
