### PR TITLE
fix: use valid path to the for_each inspector settings

### DIFF
--- a/build/config/substation.libsonnet
+++ b/build/config/substation.libsonnet
@@ -244,7 +244,7 @@
       },
       for_each(options=$.defaults.inspector.for_each.options,
                settings=$.interfaces.inspector.settings): {
-        local opt = std.mergePatch($.defaults.processor.inspector.for_each.options, options),
+        local opt = std.mergePatch($.defaults.inspector.for_each.options, options),
 
         assert $.helpers.inspector.validate(settings) : 'invalid inspector settings',
         local s = std.mergePatch($.interfaces.inspector.settings, settings),

--- a/internal/file/example_test.go
+++ b/internal/file/example_test.go
@@ -50,7 +50,7 @@ func ExampleGet_local() {
 }
 
 func ExampleGet_http() {
-	location := "https://www.gutenberg.org/files/2701/2701-h/2701-h.htm"
+	location := "https://example.com"
 
 	// a local copy of the HTTP body is created and must be removed when it's no longer needed, regardless of errors
 	path, err := file.Get(context.TODO(), location)
@@ -75,7 +75,7 @@ func ExampleGet_http() {
 		panic(err)
 	}
 
-	prefix := strings.HasPrefix(string(buf), "<!DOCTYPE")
+	prefix := strings.HasPrefix(strings.ToUpper(string(buf)), "<!DOCTYPE")
 	fmt.Println(prefix)
 
 	// Output: true


### PR DESCRIPTION
## Description

Fixes a bug in the `substation.libsonnet` library when using the `for_each` inspector due to referencing an invalid path.

## Motivation and Context

This is required to use the correct settings in the `for_each` inspector.

## How Has This Been Tested?

Fix is applied to our internal substation library and used in production.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [ ] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
