### PR TITLE
feat: Add Lexicographical Types to condition/strings

### DIFF
--- a/condition/strings.go
+++ b/condition/strings.go
@@ -29,6 +29,10 @@ type inspStringsOptions struct {
 	// - starts_with
 	//
 	// - ends_with
+	//
+	// - greater_than
+	//
+	// - less_than
 	Type string `json:"type"`
 	// Expression is a substring used during inspection.
 	Expression string `json:"expression"`
@@ -59,6 +63,10 @@ func (c inspStrings) Inspect(ctx context.Context, capsule config.Capsule) (outpu
 		matched = strings.HasPrefix(check, c.Options.Expression)
 	case "ends_with":
 		matched = strings.HasSuffix(check, c.Options.Expression)
+	case "greater_than":
+		matched = strings.Compare(check, c.Options.Expression) > 0
+	case "less_than":
+		matched = strings.Compare(check, c.Options.Expression) < 0
 	default:
 		return false, fmt.Errorf("condition: strings: type %s: %v", c.Options.Type, errors.ErrInvalidType)
 	}

--- a/condition/strings_test.go
+++ b/condition/strings_test.go
@@ -171,6 +171,56 @@ var stringsTests = []struct {
 		[]byte(``),
 		true,
 	},
+	{
+		"pass",
+		inspStrings{
+			Options: inspStringsOptions{
+				Type:       "greater_than",
+				Expression: "a",
+			},
+		},
+		[]byte("b"),
+		true,
+	},
+	{
+		"pass",
+		inspStrings{
+			Options: inspStringsOptions{
+				Type:       "less_than",
+				Expression: "c",
+			},
+		},
+		[]byte("b"),
+		true,
+	},
+	{
+		"pass",
+		inspStrings{
+			condition: condition{
+				Key: "a",
+			},
+			Options: inspStringsOptions{
+				Type:       "greater_than",
+				Expression: "2022-01-01T00:00:00Z",
+			},
+		},
+		[]byte(`{"a":"2023-01-01T00:00:00Z"}`),
+		true,
+	},
+	{
+		"pass",
+		inspStrings{
+			condition: condition{
+				Key: "a",
+			},
+			Options: inspStringsOptions{
+				Type:       "less_than",
+				Expression: "2024-01",
+			},
+		},
+		[]byte(`{"a":"2023-01-01T00:00:00Z"}`),
+		true,
+	},
 }
 
 func TestStrings(t *testing.T) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Adds a `greater_than` type to condition/strings
- Adds a `less_than` type to condition/strings

<!--- Describe your changes in detail -->

## Motivation and Context

Lexicographical string comparison can be useful when retroactively parsing data (e.g., during rehydration) or for validating data. These new types use the same syntax as conditions/length.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Added new unit tests.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [x] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
