### PR TITLE
chore: jsonnet-lint updates

### DIFF
--- a/build/config/substation.libsonnet
+++ b/build/config/substation.libsonnet
@@ -100,6 +100,9 @@
       insert: {
         options: { value: null },
       },
+      ip_database: {
+        options: { type: null, settings: null }
+      },
       join: {
         options: { separator: null },
       },
@@ -366,13 +369,13 @@
         local s = std.mergePatch($.interfaces.processor.settings, settings),
 
         type: 'drop',
-        settings: settings,
+        settings: s,
       },
       expand(settings=$.interfaces.processor.settings): {
         local s = std.mergePatch($.interfaces.processor.settings, settings),
 
         type: 'expand',
-        settings: settings,
+        settings: s,
       },
       flatten(options=$.defaults.processor.flatten.options,
               settings=$.interfaces.processor.settings): {
@@ -398,7 +401,7 @@
         type: 'group',
         settings: std.mergePatch({ options: opt }, s),
       },
-      gzip(options=$.defaults.gzip.capture.options,
+      gzip(options=$.defaults.processor.gzip.options,
            settings=$.interfaces.processor.settings): {
         local opt = std.mergePatch($.defaults.processor.gzip.options, options),
         local s = std.mergePatch($.interfaces.processor.settings, settings),
@@ -422,12 +425,13 @@
         type: 'insert',
         settings: std.mergePatch({ options: opt }, s),
       },
-      ip_database(options=$.defaults.processor.insert.options,
+      ip_database(options=$.defaults.processor.ip_database.options,
                   settings=$.interfaces.processor.settings): {
+        local opt = std.mergePatch($.defaults.processor.ip_database.options, options),
         local s = std.mergePatch($.interfaces.processor.settings, settings),
 
         type: 'ip_database',
-        settings: std.mergePatch({ options: options }, s),
+        settings: std.mergePatch({ options: opt }, s),
       },
       join(options=$.defaults.processor.join.options,
            settings=$.interfaces.processor.settings): {
@@ -461,9 +465,9 @@
         type: 'pipeline',
         settings: std.mergePatch({ options: opt }, s),
       },
-      pretty_print(options=$.defaults.processor.direction.options,
+      pretty_print(options=$.defaults.processor.pretty_print.options,
                    settings=$.interfaces.processor.settings): {
-        local opt = std.mergePatch($.defaults.processor.direction.options, options),
+        local opt = std.mergePatch($.defaults.processor.pretty_print.options, options),
         local s = std.mergePatch($.interfaces.processor.settings, settings),
 
         type: 'pretty_print',


### PR DESCRIPTION
## Description

This handles copy/paste errors and `jsonnet-lint` cases in the `substation.libsonnet` library file.

## Motivation and Context

This change improves Jsonnet code quality by reducing errors such as unused variables, and copy-paste mistakes. We can't enable jsonnet-lint in CI because there are false positive lints that can't be overridden.

## How Has This Been Tested?

Changes here have been used in internal pipelines and ensured it works correctly.

## Types of changes

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
