### PR TITLE
feat(CLI): adds force-sink flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ CHANGELOG.md
 !examples/*/data.json
 !examples/quickstart/data.json
 
+# Ignore macOS system files
+.DS_Store
+
 # Archive files
 *.zip
 

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -79,6 +80,16 @@ func (sub *substation) SetConfig(r io.Reader) error {
 	}
 
 	return nil
+}
+
+// GetConfig retreives the configuration of the app.
+func (sub *substation) GetConfig() (io.Reader, error) {
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(sub.config); err != nil {
+		return nil, err
+	}
+
+	return &buf, nil
 }
 
 // Concurrency returns the concurrency setting of the app.

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -82,8 +82,8 @@ func (sub *substation) SetConfig(r io.Reader) error {
 	return nil
 }
 
-// GetConfig retreives the configuration of the app.
-func (sub *substation) GetConfig() (io.Reader, error) {
+// Config retreives the configuration of the app.
+func (sub *substation) Config() (io.Reader, error) {
 	var buf bytes.Buffer
 	if err := json.NewEncoder(&buf).Encode(sub.config); err != nil {
 		return nil, err

--- a/cmd/development/substation/main.go
+++ b/cmd/development/substation/main.go
@@ -86,7 +86,7 @@ func run(ctx context.Context, opts options) error {
 	}
 
 	if opts.ForceSink != "" {
-		c, err = sub.GetConfig()
+		c, err = sub.Config()
 		if err != nil {
 			return fmt.Errorf("run: %v", err)
 		}


### PR DESCRIPTION
## Description

This adds a `-force-sink` flag to the `development` app to mutate the Sink configuration to a user overridden value. This currently only supports the standard output sink but can be extended to override HTTP, S3 or any sink.

## Motivation and Context

When iterating on Substation configs and checking output for pipelines typically destined to a remote output a developer needs to edit the configuration's sink to check results. This change often meant for local testing is an error prone chore which can be automated for this use case via the new `-force-sink stdout` flag for the `development` app.

## How Has This Been Tested?

I've been using this locally for a few months to save some config while testing.

```bash
$ substation -h
...
  -force-sink string
    	force sink output to value (supported: stdout)
...
$ substation -force-sink stdout ...
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
