### PR TITLE
feat: Add SetKey Support to Expand Processor

### DIFF
--- a/process/expand_test.go
+++ b/process/expand_test.go
@@ -16,39 +16,113 @@ var expandTests = []struct {
 	err      error
 }{
 	{
-		"JSON",
+		"objects",
 		procExpand{
 			process: process{
-				Key: "expand",
+				Key: "a",
 			},
 		},
-		[]byte(`{"expand":[{"foo":"bar"}]}`),
+		[]byte(`{"a":[{"b":"c"}]}`),
 		[][]byte{
-			[]byte(`{"foo":"bar"}`),
+			[]byte(`{"b":"c"}`),
 		},
 		nil,
 	},
 	{
-		"JSON extra key",
+		"objects with key",
 		procExpand{
 			process: process{
-				Key: "expand",
+				Key: "a",
 			},
 		},
-		[]byte(`{"expand":[{"foo":"bar"},{"quux":"corge"}],"baz":"qux"}`),
+		[]byte(`{"a":[{"b":"c"},{"d":"e"}],"x":"y"}`),
 		[][]byte{
-			[]byte(`{"foo":"bar","baz":"qux"}`),
-			[]byte(`{"quux":"corge","baz":"qux"}`),
+			[]byte(`{"x":"y","b":"c"}`),
+			[]byte(`{"x":"y","d":"e"}`),
 		},
 		nil,
 	},
 	{
-		"data",
+		"non-objects with key",
+		procExpand{
+			process: process{
+				Key: "a",
+			},
+		},
+		[]byte(`{"a":["b","c"],"d":"e"}`),
+		[][]byte{
+			[]byte(`{"d":"e"}`),
+			[]byte(`{"d":"e"}`),
+		},
+		nil,
+	},
+	{
+		"objects with set key",
+		procExpand{
+			process: process{
+				Key:    "a",
+				SetKey: "a",
+			},
+		},
+		[]byte(`{"a":[{"b":"c"},{"d":"e"}],"x":"y"}`),
+		[][]byte{
+			[]byte(`{"x":"y","a":{"b":"c"}}`),
+			[]byte(`{"x":"y","a":{"d":"e"}}`),
+		},
+		nil,
+	},
+	{
+		"strings with key",
+		procExpand{
+			process: process{
+				Key:    "a",
+				SetKey: "a",
+			},
+		},
+		[]byte(`{"a":["b","c"],"d":"e"}`),
+		[][]byte{
+			[]byte(`{"d":"e","a":"b"}`),
+			[]byte(`{"d":"e","a":"c"}`),
+		},
+		nil,
+	},
+	{
+		"objects with deeply nested set key",
+		procExpand{
+			process: process{
+				Key:    "a.b",
+				SetKey: "a.b.c.d",
+			},
+		},
+		[]byte(`{"a":{"b":[{"g":"h"},{"i":"j"}],"x":"y"}}`),
+		[][]byte{
+			[]byte(`{"a":{"x":"y","b":{"c":{"d":{"g":"h"}}}}}`),
+			[]byte(`{"a":{"x":"y","b":{"c":{"d":{"i":"j"}}}}}`),
+		},
+		nil,
+	},
+	{
+		"objects overwriting set key",
+		procExpand{
+			process: process{
+				Key:    "a.b",
+				SetKey: "a",
+			},
+		},
+		[]byte(`{"a":{"b":[{"c":"d"},{"e":"f"}],"x":"y"}}`),
+		[][]byte{
+			[]byte(`{"a":{"c":"d"}}`),
+			[]byte(`{"a":{"e":"f"}}`),
+		},
+		nil,
+	},
+	{
+		"data array",
 		procExpand{},
-		[]byte(`[{"foo":"bar"},{"quux":"corge"}]`),
+		[]byte(`[{"a":"b"},{"c":"d"}]`),
 		[][]byte{
-			[]byte(`{"foo":"bar"}`),
-			[]byte(`{"quux":"corge"}`),
+			[]byte(`{"a":"b"}`),
+			[]byte(`{"c":"d"}`),
 		},
 		nil,
 	},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- Adds SetKey support to the Expand processor

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Some data sources have complex object structures with either deeply nested arrays of objects or multiple layers of arrays of objects. For example:
```json
{
	"a": {
		"b": {
			"c": [{
				"d": "e"
			}],
			"h": {
				"i": 1
			}
		}
	},
	"j": {
		"k": 1
	}
}
```

The processor currently pushes `{ "d": "e" }` to the top of the object like this:
```json
{
	"d": "e",
	"a": {
		"b": {
			"h": {
				"i": 1
			}
		}
	},
	"j": {
		"k": 1
	}
}
```

This makes it nearly impossible to modify the structure of the object after the processor runs because the content of the array is dynamic. This change adds SetKey support which makes this possible (if the SetKey is "x.y"):
```json
{
	"a": {
		"b": {
			"h": {
				"i": 1
			}
		}
	},
	"j": {
		"k": 1
	},
	"x": {
		"y": {
			"d": "e"
		}
	}
}
```

This has some other benefits, like making the expansion of non-object arrays possible.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Refactored and added new unit tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [x] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
