### PR TITLE
feat: Add Stream Transform & Streamer Interface

### DIFF
--- a/cmd/development/substation/main.go
+++ b/cmd/development/substation/main.go
@@ -11,13 +11,12 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/sync/errgroup"
-
 	"github.com/brexhq/substation/cmd"
 	"github.com/brexhq/substation/config"
 	"github.com/brexhq/substation/internal/bufio"
 	"github.com/brexhq/substation/internal/file"
 	"github.com/brexhq/substation/internal/json"
+	"golang.org/x/sync/errgroup"
 )
 
 type metadata struct {

--- a/examples/streaming/config.jsonnet
+++ b/examples/streaming/config.jsonnet
@@ -1,0 +1,5 @@
+local sub = import '../../build/config/substation.libsonnet';
+
+sub.interfaces.processor.aggregate(
+  options={separator: ' '}
+)

--- a/examples/streaming/main.go
+++ b/examples/streaming/main.go
@@ -1,0 +1,101 @@
+// Provides an example of how to use streaming processors, which use channels to
+// process data. This example uses the aggregate processor, which aggregates data
+// into a single item.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/brexhq/substation/config"
+	"github.com/brexhq/substation/process"
+
+	"golang.org/x/sync/errgroup"
+)
+
+func main() {
+	cfg, err := os.ReadFile("./config.json")
+	if err != nil {
+		panic(err)
+	}
+
+	conf := config.Config{}
+	if err := json.Unmarshal(cfg, &conf); err != nil {
+		panic(err)
+	}
+
+	// maintains state across goroutines and creates
+	// two channels used for ingesting and sinking data
+	// from the transform process. Substation channels are
+	// unbuffered and can be accessed directly, in addition
+	// to helper methods for sending data and closing the
+	// channel.
+	group, ctx := errgroup.WithContext(context.TODO())
+	in, out := config.NewChannel(), config.NewChannel()
+
+	// create and start the transform process. the process
+	// must run in a goroutine to prevent blocking
+	// the main goroutine.
+	agg, err := process.NewStreamer(ctx, conf)
+	if err != nil {
+		panic(err)
+	}
+
+	group.Go(func() error {
+		if err := agg.Stream(ctx, in, out); err != nil {
+			panic(err)
+		}
+
+		return nil
+	})
+
+	// reading data must start before writing data and run inside a
+	// goroutine to prevent blocking the main goroutine.
+	group.Go(func() error {
+		for capsule := range out.C {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+				// do something with the data
+				fmt.Printf("sink: %s\n", string(capsule.Data()))
+			}
+		}
+
+		return nil
+	})
+
+	// writing data to the ingest channel can be run from the main goroutine
+	// or inside a goroutine. the channel must be closed after all data
+	// is written -- this sends a signal to the transform process to
+	// stop reading from the channel.
+	data := [][]byte{
+		[]byte("this"),
+		[]byte("is"),
+		[]byte("a"),
+		[]byte("test"),
+	}
+
+	for _, d := range data {
+		fmt.Printf("ingest: %s\n", string(d))
+
+		capsule := config.NewCapsule()
+		capsule.SetData(d)
+
+		select {
+		case <-ctx.Done():
+			panic(ctx.Err())
+		default:
+			in.Send(capsule)
+		}
+	}
+	in.Close()
+
+	// wait for all goroutines to finish, otherwise the program will exit
+	// before the transform process completes.
+	if err := group.Wait(); err != nil {
+		panic(err)
+	}
+}

