### PR TITLE
feat: Add Zstandard & Snappy Readers

### DIFF
--- a/internal/bufio/bufio.go
+++ b/internal/bufio/bufio.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/brexhq/substation/internal/errors"
 	"github.com/brexhq/substation/internal/media"
+	"github.com/klauspost/compress/snappy"
+	"github.com/klauspost/compress/zstd"
 )
 
 // errInvalidMethod is returned when an invalid scanner method is provided.
@@ -101,6 +103,17 @@ func (s *scanner) ReadFile(file *os.File) error {
 
 		reader = gzipReader
 		s.openHandles = append(s.openHandles, reader)
+	case "application/zstd":
+		zstdReader, err := zstd.NewReader(file)
+		if err != nil {
+			return fmt.Errorf("readopenfile: %v", err)
+		}
+
+		reader = io.NopCloser(zstdReader)
+		s.openHandles = append(s.openHandles, reader)
+	case "application/x-snappy-framed":
+		snappyReader := snappy.NewReader(file)
+		reader = io.NopCloser(snappyReader)
 	default:
 		// file was previously added to openHandles
 		reader = file

--- a/internal/media/media.go
+++ b/internal/media/media.go
@@ -17,6 +17,12 @@ func Bytes(b []byte) string {
 	// http.DetectContentType occasionally (rarely) generates false positive matches for application/vnd.ms-fontobject when the bytes are application/x-gzip
 	case bytes.HasPrefix(b, []byte("\x1f\x8b\x08")):
 		return "application/x-gzip"
+	// http.DetectContentType cannot detect zstd
+	case bytes.HasPrefix(b, []byte("\x28\xb5\x2f\xfd")):
+		return "application/x-zstd"
+	// http.DetectContentType cannot detect snappy
+	case bytes.HasPrefix(b, []byte("\xff\x06\x00\x00\x73\x4e\x61\x50\x70\x59")):
+		return "application/x-snappy-framed"
 	default:
 		return http.DetectContentType(b)
 	}

--- a/internal/media/media_test.go
+++ b/internal/media/media_test.go
@@ -20,6 +20,16 @@ var mediaTests = []struct {
 		[]byte("\x1f\x8b\x08"),
 		"application/x-gzip",
 	},
+	{
+		"zstd",
+		[]byte("\x28\xb5\x2f\xfd"),
+		"application/x-zstd",
+	},
+	{
+		"snappy",
+		[]byte("\xff\x06\x00\x00\x73\x4e\x61\x50\x70\x59"),
+		"application/x-snappy-framed",
+	},
 }
 
 func TestBytes(t *testing.T) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Adds[ zstd decompression](https://en.wikipedia.org/wiki/Zstd) to bufio
- Adds [Snappy decompression](https://en.wikipedia.org/wiki/Snappy_(compression)) to bufio

<!--- Describe your changes in detail -->

## Motivation and Context

zstd and Snappy compression was added in https://github.com/brexhq/substation/pull/93, but decompression (reading) wasn't. Ideally we want to maintain parity in our support for readers and writers so that users can use compressed files without needing external software.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Added unit tests and tested locally using the file sink.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
