### PR TITLE
chore: upgrade and pin to Go1.19

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/go:1.17
+FROM mcr.microsoft.com/vscode/devcontainers/go:1.19
 RUN sudo apt-get update && \
     # install Terraform
     cd /tmp/ && \

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -16,7 +16,7 @@ jobs:
     - name: setup
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: 1.19
 
     - name: tests
       run: go test -timeout 30s -v ./... 

--- a/build/container/aws/lambda/autoscaling/Dockerfile
+++ b/build/container/aws/lambda/autoscaling/Dockerfile
@@ -1,6 +1,6 @@
 ARG AWS_ARCHITECTURE=x86_64
 
-FROM golang as build
+FROM golang:1.19 as build
 ENV GO111MODULE=on
 
 # install AppConfig Lambda extension

--- a/build/container/aws/lambda/substation/Dockerfile
+++ b/build/container/aws/lambda/substation/Dockerfile
@@ -1,6 +1,6 @@
 ARG AWS_ARCHITECTURE=x86_64
 
-FROM golang as build
+FROM golang:1.19 as build
 ENV GO111MODULE=on
 
 # build AppConfig Lambda extension

--- a/build/container/file/Dockerfile
+++ b/build/container/file/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang as build
+FROM golang:1.19 as build
 ENV GO111MODULE=on
 
 # install deps

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/brexhq/substation
 
-go 1.17
+go 1.19
 
 require (
 	github.com/aws/aws-lambda-go v1.30.0


### PR DESCRIPTION
## Description

Moves all containers to pinned versions of Go 1.19, and updates the minimum supported version as well.

## Motivation and Context

This change reduces the risk of an ambiguous Go version from being deployed without specifying a container tag. It also moves the project's devlopment environment up to the latest stable release to unlock new Go features/updates such as generics and general performance improvements. The current development version Go1.17 is no longer supported and does not receive security fixes so it needs to be upgraded.

## How Has This Been Tested?

At Brex we have been using Go1.19 in production since Substation v0.4.0 due the container not specifying a tag, there have been no issues with this version.

## Types of changes

* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

* [ ] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
