### PR TITLE
fix: KV Store Processor TTL Key

### DIFF
--- a/build/config/substation.libsonnet
+++ b/build/config/substation.libsonnet
@@ -113,7 +113,7 @@
         options: { query: null },
       },
       kv_store: {
-        options: { type: null, prefix: null, offset_ttl: null, kv_options: null },
+        options: { type: null, prefix: null, ttl_key: null, offset_ttl: null, kv_options: null },
       },
       math: {
         options: { operation: null },

--- a/process/kv_store.go
+++ b/process/kv_store.go
@@ -170,6 +170,11 @@ func (p procKVStore) Apply(ctx context.Context, capsule config.Capsule) (config.
 			if err := p.kvStore.SetWithTTL(ctx, key, capsule.Get(p.Key).String(), ttl); err != nil {
 				return capsule, fmt.Errorf("process: kv_store: %v", err)
 			}
+		} else if p.Options.TTLKey != "" {
+			ttl := capsule.Get(p.Options.TTLKey).Int()
+			if err := p.kvStore.SetWithTTL(ctx, key, capsule.Get(p.Key).String(), ttl); err != nil {
+				return capsule, fmt.Errorf("process: kv_store: %v", err)
+			}
 		} else if p.Options.OffsetTTL != 0 {
 			ttl := time.Now().Add(time.Duration(p.Options.OffsetTTL) * time.Second).Unix()
 			if err := p.kvStore.SetWithTTL(ctx, key, capsule.Get(p.Key).String(), ttl); err != nil {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Fixes a bug in the KV Store processor where the `ttl_key` cannot be used by itself
- Updates the default options for the KV store processor

<!--- Describe your changes in detail -->

## Motivation and Context

N/A

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Integration tested with production data pipelines.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