--- a/internal/transform/stream.go
+++ b/internal/transform/stream.go
@@ -1,0 +1,113 @@
+package transform
+
+import (
+	"context"
+	"sync"
+
+	"github.com/brexhq/substation/config"
+	"github.com/brexhq/substation/internal/metrics"
+	"github.com/brexhq/substation/process"
+	"golang.org/x/sync/errgroup"
+)
+
+// stream transforms data by applying a series of processors to a pipeline of
+// encapsulated data.
+//
+// Data processing is iterative and each processor is enabled through conditions.
+type tformStream struct {
+	Processors []config.Config `json:"processors"`
+
+	streamers []process.Streamer
+}
+
+func newTformStream(ctx context.Context, cfg config.Config) (t tformStream, err error) {
+	if err = config.Decode(cfg.Settings, &t); err != nil {
+		return tformStream{}, err
+	}
+
+	t.streamers, err = process.NewStreamers(ctx, t.Processors...)
+	if err != nil {
+		return tformStream{}, err
+	}
+
+	return t, nil
+}
+
+// Transform processes a channel of encapsulated data with the transform.
+func (t tformStream) Transform(ctx context.Context, wg *sync.WaitGroup, in, out *config.Channel) error {
+	go func() {
+		wg.Wait()
+		//nolint: errcheck // errors are ignored in case closing fails in a single applier
+		process.CloseStreamers(ctx, t.streamers...)
+	}()
+
+	group, ctx := errgroup.WithContext(ctx)
+
+	// each streamer has two channels, one for input and one for output, that create
+	// a pipeline. streamers are executed in order as goroutines so that capsules are
+	// processed in series.
+	prevChan := config.NewChannel()
+	firstChan := prevChan
+
+	for _, s := range t.streamers {
+		nextChan := config.NewChannel()
+		func(s process.Streamer, inner, outer *config.Channel) {
+			group.Go(func() error {
+				return s.Stream(ctx, inner, outer)
+			})
+		}(s, prevChan, nextChan)
+
+		prevChan = nextChan
+	}
+
+	// the last streamer in the pipeline sends to the sink (drain), and must
+	// be read before capsules are put into the pipeline to avoid deadlock.
+	var sent int
+	group.Go(func() error {
+		for capsule := range prevChan.C {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+				out.Send(capsule)
+				sent++
+			}
+		}
+
+		return nil
+	})
+
+	// the first streamer in the pipeline receives from the source, and must
+	// start after the drain goroutine to avoid deadlock.
+	var received int
+	for capsule := range in.C {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			firstChan.Send(capsule)
+			received++
+		}
+	}
+
+	// this is required so that the pipeline goroutines can exit.
+	firstChan.Close()
+
+	// an error in any streamer will cause the entire pipeline, including sending
+	// to the sink, to fail.
+	if err := group.Wait(); err != nil {
+		return err
+	}
+
+	_ = metrics.Generate(ctx, metrics.Data{
+		Name:  "CapsulesReceived",
+		Value: received,
+	})
+
+	_ = metrics.Generate(ctx, metrics.Data{
+		Name:  "CapsulesSent",
+		Value: sent,
+	})
+
+	return nil
+}

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -18,6 +18,8 @@ func New(ctx context.Context, cfg config.Config) (Transformer, error) {
 	switch t := cfg.Type; t {
 	case "batch":
 		return newTformBatch(ctx, cfg)
+	case "stream":
+		return newTformStream(ctx, cfg)
 	case "transfer":
 		return newTformTransfer(ctx, cfg)
 	default:

--- a/process/aggregate.go
+++ b/process/aggregate.go
@@ -90,8 +90,83 @@ func newProcAggregate(ctx context.Context, cfg config.Config) (p procAggregate, 
 	return p, nil
 }
 
-// Batch processes one or more capsules with the processor. Conditions are
-// optionally applied to the data to enable processing.
+// Stream processes a pipeline of capsules with the processor.
+func (p procAggregate) Stream(ctx context.Context, in, out *config.Channel) error {
+	defer out.Close()
+
+	// aggregateKeys is used to return data stored in the
+	// buffer in order if the aggregate doesn't meet the
+	// configured threshold. any aggregate that meets the
+	// threshold is delivered immediately, out of order.
+	var aggregateKeys []string
+	buffer := map[string]*aggregate.Bytes{}
+
+	for capsule := range in.C {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			if ok, err := p.operator.Operate(ctx, capsule); err != nil {
+				return fmt.Errorf("process: aggregate: %v", err)
+			} else if !ok {
+				out.C <- capsule
+				continue
+			}
+
+			// data that exceeds the size of the buffer will never
+			// fit within it
+			length := len(capsule.Data())
+			if length > p.Options.MaxSize {
+				return fmt.Errorf("process: aggregate: size %d data length %d: %v", p.Options.MaxSize, length, errAggregateSizeLimit)
+			}
+
+			var aggregateKey string
+			if p.Options.Key != "" {
+				aggregateKey = capsule.Get(p.Options.Key).String()
+			}
+
+			if _, ok := buffer[aggregateKey]; !ok {
+				buffer[aggregateKey] = &aggregate.Bytes{}
+				buffer[aggregateKey].New(p.Options.MaxCount, p.Options.MaxSize)
+				aggregateKeys = append(aggregateKeys, aggregateKey)
+			}
+
+			ok := buffer[aggregateKey].Add(capsule.Data())
+			// data was successfully added to the buffer, every item after
+			// this is a failure
+			if ok {
+				continue
+			}
+
+			// the buffer is full, emit the aggregated data
+			data := buffer[aggregateKey].Get()
+			c, err := p.newCapsule(data)
+			if err != nil {
+				return fmt.Errorf("process: aggregate: %v", err)
+			}
+			out.Send(c)
+
+			// by this point, addition of the failed data is guaranteed
+			// to succeed after the buffer is reset
+			buffer[aggregateKey].Reset()
+			_ = buffer[aggregateKey].Add(capsule.Data())
+		}
+	}
+
+	// emit any remaining data in the buffer
+	for _, aggregateKey := range aggregateKeys {
+		data := buffer[aggregateKey].Get()
+		c, err := p.newCapsule(data)
+		if err != nil {
+			return fmt.Errorf("process: aggregate: %v", err)
+		}
+		out.Send(c)
+	}
+
+	return nil
+}
+
+// Batch processes one or more capsules with the processor.
 func (p procAggregate) Batch(ctx context.Context, capsules ...config.Capsule) ([]config.Capsule, error) {
 	// aggregateKeys is used to return elements stored in the
 	// buffer in order if the aggregate doesn't meet the
@@ -102,12 +177,9 @@ func (p procAggregate) Batch(ctx context.Context, capsules ...config.Capsule) ([
 
 	newCapsules := newBatch(&capsules)
 	for _, capsule := range capsules {
-		ok, err := p.operator.Operate(ctx, capsule)
-		if err != nil {
+		if ok, err := p.operator.Operate(ctx, capsule); err != nil {
 			return nil, fmt.Errorf("process: aggregate: %v", err)
-		}
-
-		if !ok {
+		} else if !ok {
 			newCapsules = append(newCapsules, capsule)
 			continue
 		}
@@ -130,34 +202,19 @@ func (p procAggregate) Batch(ctx context.Context, capsules ...config.Capsule) ([
 			aggregateKeys = append(aggregateKeys, aggregateKey)
 		}
 
-		ok = buffer[aggregateKey].Add(capsule.Data())
+		ok := buffer[aggregateKey].Add(capsule.Data())
 		// data was successfully added to the buffer, every item after
 		// this is a failure
 		if ok {
 			continue
 		}
 
-		newCapsule := config.NewCapsule()
-		elements := buffer[aggregateKey].Get()
-		if p.SetKey != "" {
-			var value []byte
-			for _, element := range elements {
-				var err error
-
-				value, err = json.Set(value, p.SetKey, element)
-				if err != nil {
-					return nil, fmt.Errorf("process: aggregate: %v", err)
-				}
-			}
-
-			newCapsule.SetData(value)
-			newCapsules = append(newCapsules, newCapsule)
-		} else {
-			value := bytes.Join(elements, []byte(p.Options.Separator))
-
-			newCapsule.SetData(value)
-			newCapsules = append(newCapsules, newCapsule)
+		data := buffer[aggregateKey].Get()
+		c, err := p.newCapsule(data)
+		if err != nil {
+			return nil, fmt.Errorf("process: aggregate: %v", err)
 		}
+		newCapsules = append(newCapsules, c)
 
 		// by this point, addition of the failed data is guaranteed
 		// to succeed after the buffer is reset
@@ -167,33 +224,43 @@ func (p procAggregate) Batch(ctx context.Context, capsules ...config.Capsule) ([
 
 	// remaining items must be drained from the buffer, otherwise
 	// data is lost
-	newCapsule := config.NewCapsule()
 	for _, key := range aggregateKeys {
 		if buffer[key].Count() == 0 {
 			continue
 		}
 
-		elements := buffer[key].Get()
-		if p.SetKey != "" {
-			var value []byte
-			for _, element := range elements {
-				var err error
-
-				value, err = json.Set(value, p.SetKey, element)
-				if err != nil {
-					return nil, fmt.Errorf("process: aggregate: %v", err)
-				}
-			}
-
-			newCapsule.SetData(value)
-			newCapsules = append(newCapsules, newCapsule)
-		} else {
-			value := bytes.Join(elements, []byte(p.Options.Separator))
-
-			newCapsule.SetData(value)
-			newCapsules = append(newCapsules, newCapsule)
+		data := buffer[key].Get()
+		c, err := p.newCapsule(data)
+		if err != nil {
+			return nil, fmt.Errorf("process: aggregate: %v", err)
 		}
+
+		newCapsules = append(newCapsules, c)
 	}
 
 	return newCapsules, nil
+}
+
+func (p procAggregate) newCapsule(data [][]byte) (config.Capsule, error) {
+	newCapsule := config.NewCapsule()
+
+	if p.SetKey != "" {
+		var value []byte
+		for _, element := range data {
+			var err error
+
+			value, err = json.Set(value, p.SetKey, element)
+			if err != nil {
+				return newCapsule, err
+			}
+		}
+
+		newCapsule.SetData(value)
+		return newCapsule, nil
+	}
+
+	value := bytes.Join(data, []byte(p.Options.Separator))
+	newCapsule.SetData(value)
+
+	return newCapsule, nil
 }

--- a/process/aggregate_test.go
+++ b/process/aggregate_test.go
@@ -6,6 +6,12 @@ import (
 	"testing"
 
 	"github.com/brexhq/substation/config"
+	"golang.org/x/sync/errgroup"
+)
+
+var (
+	_ Batcher  = procAggregate{}
+	_ Streamer = procAggregate{}
 )
 
 var aggregateTests = []struct {
@@ -205,7 +211,6 @@ func TestAggregate(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			var _ Batcher = proc
 
 			var capsules []config.Capsule
 			for _, t := range test.test {
@@ -223,6 +228,51 @@ func TestAggregate(t *testing.T) {
 				if !bytes.Equal(expected, res.Data()) {
 					t.Errorf("expected %s, got %s", expected, string(res.Data()))
 				}
+			}
+		})
+	}
+}
+
+func TestAggregateStream(t *testing.T) {
+	group, ctx := errgroup.WithContext(context.TODO())
+	capsule := config.NewCapsule()
+
+	for _, test := range aggregateTests {
+		t.Run(test.name, func(t *testing.T) {
+			proc, err := newProcAggregate(ctx, test.cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			in, out := config.NewChannel(), config.NewChannel()
+			group.Go(func() error {
+				if err := proc.Stream(ctx, in, out); err != nil {
+					t.Error(err)
+				}
+
+				return nil
+			})
+
+			group.Go(func() error {
+				var i int
+				for res := range out.C {
+					expected := test.expected[i]
+					if !bytes.Equal(expected, res.Data()) {
+						t.Errorf("expected %s, got %s", expected, string(res.Data()))
+					}
+					i++
+				}
+				return nil
+			})
+
+			for _, t := range test.test {
+				capsule.SetData(t)
+				in.Send(capsule)
+			}
+			in.Close()
+
+			if err := group.Wait(); err != nil {
+				t.Error(err)
 			}
 		})
 	}

--- a/process/aggregate_test.go
+++ b/process/aggregate_test.go
@@ -234,17 +234,18 @@ func TestAggregate(t *testing.T) {
 }
 
 func TestAggregateStream(t *testing.T) {
-	group, ctx := errgroup.WithContext(context.TODO())
 	capsule := config.NewCapsule()
 
 	for _, test := range aggregateTests {
 		t.Run(test.name, func(t *testing.T) {
+			group, ctx := errgroup.WithContext(context.TODO())
+			in, out := config.NewChannel(), config.NewChannel()
+
 			proc, err := newProcAggregate(ctx, test.cfg)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			in, out := config.NewChannel(), config.NewChannel()
 			group.Go(func() error {
 				if err := proc.Stream(ctx, in, out); err != nil {
 					t.Error(err)

--- a/process/aws_dynamodb.go
+++ b/process/aws_dynamodb.go
@@ -96,14 +96,24 @@ func newProcAWSDynamoDB(ctx context.Context, cfg config.Config) (p procAWSDynamo
 	return p, nil
 }
 
-// Batch processes one or more capsules with the processor. Conditions are
-// optionally applied to the data to enable processing.
+// Stream processes a pipeline of capsules with the processor.
+func (p procAWSDynamoDB) Stream(ctx context.Context, in, out *config.Channel) error {
+	return streamApply(ctx, in, out, p)
+}
+
+// Batch processes one or more capsules with the processor.
 func (p procAWSDynamoDB) Batch(ctx context.Context, capsules ...config.Capsule) ([]config.Capsule, error) {
-	return batchApply(ctx, capsules, p, p.operator)
+	return batchApply(ctx, capsules, p)
 }
 
 // Apply processes a capsule with the processor.
 func (p procAWSDynamoDB) Apply(ctx context.Context, capsule config.Capsule) (config.Capsule, error) {
+	if ok, err := p.operator.Operate(ctx, capsule); err != nil {
+		return capsule, fmt.Errorf("process: aws_dynamodb: %v", err)
+	} else if !ok {
+		return capsule, nil
+	}
+
 	// lazy load API
 	if !dynamodbAPI.IsEnabled() {
 		dynamodbAPI.Setup()

--- a/process/base64.go
+++ b/process/base64.go
@@ -71,14 +71,24 @@ func (p procBase64) Close(context.Context) error {
 	return nil
 }
 
-// Batch processes one or more capsules with the processor. Conditions are
-// optionally applied to the data to enable processing.
+// Stream processes a pipeline of capsules with the processor.
+func (p procBase64) Stream(ctx context.Context, in, out *config.Channel) error {
+	return streamApply(ctx, in, out, p)
+}
+
+// Batch processes one or more capsules with the processor.
 func (p procBase64) Batch(ctx context.Context, capsules ...config.Capsule) ([]config.Capsule, error) {
-	return batchApply(ctx, capsules, p, p.operator)
+	return batchApply(ctx, capsules, p)
 }
 
 // Apply processes a capsule with the processor.
 func (p procBase64) Apply(ctx context.Context, capsule config.Capsule) (config.Capsule, error) {
+	if ok, err := p.operator.Operate(ctx, capsule); err != nil {
+		return capsule, fmt.Errorf("process: base64: %v", err)
+	} else if !ok {
+		return capsule, nil
+	}
+
 	// JSON processing
 	if p.Key != "" && p.SetKey != "" {
 		result := capsule.Get(p.Key).String()

--- a/process/base64_test.go
+++ b/process/base64_test.go
@@ -9,8 +9,9 @@ import (
 )
 
 var (
-	_ Applier = procBase64{}
-	_ Batcher = procBase64{}
+	_ Applier  = procBase64{}
+	_ Batcher  = procBase64{}
+	_ Streamer = procBase64{}
 )
 
 var base64Tests = []struct {

--- a/process/capture.go
+++ b/process/capture.go
@@ -96,14 +96,24 @@ func (p procCapture) Close(context.Context) error {
 	return nil
 }
 
-// Batch processes one or more capsules with the processor. Conditions are
-// optionally applied to the data to enable processing.
+// Stream processes a pipeline of capsules with the processor.
+func (p procCapture) Stream(ctx context.Context, in, out *config.Channel) error {
+	return streamApply(ctx, in, out, p)
+}
+
+// Batch processes one or more capsules with the processor.
 func (p procCapture) Batch(ctx context.Context, capsules ...config.Capsule) ([]config.Capsule, error) {
-	return batchApply(ctx, capsules, p, p.operator)
+	return batchApply(ctx, capsules, p)
 }
 
 // Apply processes a capsule with the processor.
 func (p procCapture) Apply(ctx context.Context, capsule config.Capsule) (config.Capsule, error) {
+	if ok, err := p.operator.Operate(ctx, capsule); err != nil {
+		return capsule, fmt.Errorf("process: capture: %v", err)
+	} else if !ok {
+		return capsule, nil
+	}
+
 	// JSON processing
 	if p.Key != "" && p.SetKey != "" {
 		result := capsule.Get(p.Key).String()

--- a/process/capture_test.go
+++ b/process/capture_test.go
@@ -9,8 +9,9 @@ import (
 )
 
 var (
-	_ Applier = procCapture{}
-	_ Batcher = procCapture{}
+	_ Applier  = procCapture{}
+	_ Batcher  = procCapture{}
+	_ Streamer = procCapture{}
 )
 
 var captureTests = []struct {

--- a/process/case.go
+++ b/process/case.go
@@ -80,14 +80,24 @@ func (p procCase) Close(context.Context) error {
 	return nil
 }
 
-// Batch processes one or more capsules with the processor. Conditions are
-// optionally applied to the data to enable processing.
+// Stream processes a pipeline of capsules with the processor.
+func (p procCase) Stream(ctx context.Context, in, out *config.Channel) error {
+	return streamApply(ctx, in, out, p)
+}
+
+// Batch processes one or more capsules with the processor.
 func (p procCase) Batch(ctx context.Context, capsules ...config.Capsule) ([]config.Capsule, error) {
-	return batchApply(ctx, capsules, p, p.operator)
+	return batchApply(ctx, capsules, p)
 }
 
 // Apply processes a capsule with the processor.
 func (p procCase) Apply(ctx context.Context, capsule config.Capsule) (config.Capsule, error) {
+	if ok, err := p.operator.Operate(ctx, capsule); err != nil {
+		return capsule, fmt.Errorf("process: case: %v", err)
+	} else if !ok {
+		return capsule, nil
+	}
+
 	// JSON processing
 	if p.Key != "" && p.SetKey != "" {
 		result := capsule.Get(p.Key).String()

--- a/process/case_test.go
+++ b/process/case_test.go
@@ -9,8 +9,9 @@ import (
 )
 
 var (
-	_ Applier = procCase{}
-	_ Batcher = procCase{}
+	_ Applier  = procCase{}
+	_ Batcher  = procCase{}
+	_ Streamer = procCase{}
 )
 
 var caseTests = []struct {

--- a/process/convert_test.go
+++ b/process/convert_test.go
@@ -9,8 +9,9 @@ import (
 )
 
 var (
-	_ Applier = procConvert{}
-	_ Batcher = procConvert{}
+	_ Applier  = procConvert{}
+	_ Batcher  = procConvert{}
+	_ Streamer = procConvert{}
 )
 
 var convertTests = []struct {

--- a/process/copy.go
+++ b/process/copy.go
@@ -39,14 +39,24 @@ func (p procCopy) Close(context.Context) error {
 	return nil
 }
 
-// Batch processes one or more capsules with the processor. Conditions are
-// optionally applied to the data to enable processing.
+// Stream processes a pipeline of capsules with the processor.
+func (p procCopy) Stream(ctx context.Context, in, out *config.Channel) error {
+	return streamApply(ctx, in, out, p)
+}
+
+// Batch processes one or more capsules with the processor.
 func (p procCopy) Batch(ctx context.Context, capsules ...config.Capsule) ([]config.Capsule, error) {
-	return batchApply(ctx, capsules, p, p.operator)
+	return batchApply(ctx, capsules, p)
 }
 
 // Apply processes a capsule with the processor.
 func (p procCopy) Apply(ctx context.Context, capsule config.Capsule) (config.Capsule, error) {
+	if ok, err := p.operator.Operate(ctx, capsule); err != nil {
+		return capsule, fmt.Errorf("process: copy: %v", err)
+	} else if !ok {
+		return capsule, nil
+	}
+
 	// JSON processing
 	if p.Key != "" && p.SetKey != "" {
 		if err := capsule.Set(p.SetKey, capsule.Get(p.Key)); err != nil {

--- a/process/copy_test.go
+++ b/process/copy_test.go
@@ -9,8 +9,9 @@ import (
 )
 
 var (
-	_ Applier = procCopy{}
-	_ Batcher = procCopy{}
+	_ Applier  = procCopy{}
+	_ Batcher  = procCopy{}
+	_ Streamer = procCopy{}
 )
 
 var copyTests = []struct {

--- a/process/count_test.go
+++ b/process/count_test.go
@@ -8,7 +8,10 @@ import (
 	"github.com/brexhq/substation/config"
 )
 
-var _ Batcher = procCount{}
+var (
+	_ Batcher  = procCount{}
+	_ Streamer = procCount{}
+)
 
 var countTests = []struct {
 	name     string

--- a/process/count_test.go
+++ b/process/count_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/brexhq/substation/config"
+	"golang.org/x/sync/errgroup"
 )
 
 var (
@@ -89,5 +90,50 @@ func BenchmarkCount(b *testing.B) {
 				benchmarkCount(b, proc, capsules)
 			},
 		)
+	}
+}
+
+func TestCountStream(t *testing.T) {
+	capsule := config.NewCapsule()
+
+	for _, test := range countTests {
+		t.Run(test.name, func(t *testing.T) {
+			group, ctx := errgroup.WithContext(context.TODO())
+			in, out := config.NewChannel(), config.NewChannel()
+
+			proc, err := newProcCount(ctx, test.cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			group.Go(func() error {
+				if err := proc.Stream(ctx, in, out); err != nil {
+					t.Error(err)
+				}
+
+				return nil
+			})
+
+			group.Go(func() error {
+				var i int
+				for res := range out.C {
+					if !bytes.Equal(test.expected, res.Data()) {
+						t.Errorf("expected %s, got %s", test.expected, string(res.Data()))
+					}
+					i++
+				}
+				return nil
+			})
+
+			for _, t := range test.test {
+				capsule.SetData(t)
+				in.Send(capsule)
+			}
+			in.Close()
+
+			if err := group.Wait(); err != nil {
+				t.Error(err)
+			}
+		})
 	}
 }

--- a/process/delete.go
+++ b/process/delete.go
@@ -42,14 +42,24 @@ func (p procDelete) Close(context.Context) error {
 	return nil
 }
 
-// Batch processes one or more capsules with the processor. Conditions are
-// optionally applied to the data to enable processing.
+// Stream processes a pipeline of capsules with the processor.
+func (p procDelete) Stream(ctx context.Context, in, out *config.Channel) error {
+	return streamApply(ctx, in, out, p)
+}
+
+// Batch processes one or more capsules with the processor.
 func (p procDelete) Batch(ctx context.Context, capsules ...config.Capsule) ([]config.Capsule, error) {
-	return batchApply(ctx, capsules, p, p.operator)
+	return batchApply(ctx, capsules, p)
 }
 
 // Apply processes a capsule with the processor.
 func (p procDelete) Apply(ctx context.Context, capsule config.Capsule) (config.Capsule, error) {
+	if ok, err := p.operator.Operate(ctx, capsule); err != nil {
+		return capsule, fmt.Errorf("process: delete: %v", err)
+	} else if !ok {
+		return capsule, nil
+	}
+
 	if err := capsule.Delete(p.Key); err != nil {
 		return capsule, fmt.Errorf("process: delete: %v", err)
 	}

--- a/process/delete_test.go
+++ b/process/delete_test.go
@@ -9,8 +9,9 @@ import (
 )
 
 var (
-	_ Applier = procDelete{}
-	_ Batcher = procDelete{}
+	_ Applier  = procDelete{}
+	_ Batcher  = procDelete{}
+	_ Streamer = procDelete{}
 )
 
 var deleteTests = []struct {

--- a/process/dns.go
+++ b/process/dns.go
@@ -84,16 +84,26 @@ func (p procDNS) Close(context.Context) error {
 	return nil
 }
 
-// Batch processes one or more capsules with the processor. Conditions are
-// optionally applied to the data to enable processing.
+// Stream processes a pipeline of capsules with the processor.
+func (p procDNS) Stream(ctx context.Context, in, out *config.Channel) error {
+	return streamApply(ctx, in, out, p)
+}
+
+// Batch processes one or more capsules with the processor.
 func (p procDNS) Batch(ctx context.Context, capsules ...config.Capsule) ([]config.Capsule, error) {
-	return batchApply(ctx, capsules, p, p.operator)
+	return batchApply(ctx, capsules, p)
 }
 
 // Apply processes a capsule with the processor.
 //
 //nolint:gocognit
 func (p procDNS) Apply(ctx context.Context, capsule config.Capsule) (config.Capsule, error) {
+	if ok, err := p.operator.Operate(ctx, capsule); err != nil {
+		return capsule, fmt.Errorf("process: delete: %v", err)
+	} else if !ok {
+		return capsule, nil
+	}
+
 	var timeout time.Duration
 	if p.Options.Timeout != 0 {
 		timeout = time.Duration(p.Options.Timeout) * time.Millisecond

--- a/process/dns.go
+++ b/process/dns.go
@@ -96,7 +96,7 @@ func (p procDNS) Batch(ctx context.Context, capsules ...config.Capsule) ([]confi
 
 // Apply processes a capsule with the processor.
 //
-//nolint:gocognit
+//nolint:gocognit,cyclop // ignore complexity
 func (p procDNS) Apply(ctx context.Context, capsule config.Capsule) (config.Capsule, error) {
 	if ok, err := p.operator.Operate(ctx, capsule); err != nil {
 		return capsule, fmt.Errorf("process: delete: %v", err)

--- a/process/domain.go
+++ b/process/domain.go
@@ -80,14 +80,24 @@ func newProcDomain(ctx context.Context, cfg config.Config) (p procDomain, err er
 	return p, nil
 }
 
-// Batch processes one or more capsules with the processor. Conditions are
-// optionally applied to the data to enable processing.
+// Stream processes a pipeline of capsules with the processor.
+func (p procDomain) Stream(ctx context.Context, in, out *config.Channel) error {
+	return streamApply(ctx, in, out, p)
+}
+
+// Batch processes one or more capsules with the processor.
 func (p procDomain) Batch(ctx context.Context, capsules ...config.Capsule) ([]config.Capsule, error) {
-	return batchApply(ctx, capsules, p, p.operator)
+	return batchApply(ctx, capsules, p)
 }
 
 // Apply processes a capsule with the processor.
 func (p procDomain) Apply(ctx context.Context, capsule config.Capsule) (config.Capsule, error) {
+	if ok, err := p.operator.Operate(ctx, capsule); err != nil {
+		return capsule, fmt.Errorf("process: delete: %v", err)
+	} else if !ok {
+		return capsule, nil
+	}
+
 	// JSON processing
 	if p.Key != "" && p.SetKey != "" {
 		result := capsule.Get(p.Key).String()

--- a/process/domain_test.go
+++ b/process/domain_test.go
@@ -9,8 +9,9 @@ import (
 )
 
 var (
-	_ Applier = procDomain{}
-	_ Batcher = procDomain{}
+	_ Applier  = procDomain{}
+	_ Batcher  = procDomain{}
+	_ Streamer = procDomain{}
 )
 
 var domainTests = []struct {

--- a/process/drop_test.go
+++ b/process/drop_test.go
@@ -7,7 +7,10 @@ import (
 	"github.com/brexhq/substation/config"
 )
 
-var _ Batcher = procDrop{}
+var (
+	_ Batcher  = procDrop{}
+	_ Streamer = procDrop{}
+)
 
 var dropTests = []struct {
 	name string

--- a/process/expand.go
+++ b/process/expand.go
@@ -40,17 +40,113 @@ func (p procExpand) Close(context.Context) error {
 	return nil
 }
 
-// Batch processes one or more capsules with the processor. Conditions are
-// optionally applied to the data to enable processing.
+// Stream processes a pipeline of capsules with the processor.
+func (p procExpand) Stream(ctx context.Context, in, out *config.Channel) error {
+	defer out.Close()
+
+	for capsule := range in.C {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			if ok, err := p.operator.Operate(ctx, capsule); err != nil {
+				return fmt.Errorf("process: expand: %v", err)
+			} else if !ok {
+				out.Send(capsule)
+				continue
+			}
+
+			// data is processed by retrieving and iterating an
+			// array containing JSON objects (result) and setting
+			// any remaining keys from the object (remains) into
+			// each new object. if there is no Key, then the input
+			// is treated as an array.
+			//
+			// input:
+			// 	{"expand":[{"foo":"bar"},{"baz":"qux"}],"quux":"corge"}
+			// result:
+			//  [{"foo":"bar"},{"baz":"qux"}]
+			// remains:
+			// 	{"quux":"corge"}
+			// output:
+			// 	{"foo":"bar","quux":"corge"}
+			// 	{"baz":"qux","quux":"corge"}
+			var result, remains json.Result
+
+			if p.Key != "" {
+				result = json.Get(capsule.Data(), p.Key)
+				// deleting the key from the object speeds
+				// up processing large objects.
+				if err := capsule.Delete(p.Key); err != nil {
+					return fmt.Errorf("process: expand: %v", err)
+				}
+
+				remains = json.Get(capsule.Data(), "@this")
+			} else {
+				// remains is unused when there is no key
+				result = json.Get(capsule.Data(), "@this")
+			}
+
+			for _, res := range result.Array() {
+				// retains metadata from the original event
+				newCapsule := capsule
+				newCapsule.SetData([]byte{})
+
+				// data processing
+				//
+				// elements from the array become new data.
+				if p.Key == "" {
+					newCapsule.SetData([]byte(res.String()))
+					out.Send(newCapsule)
+					continue
+				}
+
+				// object processing
+				//
+				// remaining keys from the original object are added
+				// to the new object.
+				for key, val := range remains.Map() {
+					if err := newCapsule.Set(key, val); err != nil {
+						return fmt.Errorf("process: expand: %v", err)
+					}
+				}
+
+				if p.SetKey != "" {
+					if err := newCapsule.Set(p.SetKey, res); err != nil {
+						return fmt.Errorf("process: expand: %v", err)
+					}
+
+					out.Send(newCapsule)
+					continue
+				}
+
+				// at this point there should be two objects that need to be
+				// merged into a single object. the objects are merged using
+				// the GJSON @join function, which joins all objects that are
+				// in an array. if the array contains non-object data, then
+				// it is ignored.
+				//
+				// [{"foo":"bar"},{"baz":"qux"}}] becomes {"foo":"bar","baz":"qux"}
+				// [{"foo":"bar"},{"baz":"qux"},"quux"] becomes {"foo":"bar","baz":"qux"}
+				tmp := fmt.Sprintf(`[%s,%s]`, newCapsule.Data(), res.String())
+				join := json.Get([]byte(tmp), "@join")
+				newCapsule.SetData([]byte(join.String()))
+
+				out.Send(newCapsule)
+			}
+		}
+	}
+
+	return nil
+}
+
+// Batch processes one or more capsules with the processor.
 func (p procExpand) Batch(ctx context.Context, capsules ...config.Capsule) ([]config.Capsule, error) {
 	newCapsules := newBatch(&capsules)
 	for _, capsule := range capsules {
-		ok, err := p.operator.Operate(ctx, capsule)
-		if err != nil {
+		if ok, err := p.operator.Operate(ctx, capsule); err != nil {
 			return nil, fmt.Errorf("process: expand: %v", err)
-		}
-
-		if !ok {
+		} else if !ok {
 			newCapsules = append(newCapsules, capsule)
 			continue
 		}
@@ -106,7 +202,7 @@ func (p procExpand) Batch(ctx context.Context, capsules ...config.Capsule) ([]co
 			// remaining keys from the original object are added
 			// to the new object.
 			for key, val := range remains.Map() {
-				if err = newCapsule.Set(key, val); err != nil {
+				if err := newCapsule.Set(key, val); err != nil {
 					return nil, fmt.Errorf("process: expand: %v", err)
 				}
 			}

--- a/process/expand_test.go
+++ b/process/expand_test.go
@@ -201,17 +201,18 @@ func BenchmarkExpand(b *testing.B) {
 }
 
 func TestExpandStream(t *testing.T) {
-	group, ctx := errgroup.WithContext(context.TODO())
 	capsule := config.NewCapsule()
 
 	for _, test := range expandTests {
 		t.Run(test.name, func(t *testing.T) {
+			group, ctx := errgroup.WithContext(context.TODO())
+			in, out := config.NewChannel(), config.NewChannel()
+
 			proc, err := newProcExpand(ctx, test.cfg)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			in, out := config.NewChannel(), config.NewChannel()
 			group.Go(func() error {
 				if err := proc.Stream(ctx, in, out); err != nil {
 					t.Error(err)

--- a/process/expand_test.go
+++ b/process/expand_test.go
@@ -6,9 +6,13 @@ import (
 	"testing"
 
 	"github.com/brexhq/substation/config"
+	"golang.org/x/sync/errgroup"
 )
 
-var _ Batcher = procExpand{}
+var (
+	_ Batcher  = procExpand{}
+	_ Streamer = procExpand{}
+)
 
 var expandTests = []struct {
 	name     string
@@ -193,5 +197,48 @@ func BenchmarkExpand(b *testing.B) {
 				benchmarkExpand(b, proc, slice)
 			},
 		)
+	}
+}
+
+func TestExpandStream(t *testing.T) {
+	group, ctx := errgroup.WithContext(context.TODO())
+	capsule := config.NewCapsule()
+
+	for _, test := range expandTests {
+		t.Run(test.name, func(t *testing.T) {
+			proc, err := newProcExpand(ctx, test.cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			in, out := config.NewChannel(), config.NewChannel()
+			group.Go(func() error {
+				if err := proc.Stream(ctx, in, out); err != nil {
+					t.Error(err)
+				}
+
+				return nil
+			})
+
+			group.Go(func() error {
+				var i int
+				for res := range out.C {
+					expected := test.expected[i]
+					if !bytes.Equal(expected, res.Data()) {
+						t.Errorf("expected %s, got %s", expected, string(res.Data()))
+					}
+					i++
+				}
+				return nil
+			})
+
+			capsule.SetData(test.test)
+			in.Send(capsule)
+			in.Close()
+
+			if err := group.Wait(); err != nil {
+				t.Error(err)
+			}
+		})
 	}
 }

--- a/process/flatten_test.go
+++ b/process/flatten_test.go
@@ -9,8 +9,9 @@ import (
 )
 
 var (
-	_ Applier = procFlatten{}
-	_ Batcher = procFlatten{}
+	_ Applier  = procFlatten{}
+	_ Batcher  = procFlatten{}
+	_ Streamer = procFlatten{}
 )
 
 var flattenTests = []struct {

--- a/process/for_each_test.go
+++ b/process/for_each_test.go
@@ -9,8 +9,9 @@ import (
 )
 
 var (
-	_ Applier = procForEach{}
-	_ Batcher = procForEach{}
+	_ Applier  = procForEach{}
+	_ Batcher  = procForEach{}
+	_ Streamer = procForEach{}
 )
 
 var forEachTests = []struct {

--- a/process/group_test.go
+++ b/process/group_test.go
@@ -9,8 +9,9 @@ import (
 )
 
 var (
-	_ Applier = procGroup{}
-	_ Batcher = procGroup{}
+	_ Applier  = procGroup{}
+	_ Batcher  = procGroup{}
+	_ Streamer = procGroup{}
 )
 
 var groupTests = []struct {

--- a/process/gzip.go
+++ b/process/gzip.go
@@ -90,14 +90,24 @@ func (p procGzip) Close(context.Context) error {
 	return nil
 }
 
-// Batch processes one or more capsules with the processor. Conditions are
-// optionally applied to the data to enable processing.
+// Stream processes a pipeline of capsules with the processor.
+func (p procGzip) Stream(ctx context.Context, in, out *config.Channel) error {
+	return streamApply(ctx, in, out, p)
+}
+
+// Batch processes one or more capsules with the processor.
 func (p procGzip) Batch(ctx context.Context, capsules ...config.Capsule) ([]config.Capsule, error) {
-	return batchApply(ctx, capsules, p, p.operator)
+	return batchApply(ctx, capsules, p)
 }
 
 // Apply processes a capsule with the processor.
 func (p procGzip) Apply(ctx context.Context, capsule config.Capsule) (config.Capsule, error) {
+	if ok, err := p.operator.Operate(ctx, capsule); err != nil {
+		return capsule, fmt.Errorf("process: gzip: %v", err)
+	} else if !ok {
+		return capsule, nil
+	}
+
 	var value []byte
 	switch p.Options.Direction {
 	case "from":

--- a/process/gzip_test.go
+++ b/process/gzip_test.go
@@ -9,8 +9,9 @@ import (
 )
 
 var (
-	_ Applier = procGzip{}
-	_ Batcher = procGzip{}
+	_ Applier  = procGzip{}
+	_ Batcher  = procGzip{}
+	_ Streamer = procGzip{}
 )
 
 var gzipTests = []struct {

--- a/process/hash.go
+++ b/process/hash.go
@@ -69,14 +69,24 @@ func (p procHash) Close(context.Context) error {
 	return nil
 }
 
-// Batch processes one or more capsules with the processor. Conditions are
-// optionally applied to the data to enable processing.
+// Stream processes a pipeline of capsules with the processor.
+func (p procHash) Stream(ctx context.Context, in, out *config.Channel) error {
+	return streamApply(ctx, in, out, p)
+}
+
+// Batch processes one or more capsules with the processor.
 func (p procHash) Batch(ctx context.Context, capsules ...config.Capsule) ([]config.Capsule, error) {
-	return batchApply(ctx, capsules, p, p.operator)
+	return batchApply(ctx, capsules, p)
 }
 
 // Apply processes a capsule with the processor.
 func (p procHash) Apply(ctx context.Context, capsule config.Capsule) (config.Capsule, error) {
+	if ok, err := p.operator.Operate(ctx, capsule); err != nil {
+		return capsule, fmt.Errorf("process: hash: %v", err)
+	} else if !ok {
+		return capsule, nil
+	}
+
 	// JSON processing
 	if p.Key != "" && p.SetKey != "" {
 		result := capsule.Get(p.Key).String()

--- a/process/hash_test.go
+++ b/process/hash_test.go
@@ -9,8 +9,9 @@ import (
 )
 
 var (
-	_ Applier = procHash{}
-	_ Batcher = procHash{}
+	_ Applier  = procHash{}
+	_ Batcher  = procHash{}
+	_ Streamer = procHash{}
 )
 
 var hashTests = []struct {

--- a/process/http.go
+++ b/process/http.go
@@ -115,14 +115,24 @@ func newProcHTTP(ctx context.Context, cfg config.Config) (p procHTTP, err error)
 	return p, nil
 }
 
-// Batch processes one or more capsules with the processor. Conditions are
-// optionally applied to the data to enable processing.
+// Stream processes a pipeline of capsules with the processor.
+func (p procHTTP) Stream(ctx context.Context, in, out *config.Channel) error {
+	return streamApply(ctx, in, out, p)
+}
+
+// Batch processes one or more capsules with the processor.
 func (p procHTTP) Batch(ctx context.Context, capsules ...config.Capsule) ([]config.Capsule, error) {
-	return batchApply(ctx, capsules, p, p.operator)
+	return batchApply(ctx, capsules, p)
 }
 
 // Apply processes a capsule with the processor.
 func (p procHTTP) Apply(ctx context.Context, capsule config.Capsule) (config.Capsule, error) {
+	if ok, err := p.operator.Operate(ctx, capsule); err != nil {
+		return capsule, fmt.Errorf("process: http: %v", err)
+	} else if !ok {
+		return capsule, nil
+	}
+
 	// the URL can exist in three states:
 	//
 	// - no interpolation, the URL is unchanged

--- a/process/insert_test.go
+++ b/process/insert_test.go
@@ -9,8 +9,9 @@ import (
 )
 
 var (
-	_ Applier = procInsert{}
-	_ Batcher = procInsert{}
+	_ Applier  = procInsert{}
+	_ Batcher  = procInsert{}
+	_ Streamer = procInsert{}
 )
 
 var insertTests = []struct {

--- a/process/join_test.go
+++ b/process/join_test.go
@@ -9,8 +9,9 @@ import (
 )
 
 var (
-	_ Applier = procJoin{}
-	_ Batcher = procJoin{}
+	_ Applier  = procJoin{}
+	_ Batcher  = procJoin{}
+	_ Streamer = procJoin{}
 )
 
 var joinTests = []struct {

--- a/process/jq.go
+++ b/process/jq.go
@@ -62,14 +62,24 @@ func (p procJQ) Close(context.Context) error {
 	return nil
 }
 
-// Batch processes one or more capsules with the processor. Conditions are
-// optionally applied to the data to enable processing.
+// Stream processes a pipeline of capsules with the processor.
+func (p procJQ) Stream(ctx context.Context, in, out *config.Channel) error {
+	return streamApply(ctx, in, out, p)
+}
+
+// Batch processes one or more capsules with the processor.
 func (p procJQ) Batch(ctx context.Context, capsules ...config.Capsule) ([]config.Capsule, error) {
-	return batchApply(ctx, capsules, p, p.operator)
+	return batchApply(ctx, capsules, p)
 }
 
 // Apply processes encapsulated data with the processor.
 func (p procJQ) Apply(ctx context.Context, capsule config.Capsule) (config.Capsule, error) {
+	if ok, err := p.operator.Operate(ctx, capsule); err != nil {
+		return capsule, fmt.Errorf("process: jq: %v", err)
+	} else if !ok {
+		return capsule, nil
+	}
+
 	var i interface{}
 	if err := gojson.Unmarshal(capsule.Data(), &i); err != nil {
 		return capsule, fmt.Errorf("process: jq: %v", err)

--- a/process/jq_test.go
+++ b/process/jq_test.go
@@ -8,6 +8,12 @@ import (
 	"github.com/brexhq/substation/config"
 )
 
+var (
+	_ Applier  = procJQ{}
+	_ Batcher  = procJQ{}
+	_ Streamer = procJQ{}
+)
+
 var jsonTests = []struct {
 	name     string
 	cfg      config.Config

--- a/process/kv_store.go
+++ b/process/kv_store.go
@@ -117,14 +117,24 @@ func (p procKVStore) Close(ctx context.Context) error {
 	return nil
 }
 
-// Batch processes one or more capsules with the processor. Conditions are
-// optionally applied to the data to enable processing.
+// Stream processes a pipeline of capsules with the processor.
+func (p procKVStore) Stream(ctx context.Context, in, out *config.Channel) error {
+	return streamApply(ctx, in, out, p)
+}
+
+// Batch processes one or more capsules with the processor.
 func (p procKVStore) Batch(ctx context.Context, capsules ...config.Capsule) ([]config.Capsule, error) {
-	return batchApply(ctx, capsules, p, p.operator)
+	return batchApply(ctx, capsules, p)
 }
 
 // Apply processes a capsule with the processor.
 func (p procKVStore) Apply(ctx context.Context, capsule config.Capsule) (config.Capsule, error) {
+	if ok, err := p.operator.Operate(ctx, capsule); err != nil {
+		return capsule, fmt.Errorf("process: kv_store: %v", err)
+	} else if !ok {
+		return capsule, nil
+	}
+
 	switch p.Options.Type {
 	case "get":
 		key := capsule.Get(p.Key).String()

--- a/process/math.go
+++ b/process/math.go
@@ -75,14 +75,24 @@ func (p procMath) Close(context.Context) error {
 	return nil
 }
 
-// Batch processes one or more capsules with the processor. Conditions are
-// optionally applied to the data to enable processing.
+// Stream processes a pipeline of capsules with the processor.
+func (p procMath) Stream(ctx context.Context, in, out *config.Channel) error {
+	return streamApply(ctx, in, out, p)
+}
+
+// Batch processes one or more capsules with the processor.
 func (p procMath) Batch(ctx context.Context, capsules ...config.Capsule) ([]config.Capsule, error) {
-	return batchApply(ctx, capsules, p, p.operator)
+	return batchApply(ctx, capsules, p)
 }
 
 // Apply processes a capsule with the processor.
 func (p procMath) Apply(ctx context.Context, capsule config.Capsule) (config.Capsule, error) {
+	if ok, err := p.operator.Operate(ctx, capsule); err != nil {
+		return capsule, fmt.Errorf("process: math: %v", err)
+	} else if !ok {
+		return capsule, nil
+	}
+
 	var value float64
 	result := capsule.Get(p.Key)
 	for i, res := range result.Array() {

--- a/process/math_test.go
+++ b/process/math_test.go
@@ -9,8 +9,9 @@ import (
 )
 
 var (
-	_ Applier = procMath{}
-	_ Batcher = procMath{}
+	_ Applier  = procMath{}
+	_ Batcher  = procMath{}
+	_ Streamer = procMath{}
 )
 
 var mathTests = []struct {

--- a/process/pipeline.go
+++ b/process/pipeline.go
@@ -55,10 +55,14 @@ func (p procPipeline) Close(context.Context) error {
 	return nil
 }
 
-// Batch processes one or more capsules with the processor. Conditions are
-// optionally applied to the data to enable processing.
+// Stream processes a pipeline of capsules with the processor.
+func (p procPipeline) Stream(ctx context.Context, in, out *config.Channel) error {
+	return streamApply(ctx, in, out, p)
+}
+
+// Batch processes one or more capsules with the processor.
 func (p procPipeline) Batch(ctx context.Context, capsules ...config.Capsule) ([]config.Capsule, error) {
-	return batchApply(ctx, capsules, p, p.operator)
+	return batchApply(ctx, capsules, p)
 }
 
 // Apply processes a capsule with the processor.
@@ -73,6 +77,12 @@ func (p procPipeline) Batch(ctx context.Context, capsules ...config.Capsule) ([]
 // should be run through the forEach processor (which can
 // encapsulate the pipeline processor).
 func (p procPipeline) Apply(ctx context.Context, capsule config.Capsule) (config.Capsule, error) {
+	if ok, err := p.operator.Operate(ctx, capsule); err != nil {
+		return capsule, fmt.Errorf("process: pipeline: %v", err)
+	} else if !ok {
+		return capsule, nil
+	}
+
 	if p.Key != "" && p.SetKey != "" {
 		result := capsule.Get(p.Key)
 		if result.IsArray() {

--- a/process/pipeline_test.go
+++ b/process/pipeline_test.go
@@ -9,8 +9,9 @@ import (
 )
 
 var (
-	_ Applier = procPipeline{}
-	_ Batcher = procPipeline{}
+	_ Applier  = procPipeline{}
+	_ Batcher  = procPipeline{}
+	_ Streamer = procPipeline{}
 )
 
 var pipelineTests = []struct {

--- a/process/pretty_print_test.go
+++ b/process/pretty_print_test.go
@@ -9,8 +9,9 @@ import (
 )
 
 var (
-	_ Applier = procPrettyPrint{}
-	_ Batcher = procPrettyPrint{}
+	_ Applier  = procPrettyPrint{}
+	_ Batcher  = procPrettyPrint{}
+	_ Streamer = procPrettyPrint{}
 )
 
 var prettyPrintBatchTests = []struct {

--- a/process/process.go
+++ b/process/process.go
@@ -58,7 +58,7 @@ type Applier interface {
 }
 
 // NewApplier returns a configured Applier from a processor configuration.
-func NewApplier(ctx context.Context, cfg config.Config) (Applier, error) { //nolint: cyclop, gocyclo // ignore cyclomatic complexity
+func NewApplier(ctx context.Context, cfg config.Config) (Applier, error) {
 	switch cfg.Type {
 	case "aws_dynamodb":
 		return newProcAWSDynamoDB(ctx, cfg)

--- a/process/process.go
+++ b/process/process.go
@@ -58,7 +58,7 @@ type Applier interface {
 }
 
 // NewApplier returns a configured Applier from a processor configuration.
-func NewApplier(ctx context.Context, cfg config.Config) (Applier, error) {
+func NewApplier(ctx context.Context, cfg config.Config) (Applier, error) { //nolint: cyclop, gocyclo // ignore cyclomatic complexity
 	switch cfg.Type {
 	case "aws_dynamodb":
 		return newProcAWSDynamoDB(ctx, cfg)

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -167,17 +167,18 @@ func TestBatch(t *testing.T) {
 }
 
 func TestStream(t *testing.T) {
-	group, ctx := errgroup.WithContext(context.TODO())
 	capsule := config.NewCapsule()
 
 	for _, test := range processTests {
 		t.Run(test.name, func(t *testing.T) {
+			group, ctx := errgroup.WithContext(context.TODO())
+			in, out := config.NewChannel(), config.NewChannel()
+
 			streamer, err := NewStreamer(ctx, test.conf)
 			if err != nil {
 				t.Error(err)
 			}
 
-			in, out := config.NewChannel(), config.NewChannel()
 			group.Go(func() error {
 				if err := streamer.Stream(ctx, in, out); err != nil {
 					panic(err)

--- a/process/replace.go
+++ b/process/replace.go
@@ -63,14 +63,24 @@ func (p procReplace) Close(context.Context) error {
 	return nil
 }
 
-// Batch processes one or more capsules with the processor. Conditions are
-// optionally applied to the data to enable processing.
+// Stream processes a pipeline of capsules with the processor.
+func (p procReplace) Stream(ctx context.Context, in, out *config.Channel) error {
+	return streamApply(ctx, in, out, p)
+}
+
+// Batch processes one or more capsules with the processor.
 func (p procReplace) Batch(ctx context.Context, capsules ...config.Capsule) ([]config.Capsule, error) {
-	return batchApply(ctx, capsules, p, p.operator)
+	return batchApply(ctx, capsules, p)
 }
 
 // Apply processes a capsule with the processor.
 func (p procReplace) Apply(ctx context.Context, capsule config.Capsule) (config.Capsule, error) {
+	if ok, err := p.operator.Operate(ctx, capsule); err != nil {
+		return capsule, fmt.Errorf("process: replace: %v", err)
+	} else if !ok {
+		return capsule, nil
+	}
+
 	// JSON processing
 	if p.Key != "" && p.SetKey != "" {
 		result := capsule.Get(p.Key).String()

--- a/process/replace_test.go
+++ b/process/replace_test.go
@@ -9,8 +9,9 @@ import (
 )
 
 var (
-	_ Applier = procReplace{}
-	_ Batcher = procReplace{}
+	_ Applier  = procReplace{}
+	_ Batcher  = procReplace{}
+	_ Streamer = procReplace{}
 )
 
 var replaceTests = []struct {

--- a/process/split.go
+++ b/process/split.go
@@ -53,17 +53,18 @@ func (p procSplit) Close(context.Context) error {
 	return nil
 }
 
-// Batch processes one or more capsules with the processor. Conditions are
-// optionally applied to the data to enable processing.
+// Stream processes a pipeline of capsules with the processor.
+func (p procSplit) Stream(ctx context.Context, in, out *config.Channel) error {
+	return streamApply(ctx, in, out, p)
+}
+
+// Batch processes one or more capsules with the processor.
 func (p procSplit) Batch(ctx context.Context, capsules ...config.Capsule) ([]config.Capsule, error) {
 	newCapsules := newBatch(&capsules)
 	for _, capsule := range capsules {
-		ok, err := p.operator.Operate(ctx, capsule)
-		if err != nil {
+		if ok, err := p.operator.Operate(ctx, capsule); err != nil {
 			return nil, fmt.Errorf("process: split: %v", err)
-		}
-
-		if !ok {
+		} else if !ok {
 			newCapsules = append(newCapsules, capsule)
 			continue
 		}

--- a/process/split_test.go
+++ b/process/split_test.go
@@ -9,8 +9,9 @@ import (
 )
 
 var (
-	_ Applier = procSplit{}
-	_ Batcher = procSplit{}
+	_ Applier  = procSplit{}
+	_ Batcher  = procSplit{}
+	_ Streamer = procSplit{}
 )
 
 var splitTests = []struct {

--- a/process/time.go
+++ b/process/time.go
@@ -83,14 +83,24 @@ func newProcTime(ctx context.Context, cfg config.Config) (p procTime, err error)
 	return p, nil
 }
 
-// Batch processes one or more capsules with the processor. Conditions are
-// optionally applied to the data to enable processing.
+// Stream processes a pipeline of capsules with the processor.
+func (p procTime) Stream(ctx context.Context, in, out *config.Channel) error {
+	return streamApply(ctx, in, out, p)
+}
+
+// Batch processes one or more capsules with the processor.
 func (p procTime) Batch(ctx context.Context, capsules ...config.Capsule) ([]config.Capsule, error) {
-	return batchApply(ctx, capsules, p, p.operator)
+	return batchApply(ctx, capsules, p)
 }
 
 // Apply processes a capsule with the processor.
 func (p procTime) Apply(ctx context.Context, capsule config.Capsule) (config.Capsule, error) {
+	if ok, err := p.operator.Operate(ctx, capsule); err != nil {
+		return capsule, fmt.Errorf("process: time: %v", err)
+	} else if !ok {
+		return capsule, nil
+	}
+
 	// "now" processing, supports json and data
 	if p.Options.Format == "now" {
 		ts := time.Now()

--- a/process/time_test.go
+++ b/process/time_test.go
@@ -9,8 +9,9 @@ import (
 )
 
 var (
-	_ Applier = procTime{}
-	_ Batcher = procTime{}
+	_ Applier  = procTime{}
+	_ Batcher  = procTime{}
+	_ Streamer = procTime{}
 )
 
 var setFmt = "2006-01-02T15:04:05.000000Z"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Adds condition support to processor Applier interface and methods
- Adds support to process streaming data using channels
  - Adds exported processor Streamer interface (with example in `examples/streaming/`)
  - Adds stream type to `internal/transform`
- Refactors `process/aggregate` to use a private method for aggregating data
- Fixes some tests and refactors some imports

<!--- Describe your changes in detail -->

## Motivation and Context

This PR adds a third type of data transformation called "streaming" (or "stream") that uses channels to process data. This solves a couple problems:
- Running processors on continuous streams of data, like data read from a network (socket, streaming RPC, etc.)
- Processing data as a pipeline and not a batch

The second problem is the most impactful because it improves how users run our [default ITL application](https://substation.readme.io/docs/substation). With stream support the application creates a concurrency pipeline for data processing, so data is always sent to the next processor in series whenever the processor is ready to accept more data. This is different from the batch transform, where data must always be sent to the next processor _as a group_; batching data can create unintentional bottlenecks in the system depending on the configuration. Eventually stream processing should be the default settings for all non-transfer data processing use cases.

This PR also adds condition support to the processor Applier interface, which means that the `Apply` method now checks if the data passes a condition before processing. This simplifies some of the batching code and should reduce user confusion (e.g., "why is the configured condition not working?"), but also solves a problem we have with meta-processors like `process/pipeline` not using configured conditions.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added and updated unit tests, integration tested on a high-volume production deployment. Here's some real-world evidence from AWS X-Ray of how the streaming transformation differs from batch transformation:

**Streaming**
![stream_xray](https://user-images.githubusercontent.com/5711448/234332334-674ed63d-1cd9-4450-a568-4a59dc3d906d.png)

**Batch**
![batch_xray](https://user-images.githubusercontent.com/5711448/234332375-24afe27b-aef3-4cf3-a659-36a4066c152d.png)

Notice how in the streaming screencap the Kinesis PutRecord calls occur before any DynamoDB GetItem calls -- that's because the concurrency pipeline is continuously sending data to the sink instead of waiting for all data to be processed first. In the batching screencap, all data processing (i.e., calls to DynamoDB GetItem) must complete before sending data to the sink.

## Types of changes


<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [x] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
