### PR TITLE
[FIX] Remove custom error type implementation

### DIFF
--- a/cmd/aws/lambda/substation/lambda.go
+++ b/cmd/aws/lambda/substation/lambda.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/brexhq/substation/cmd"
 	"github.com/brexhq/substation/config"
-	"github.com/brexhq/substation/internal/errors"
 	"github.com/brexhq/substation/internal/service"
 	"golang.org/x/sync/errgroup"
 )
@@ -80,7 +79,7 @@ func lambdaAsyncHandler(ctx context.Context, event json.RawMessage) error {
 
 // errLambdaSyncMultipleItems is returned when an invocation of the lambdaSync handler
 // produces multiple items, which cannot be returned.
-const errLambdaSyncMultipleItems = errors.Error("transformed data into multiple items")
+var errLambdaSyncMultipleItems = fmt.Errorf("transformed data into multiple items")
 
 // lambdaSyncHandler implements ITL using a request-reply service that is triggered
 // by synchronous invocation of the Lambda. Read more about synchronous invocation here:

--- a/cmd/aws/lambda/substation/main.go
+++ b/cmd/aws/lambda/substation/main.go
@@ -10,17 +10,16 @@ import (
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/brexhq/substation/config"
 	"github.com/brexhq/substation/internal/aws/appconfig"
-	"github.com/brexhq/substation/internal/errors"
 	"github.com/brexhq/substation/internal/file"
 )
 
 var handler string
 
 // errLambdaMissingHandler is returned when the Lambda is deployed without a configured handler.
-const errLambdaMissingHandler = errors.Error("missing SUBSTATION_HANDLER environment variable")
+var errLambdaMissingHandler = fmt.Errorf("missing SUBSTATION_HANDLER environment variable")
 
 // errLambdaInvalidHandler is returned when the Lambda is deployed with an unsupported handler.
-const errLambdaInvalidHandler = errors.Error("invalid handler")
+var errLambdaInvalidHandler = fmt.Errorf("invalid handler")
 
 // getConfig contextually retrieves a Substation configuration.
 func getConfig(ctx context.Context) (io.Reader, error) {

--- a/condition/condition.go
+++ b/condition/condition.go
@@ -11,7 +11,7 @@ import (
 
 // errOperatorMissingInspectors is returned when an Operator that requires
 // inspectors is created with no inspectors.
-const errOperatorMissingInspectors = errors.Error("missing inspectors")
+var errOperatorMissingInspectors = fmt.Errorf("missing inspectors")
 
 type condition struct {
 	// Key retrieves a value from an object for inspection.

--- a/config/config.go
+++ b/config/config.go
@@ -3,16 +3,16 @@ package config
 
 import (
 	gojson "encoding/json"
+	"fmt"
 	"os"
 	"strings"
 	"sync"
 
-	"github.com/brexhq/substation/internal/errors"
 	"github.com/brexhq/substation/internal/json"
 )
 
 // errSetInvalidKey is returned when an invalid key is used in a Capsule Set function.
-const errSetInvalidKey = errors.Error("invalid set key")
+var errSetInvalidKey = fmt.Errorf("invalid set key")
 
 // Config is a template used by Substation interface factories to produce new instances from JSON configurations. Type refers to the type of instance and Settings contains options used in the instance. Examples of this are found in the condition and process packages.
 type Config struct {

--- a/internal/aws/appconfig/appconfig.go
+++ b/internal/aws/appconfig/appconfig.go
@@ -7,12 +7,11 @@ import (
 	"io"
 	"os"
 
-	"github.com/brexhq/substation/internal/errors"
 	"github.com/brexhq/substation/internal/http"
 )
 
 // errMissingPrefetchEnvVar is returned when a Lambda is deployed without a configured AppConfig URL.
-const errMissingPrefetchEnvVar = errors.Error("missing AWS_APPCONFIG_EXTENSION_PREFETCH_LIST environment variable")
+var errMissingPrefetchEnvVar = fmt.Errorf("missing AWS_APPCONFIG_EXTENSION_PREFETCH_LIST environment variable")
 
 var client http.HTTP
 

--- a/internal/bufio/bufio.go
+++ b/internal/bufio/bufio.go
@@ -10,12 +10,11 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/brexhq/substation/internal/errors"
 	"github.com/brexhq/substation/internal/media"
 )
 
 // errInvalidMethod is returned when an invalid scanner method is provided.
-const errInvalidMethod = errors.Error("invalid scanner method")
+var errInvalidMethod = fmt.Errorf("invalid scanner method")
 
 // NewScanner returns a new scanner with default settings provided by scanCapacity and scanMethod.
 func NewScanner() *scanner {

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,17 +1,12 @@
 package errors
 
-// Error is an exported constant error string
-// use of constant errors is based on this blog post: https://dave.cheney.net/2016/04/07/constant-errors
-// constant errors make it easier to reference errors across the application
-type Error string
-
-func (e Error) Error() string { return string(e) }
+import "fmt"
 
 // ErrInvalidFactoryInput is returned when an unsupported input is referenced in any factory function.
-const ErrInvalidFactoryInput = Error("invalid factory input")
+var ErrInvalidFactoryInput = fmt.Errorf("invalid factory input")
 
 // ErrMissingRequiredOption is returned when a component does not have the required options to properly run.
-const ErrMissingRequiredOption = Error("missing required option")
+var ErrMissingRequiredOption = fmt.Errorf("missing required option")
 
 // ErrInvalidOption is returned when an invalid option input received in a constructor.
-const ErrInvalidOption = Error("invalid option input")
+var ErrInvalidOption = fmt.Errorf("invalid option input")

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/brexhq/substation/internal/aws/s3manager"
-	"github.com/brexhq/substation/internal/errors"
 	"github.com/brexhq/substation/internal/http"
 )
 
@@ -19,10 +18,10 @@ var (
 )
 
 // errEmptyFile is returned when Get is called but finds an empty file.
-const errEmptyFile = errors.Error("empty file found")
+var errEmptyFile = fmt.Errorf("empty file found")
 
 // errNoFile is returned when Get is called but no file is found.
-const errNoFile = errors.Error("no file found")
+var errNoFile = fmt.Errorf("no file found")
 
 /*
 Get retrieves a file from these locations (in order):

--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -7,12 +7,10 @@ import (
 
 	"github.com/aws/aws-xray-sdk-go/xray"
 	"github.com/hashicorp/go-retryablehttp"
-
-	"github.com/brexhq/substation/internal/errors"
 )
 
 // errHTTPInvalidPayload is returned by Post when it receives an unexpected payload interface.
-const errHTTPInvalidPayload = errors.Error("invalid payload interface")
+var errHTTPInvalidPayload = fmt.Errorf("invalid payload interface")
 
 // Header contains a single HTTP header that can be passed to HTTP.Post. Multiple headers can be passed to HTTP.Post as a slice.
 type Header struct {

--- a/internal/ip/ip.go
+++ b/internal/ip/ip.go
@@ -1,10 +1,10 @@
 // package ip provides tools for modifying IP address data.
 package ip
 
-import "github.com/brexhq/substation/internal/errors"
+import "fmt"
 
 // ErrInvalidIPAddress is returned when an invalid IP address is referenced in any function or method.
-const ErrInvalidIPAddress = errors.Error("invalid IP address")
+var ErrInvalidIPAddress = fmt.Errorf("invalid IP address")
 
 // Getter provides a method for getting an enrichment record from any IP address enrichment source.
 type Getter interface {

--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -12,11 +12,10 @@ import (
 	"github.com/tidwall/sjson"
 
 	"github.com/brexhq/substation/internal/base64"
-	"github.com/brexhq/substation/internal/errors"
 )
 
 // errSetRawInvalid is returned when SetRaw receives an invalid input value.
-const errSetRawInvalid = errors.Error("invalid value interface")
+var errSetRawInvalid = fmt.Errorf("invalid value interface")
 
 // Types maps gjson.Type to strings.
 var Types = map[gjson.Type]string{

--- a/internal/kv/csv_file.go
+++ b/internal/kv/csv_file.go
@@ -17,7 +17,7 @@ import (
 )
 
 // errCSVFileColumnNotFound is returned when the column is not found in the CSV header.
-var errCSVFileColumnNotFound = errors.Error("column not found")
+var errCSVFileColumnNotFound = fmt.Errorf("column not found")
 
 // kvCSVFile is a read-only key-value store that is derived from a CSV file and
 // stored in memory.

--- a/internal/kv/kv.go
+++ b/internal/kv/kv.go
@@ -14,7 +14,7 @@ var (
 	mu sync.Mutex
 	m  map[string]Storer
 	// errSetNotSupported is returned when the KV set action is not supported.
-	errSetNotSupported = errors.Error("set not supported")
+	errSetNotSupported = fmt.Errorf("set not supported")
 )
 
 // Storer provides tools for getting values from and putting values into key-value stores.

--- a/internal/kv/mmdb.go
+++ b/internal/kv/mmdb.go
@@ -17,7 +17,7 @@ import (
 
 // errMMDBKeyMustBeAddr is returned when the key used in a Get call is not a valid
 // IP address.
-var errMMDBKeyMustBeAddr = errors.Error("key must be IP address")
+var errMMDBKeyMustBeAddr = fmt.Errorf("key must be IP address")
 
 // KvMMDB is a read-only key-value store that is derived from any MaxMind database
 // format (MMDB) file.

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/brexhq/substation/config"
 	"github.com/brexhq/substation/internal/aws/secretsmanager"
-	"github.com/brexhq/substation/internal/errors"
 	"github.com/brexhq/substation/internal/kv"
 )
 
@@ -25,7 +24,7 @@ var (
 )
 
 // errSecretNotFound is returned when Get is called but no secret is found.
-const errSecretNotFound = errors.Error("secret not found")
+var errSecretNotFound = fmt.Errorf("secret not found")
 
 // ttl enforces a 15 minute rotation for all secrets stored in memory.
 const ttl = 15 * 60

--- a/internal/sink/aws_dynamodb.go
+++ b/internal/sink/aws_dynamodb.go
@@ -18,7 +18,7 @@ var dynamodbAPI dynamodb.API
 //
 // If this error occurs, then parse the data into an object (or drop invalid objects)
 // before it reaches the sink.
-const errDynamoDBNonObject = errors.Error("input must be object")
+var errDynamoDBNonObject = fmt.Errorf("input must be object")
 
 // awsDynamodb sinks data to an AWS DynamoDB table.
 //

--- a/internal/sink/aws_kinesis_firehose.go
+++ b/internal/sink/aws_kinesis_firehose.go
@@ -23,7 +23,7 @@ Kinesis Firehose record size limit. If this error occurs,
 then conditions or processors should be applied to either
 drop or reduce the size of the data.
 */
-const errFirehoseRecordSizeLimit = errors.Error("data exceeded size limit")
+var errFirehoseRecordSizeLimit = fmt.Errorf("data exceeded size limit")
 
 // awsKinesisFirehose sinks data to an AWS Kinesis Firehose Delivery Stream.
 //

--- a/internal/sink/aws_sqs.go
+++ b/internal/sink/aws_sqs.go
@@ -22,7 +22,7 @@ errSQSMessageSizeLimit is returned when data exceeds the SQS message
 size limit. If this error occurs, then conditions or processors
 should be applied to either drop or reduce the size of the data.
 */
-const errSQSMessageSizeLimit = errors.Error("data exceeded size limit")
+var errSQSMessageSizeLimit = fmt.Errorf("data exceeded size limit")
 
 // awsSQS sinks data to an AWS SQS queue.
 type sinkAWSSQS struct {

--- a/internal/sink/sink.go
+++ b/internal/sink/sink.go
@@ -17,13 +17,13 @@ import (
 	"github.com/klauspost/compress/zstd"
 )
 
-const (
+var (
 	// errEmptyPrefix is returned when a file-based sink is configured with a
 	// prefix key, but the key is not found in the object or the key is empty.
-	errEmptyPrefix = errors.Error("empty prefix string")
+	errEmptyPrefix = fmt.Errorf("empty prefix string")
 	// errEmptySuffix is returned when a file-based sink is configured with a
 	// suffix key, but the key is not found in the object or the key is empty.
-	errEmptySuffix = errors.Error("empty suffix string")
+	errEmptySuffix = fmt.Errorf("empty suffix string")
 )
 
 type Sink interface {

--- a/internal/sink/sumologic.go
+++ b/internal/sink/sumologic.go
@@ -22,7 +22,7 @@ var sumoLogicClient http.HTTP
 //
 // If this error occurs, then parse the data into an object (or drop invalid objects)
 // before it reaches the sink.
-const errSumoLogicNonObject = errors.Error("input must be object")
+var errSumoLogicNonObject = fmt.Errorf("input must be object")
 
 // sumologic sinks data to Sumo Logic using an HTTP collector.
 //

--- a/process/aggregate.go
+++ b/process/aggregate.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/brexhq/substation/condition"
 	"github.com/brexhq/substation/config"
-	"github.com/brexhq/substation/internal/errors"
 	"github.com/brexhq/substation/internal/json"
 	"github.com/jshlbrd/go-aggregate"
 )
@@ -16,7 +15,7 @@ import (
 // limit is reached. If this error occurs, then increase the size of
 // the buffer or use the Drop processor to remove data that exceeds
 // the buffer limit.
-const errAggregateSizeLimit = errors.Error("data exceeded size limit")
+var errAggregateSizeLimit = fmt.Errorf("data exceeded size limit")
 
 // aggregate processes data by buffering and aggregating it into a
 // single item.

--- a/process/aws_dynamodb.go
+++ b/process/aws_dynamodb.go
@@ -19,11 +19,11 @@ var dynamodbAPI dynamodb.API
 
 // errAWSDynamodbInputNotAnObject is returned when the input is not an object.
 // Refer to the dynamodb processor documentation for input requirements.
-const errAWSDynamodbInputNotAnObject = errors.Error("input is not an object")
+var errAWSDynamodbInputNotAnObject = fmt.Errorf("input is not an object")
 
 // errAWSDynamodbInputMissingPK is returned when the JSON key "PK" is missing in
 // the input. Refer to the dynamodb processor documentation for input requirements.
-const errAWSDynamodbInputMissingPK = errors.Error("input missing PK")
+var errAWSDynamodbInputMissingPK = fmt.Errorf("input missing PK")
 
 // awsDynamodb processes data by querying a DynamoDB table and returning all
 // matched items as an array of objects. The input must be an object containing

--- a/process/aws_lambda.go
+++ b/process/aws_lambda.go
@@ -16,7 +16,7 @@ import (
 var lambdaAPI lambda.API
 
 // errAWSLambdaInputNotAnObject is returned when the input is not a JSON object.
-const errAWSLambdaInputNotAnObject = errors.Error("input is not an object")
+var errAWSLambdaInputNotAnObject = fmt.Errorf("input is not an object")
 
 // awsLambda processes data by synchronously invoking an AWS Lambda function
 // and returning the payload. The average latency of synchronously invoking

--- a/process/base64.go
+++ b/process/base64.go
@@ -16,7 +16,7 @@ import (
 // errBase64DecodedBinary is returned when the Base64 processor is configured
 // to decode output into an object, but the output contains binary data and
 // cannot be written into a valid object.
-const errBase64DecodedBinary = errors.Error("cannot write binary as object")
+var errBase64DecodedBinary = fmt.Errorf("cannot write binary as object")
 
 // base64 processes data by converting it to and from base64.
 //

--- a/process/case.go
+++ b/process/case.go
@@ -16,7 +16,7 @@ import (
 
 // errCaseInvalid is returned when the Case processor is configured with
 // an invalid case.
-const errCaseInvalid = errors.Error("invalid case")
+var errCaseInvalid = fmt.Errorf("invalid case")
 
 // case processes data by modifying letter case (https://en.wikipedia.org/wiki/LetterprocCase).
 //

--- a/process/domain.go
+++ b/process/domain.go
@@ -15,7 +15,7 @@ import (
 
 // errDomainNoSubdomain is returned when a domain without a subdomain is
 // processed.
-const errDomainNoSubdomain = errors.Error("no subdomain")
+var errDomainNoSubdomain = fmt.Errorf("no subdomain")
 
 // domain processes data by parsing fully qualified domain names (FQDNs) into
 // labels.

--- a/process/hash.go
+++ b/process/hash.go
@@ -14,7 +14,7 @@ import (
 )
 
 // errHashInvalidAlgorithm is returned when the hash processor is configured with an invalid algorithm.
-const errHashInvalidAlgorithm = errors.Error("invalid algorithm")
+var errHashInvalidAlgorithm = fmt.Errorf("invalid algorithm")
 
 // hash processes data by calculating hashes (https://en.wikipedia.org/wiki/CryptographicprocHash_function).
 //

--- a/process/jq.go
+++ b/process/jq.go
@@ -12,7 +12,7 @@ import (
 )
 
 // errJqNoOutputGenerated is returned when the jq query generates no output.
-const errJqNoOutputGenerated = errors.Error("no output generated")
+var errJqNoOutputGenerated = fmt.Errorf("no output generated")
 
 // jq processes data by applying jq queries.
 //

--- a/process/pipeline.go
+++ b/process/pipeline.go
@@ -6,11 +6,10 @@ import (
 
 	"github.com/brexhq/substation/condition"
 	"github.com/brexhq/substation/config"
-	"github.com/brexhq/substation/internal/errors"
 )
 
 // errPipelineArrayInput is returned when the pipeline processor is configured to process JSON, but the input is an array. Array values are not supported by this processor, instead the input should be run through the ForEach processor (which can encapsulate the pipeline processor).
-const errPipelineArrayInput = errors.Error("input is an array")
+var errPipelineArrayInput = fmt.Errorf("input is an array")
 
 // pipeline processes data by applying a series of processors.
 //

--- a/process/pretty_print.go
+++ b/process/pretty_print.go
@@ -27,7 +27,7 @@ const (
 //
 // The most common causes of this error are invalid input JSON
 // (e.g., {{"foo":"bar"}) or using the processor with multi-core processing enabled.
-const errPrettyPrintIncompleteJSON = errors.Error("incomplete JSON object")
+var errPrettyPrintIncompleteJSON = fmt.Errorf("incomplete JSON object")
 
 // prettyPrint processes data by applying or reversing prettyprint formatting to objects.
 //

--- a/process/process.go
+++ b/process/process.go
@@ -11,10 +11,10 @@ import (
 )
 
 // errInvalidDataPattern is returned when a processor is configured with an invalid data access pattern. This is commonly caused by improperly set input and output settings.
-var errInvalidDataPattern = errors.Error("invalid data access pattern")
+var errInvalidDataPattern = fmt.Errorf("invalid data access pattern")
 
 // errInvalidDirection is returned when a processor is configured with an invalid direction setting.
-const errInvalidDirection = errors.Error("invalid direction")
+var errInvalidDirection = fmt.Errorf("invalid direction")
 
 type process struct {
 	// Condition optionally enables processing depending on the outcome of data inspection.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Removed the type `Error` from `internal/errors`
- Replace all occurrences of `errors.Error("error_message")` with `fmt.Errorf("error_message")`
<!--- Describe your changes in detail -->

## Motivation and Context
> This isn't a problem, but an opportunity to improve the projects error handling code.
> [...]
> Refactor the project to remove this [errors](https://github.com/brexhq/substation/tree/main/internal/errors) sentinel type, it's not needed since after Go 1.13 (and we use Go 1.19), the Go standard library supports [comparing errors natively](https://go.dev/blog/go1.13-errors#:~:text=Examining%20errors%20with%20Is%20and%20As). The Go standard library errors package in the upcoming release will also support >1 error types to wrap/unwrap so they're still investing in this.

Closes #63 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Ran: `$ go test ./...` 
All tests passed, there was NOT any change on the tests.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
