### PR TITLE
build: S3 Rehydration Python Script

### DIFF
--- a/build/scripts/aws/README.md
+++ b/build/scripts/aws/README.md
@@ -25,6 +25,14 @@ Python script that manages the upload and deployment of compiled Substation JSON
 
 This script is intended to be deployed to a CI / CD pipeline (e.g., GitHub Actions, Circle CI, Jenkins, etc.), but can be run locally if needed. See [examples/aws/](/examples/aws/) for example usage.
 
+## s3/s3_rehydration.py
+
+Python script that rehydrates data from an S3 bucket into an SNS topic by simulating S3 
+object creation events. This script has some dependencies:
+
+* boto3 must be installed
+* AWS credentials for reading from S3 and writing to SNS
+
 ## lambda/get_appconfig_extension.sh
 
 Bash script that is used to download the [AWS AppConfig Lambda extension](https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html) for any AWS region. This extension is required for deploying Substation to AWS Lambda.

--- a/build/scripts/aws/s3/s3_rehydration.py
+++ b/build/scripts/aws/s3/s3_rehydration.py
@@ -1,0 +1,109 @@
+"""
+Rehydrates data from an AWS S3 bucket into an SNS topic by simulating S3 
+object creation events.
+
+Typical usage example:
+
+    python3 s3_rehydration.py --bucket my-bucket --topic my-topic 
+    --prefix my-prefix --filter my-filter my-other-filter
+"""
+
+import argparse
+import boto3
+import json
+import logging
+import os
+import time
+
+from botocore.exceptions import ClientError
+
+logging.getLogger().setLevel(logging.INFO)
+
+S3 = boto3.client("s3")
+SNS = boto3.client("sns")
+
+
+def main():
+    args = argparse.ArgumentParser(
+        description="""Rehydrates data from an AWS S3 bucket into an SNS topic by 
+        simulating S3 object creation events. If no --prefix and --filter are specified, all objects in the bucket are rehydrated.""",
+        add_help=True,
+    )
+    args.add_argument("--bucket", required=True, help="S3 bucket name")
+    args.add_argument("--topic", required=True, help="SNS topic ARN")
+    args.add_argument("--prefix", required=False, help="S3 prefix")
+    args.add_argument(
+        "--filter",
+        default=[],
+        nargs="+",
+        required=False,
+        help="filter S3 object keys using substrings",
+    )
+    args = args.parse_args()
+
+    try:
+        S3.head_bucket(Bucket=args.bucket)
+    except ClientError as e:
+        logging.exception(f'bucket "{args.bucket}" not found')
+
+    try:
+        SNS.get_topic_attributes(TopicArn=args.topic)
+    except ClientError as e:
+        logging.exception(f'topic "{args.topic}" not found')
+
+    continuation_token = None
+    while 1:
+        objects = S3.list_objects_v2(
+            Bucket=args.bucket,
+            Prefix=args.prefix,
+            MaxKeys=1000,
+            EncodingType="url",
+        )
+        if continuation_token:
+            objects["NextContinuationToken"] = continuation_token
+
+        count = 0
+        for o in objects.get("Contents", []):
+            if not args.filter or all(x in o.get("Key") for x in args.filter):
+                event = {
+                    "Records": [
+                        {
+                            "eventVersion": "2.2",
+                            "eventSource": "aws:s3",
+                            "awsRegion": os.environ.get("AWS_REGION"),
+                            "eventTime": time.strftime(
+                                "%Y-%m-%dT%H:%M:%SZ", time.gmtime()
+                            ),
+                            "eventName": "ObjectCreated:*",
+                            "userIdentity": {
+                                "principalId": os.environ.get("AWS_ACCOUNT_ID"),
+                            },
+                            "s3": {
+                                "s3SchemaVersion": "1.0",
+                                "configurationId": "substation_s3_rehydrate",
+                                "bucket": {
+                                    "name": args.bucket,
+                                    "arn": f"arn:aws:s3:::{args.bucket}",
+                                },
+                                "object": {
+                                    "key": o.get("Key"),
+                                    "size": o.get("Size"),
+                                    "eTag": o.get("ETag"),
+                                },
+                            },
+                        }
+                    ]
+                }
+
+                SNS.publish(TopicArn=args.topic, Message=json.dumps(event))
+                count += 1
+
+        logging.info(f"rehydrated {count} object(s)")
+
+        continuation_token = objects.get("NextContinuationToken")
+        if not continuation_token:
+            break
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- Adds a Python script that allows for rehydrating data from S3 into Substation via SNS

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This addresses a use case where teams need to rehydrate (re-ingest) data from an S3 bucket into Substation. No new infrastructure is required to use this (if the team is already using SNS notifications for S3), the script simulates the object notification that S3 sends to Lambda.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Integration tested in a development AWS account using an S3 bucket, SNS topic, and Substation Lambda running the AWS_S3_SNS handler.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [x] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
