### PR TITLE
feat: Add Sort Key Support to the AWS DynamoDB KV Store

### DIFF
--- a/build/config/substation.libsonnet
+++ b/build/config/substation.libsonnet
@@ -901,16 +901,12 @@
           local kv_hit = $.interfaces.operator.all([
             $.patterns.inspector.length.gt_zero(key=_store_key),
           ]),
-          local kv_miss = $.interfaces.operator.all([
-            $.patterns.inspector.length.eq_zero(key=_store_key),
-          ]),
 
           // if there was no result from the KV store and the processor flag is bool
           // true, then the processor runs
-          local run_processor = $.interfaces.operator.all([
+          local kv_miss = $.interfaces.operator.all([
             $.patterns.inspector.length.eq_zero(key=_store_key),
             $.patterns.inspector.length.gt_zero(key=_processor_flag),
-            $.patterns.inspector.length.eq_zero(key=_store_key),
           ]),
 
           // if the processor ran and the result is null, then a static value is
@@ -956,7 +952,7 @@
                 options={ separator: ':' }
               ),
               // if there is a miss and the processor flag is true, then the processor runs
-              $.patterns.processor.replace_condition(processor, condition=run_processor, force=true).processor[0],
+              $.patterns.processor.replace_condition(processor, condition=kv_miss, force=true).processor[0],
               // if the processor result is null, then a static value is created in its place
               // the value indicates which processor produced the null value (e.g., 'dns:null')
               $.interfaces.processor.insert(

--- a/build/config/substation.libsonnet
+++ b/build/config/substation.libsonnet
@@ -36,7 +36,7 @@
     },
     kv_store: {
       aws_dynamodb: {
-        settings: { table: null, attributes: { partition_key: null, value: null, ttl: null } },
+        settings: { table: null, attributes: { partition_key: null, sort_key: null, value: null, ttl: null } },
       },
       csv_file: {
         settings: { file: null, column: null, delimiter: ',', header: null },

--- a/build/terraform/aws/dynamodb/main.tf
+++ b/build/terraform/aws/dynamodb/main.tf
@@ -9,7 +9,7 @@ resource "aws_dynamodb_table" "table" {
   # services can opt in to use TTL functionality at runtime
   # https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/TTL.html
   ttl {
-    attribute_name = "TTL"
+    attribute_name = "ttl"
     enabled        = true
   }
   point_in_time_recovery {

--- a/build/terraform/aws/iam/main.tf
+++ b/build/terraform/aws/iam/main.tf
@@ -88,6 +88,7 @@ data "aws_iam_policy_document" "dynamodb_read" {
   statement {
     effect = "Allow"
     actions = [
+      "dynamodb:GetItem",
       "dynamodb:Query",
     ]
     resources = var.resources


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Adds Sort (Range) Key support to the AWS DynamoDB KV store
- Fixes a bug in the kv_store.cache_aside pattern that caused unnecessary sets to KV stores
- Updated Terraform configs

<!--- Describe your changes in detail -->

## Motivation and Context

This is an addendum to #66 to provide support for DynamoDB tables that follow [single-table design](https://aws.amazon.com/blogs/compute/creating-a-single-table-design-with-amazon-dynamodb/), fix a bug in the KV store cache-aside pattern, and clean up some Terraform modules.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Integration tested with DynamoDB tables that use primary keys (partition key) and composite primary keys (partition key and sort key).

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [x] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
