### PR TITLE
feat: Add Object Interpretation to Capture Named Groups

### DIFF
--- a/process/capture_test.go
+++ b/process/capture_test.go
@@ -72,6 +72,22 @@ var captureTests = []struct {
 		[]byte(`{"foo":"bar","qux":"quux"}`),
 		nil,
 	},
+	{
+		"named_group",
+		procCapture{
+			process: process{
+				Key:    "capture",
+				SetKey: "capture",
+			},
+			Options: procCaptureOptions{
+				Type:       "named_group",
+				Expression: "(?P<foo>[a-zA-Z]+) (?P<qux>[a-zA-Z]+)",
+			},
+		},
+		[]byte(`{"capture":"bar quux"}`),
+		[]byte(`{"capture":{"foo":"bar","qux":"quux"}}`),
+		nil,
+	},
 }
 
 func TestCapture(t *testing.T) {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

- Adds named group support to object interpretation in the Capture processor

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Okta's audit logs contain unusual pseudo-JSON like this ...
```json
{
	"debugContext": {
		"debugData": {
			"behaviors": "{New Geo-Location=NEGATIVE, New Device=NEGATIVE, New IP=NEGATIVE, New State=NEGATIVE, New Country=NEGATIVE, Velocity=NEGATIVE, New City=NEGATIVE}"
		}
	}
}
```

... that would be much better if it were like this instead:
```json
{
	"debugContext": {
		"debugData": {
			"behaviors": {
				"New Geo-Location": "NEGATIVE",
				"New Device": "NEGATIVE",
				"New IP": "NEGATIVE",
				"New State": "NEGATIVE",
				"New Country": "NEGATIVE",
				"Velocity": "NEGATIVE",
				"New City": "NEGATIVE"
			}
		}
	}
}
```

This PR makes that possible by nesting captured fields under the `set_key` configuration.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added new unit testing.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [x] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
