### PR TITLE
feat: Add JSON Lines Support to KV Store

### DIFF
--- a/build/config/substation.libsonnet
+++ b/build/config/substation.libsonnet
@@ -42,7 +42,7 @@
         settings: { file: null, column: null, delimiter: ',', header: null },
       },
       json_file: {
-        settings: { file: null },
+        settings: { file: null, lines: false },
       },
       memory: {
         settings: { capacity: 1024 },

--- a/build/config/substation.libsonnet
+++ b/build/config/substation.libsonnet
@@ -42,7 +42,7 @@
         settings: { file: null, column: null, delimiter: ',', header: null },
       },
       json_file: {
-        settings: { file: null, lines: false },
+        settings: { file: null, is_lines: false },
       },
       memory: {
         settings: { capacity: 1024 },

--- a/internal/kv/json_file.go
+++ b/internal/kv/json_file.go
@@ -58,10 +58,12 @@ func (store *kvJSONFile) Get(ctx context.Context, key string) (interface{}, erro
 		res := json.Get(store.object, key)
 
 		for _, v := range res.Array() {
-			if json.Types[v.Type] != "Null" {
+			if v.Exists() {
 				return v.Value(), nil
 			}
 		}
+
+		return nil, nil
 	}
 
 	res := json.Get(store.object, key)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- Adds support for [JSON Lines](https://jsonlines.org/) in the JSON File KV store

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

GJSON has native support for JSON Lines and this is the simplest way to support using them as a KV store.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Integration tested using the development app. The test can be recreated with these configs:

> kv.json
```json
{"a":1}
{"b":2}
{"c":3}
{"d":4}
{"e":5}
```

> process.libsonnet
```jsonnet
local sub = import '../../build/config/substation.libsonnet';

local processors = [
  {
    processor: sub.interfaces.processor.kv_store(
      options={
        type: 'get',
        kv_options: sub.interfaces.kv_store.json_file(
          settings={file: 'kv.json', is_lines: true}
        )
      },
      settings={key: 'bar', set_key: 'kv_store'}
    )
  },
];

{
  processors: sub.helpers.flatten_processors(processors),
}
```

> data.json
```json
{"foo":"a"}
{"bar":"b"}
{"baz":"c"}
{"qux":"d"}
{"quux":"e"}
```

The results are:
```json
{"foo":"a","kv_store":null}
{"bar":"b","kv_store":2}
{"baz":"c","kv_store":null}
{"qux":"d","kv_store":null}
{"quux":"e","kv_store":null}
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [x] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
