### PR TITLE
feat: Allow Multiple URL Interpolations in the HTTP Processor

### DIFF
--- a/process/http.go
+++ b/process/http.go
@@ -147,9 +147,9 @@ func (p procHTTP) Apply(ctx context.Context, capsule config.Capsule) (config.Cap
 	url := p.Options.URL
 	if strings.Contains(url, httpInterp) {
 		if p.Key != "" {
-			url = strings.Replace(url, httpInterp, capsule.Get(p.Key).String(), 1)
+			url = strings.Replace(url, httpInterp, capsule.Get(p.Key).String(), -1)
 		} else {
-			url = strings.Replace(url, httpInterp, string(capsule.Data()), 1)
+			url = strings.Replace(url, httpInterp, string(capsule.Data()), -1)
 		}
 	}
 

--- a/process/http.go
+++ b/process/http.go
@@ -147,9 +147,9 @@ func (p procHTTP) Apply(ctx context.Context, capsule config.Capsule) (config.Cap
 	url := p.Options.URL
 	if strings.Contains(url, httpInterp) {
 		if p.Key != "" {
-			url = strings.Replace(url, httpInterp, capsule.Get(p.Key).String(), -1)
+			url = strings.ReplaceAll(url, httpInterp, capsule.Get(p.Key).String())
 		} else {
-			url = strings.Replace(url, httpInterp, string(capsule.Data()), -1)
+			url = strings.ReplaceAll(url, httpInterp, string(capsule.Data()))
 		}
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Changes the URL interpolation to match any number of times instead of once

<!--- Describe your changes in detail -->

## Motivation and Context

Discovered this while working with an enrichment service that has its own search language, there are some scenarios where it's helpful to interpolate the same value multiple times. For example: `url:"hxxps://foo.com/?query=( a:"${data}" AND b:"*${data}" )`. Since this goes from supporting a single interpolation to many interpolations this should be non-breaking.

Also, this doesn't add support for interpolating multiple values, just interpolating the same value multiple times. Multi-value interpolation would have bigger impact but could be possible.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Integration tested locally and in production data pipelines.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
