### PR TITLE
build(terraform): Update Kinesis CloudWatch Alarm Lifecycle

### DIFF
--- a/build/terraform/aws/kinesis_data_stream/main.tf
+++ b/build/terraform/aws/kinesis_data_stream/main.tf
@@ -21,7 +21,7 @@ resource "aws_kinesis_stream" "stream" {
   tags = var.tags
 
   lifecycle {
-    ignore_changes = [shard_count, tags]
+    ignore_changes = [shard_count, tags["LastScalingEvent"]]
   }
 }
 

--- a/build/terraform/aws/kinesis_data_stream/main.tf
+++ b/build/terraform/aws/kinesis_data_stream/main.tf
@@ -92,7 +92,12 @@ resource "aws_cloudwatch_metric_alarm" "metric_alarm_downscale" {
   treat_missing_data  = "ignore"
 
   lifecycle {
-    ignore_changes = [metric_query, datapoints_to_alarm]
+    ignore_changes = [
+      datapoints_to_alarm,
+      evaluation_periods,
+      threshold,
+      metric_query,
+    ]
   }
 
   metric_query {
@@ -177,7 +182,12 @@ resource "aws_cloudwatch_metric_alarm" "metric_alarm_upscale" {
   treat_missing_data  = "ignore"
 
   lifecycle {
-    ignore_changes = [metric_query, datapoints_to_alarm]
+    ignore_changes = [
+      datapoints_to_alarm,
+      evaluation_periods,
+      threshold,
+      metric_query,
+    ]
   }
 
   metric_query {

--- a/build/terraform/aws/kinesis_data_stream/main.tf
+++ b/build/terraform/aws/kinesis_data_stream/main.tf
@@ -1,3 +1,14 @@
+locals {
+  # These are managed by the Autoscale application.
+  # https://github.com/brexhq/substation/blob/main/internal/aws/cloudwatch/cloudwatch.go
+  cw_alarm_ignore_changes = [
+    "datapoints_to_alarm",
+    "evaluation_periods",
+    "threshold",
+    "metric_query",
+  ]
+}
+
 resource "random_uuid" "id" {}
 
 resource "aws_kinesis_stream" "stream" {
@@ -92,12 +103,7 @@ resource "aws_cloudwatch_metric_alarm" "metric_alarm_downscale" {
   treat_missing_data  = "ignore"
 
   lifecycle {
-    ignore_changes = [
-      datapoints_to_alarm,
-      evaluation_periods,
-      threshold,
-      metric_query,
-    ]
+    ignore_changes = local.cw_alarm_ignore_changes
   }
 
   metric_query {
@@ -182,12 +188,7 @@ resource "aws_cloudwatch_metric_alarm" "metric_alarm_upscale" {
   treat_missing_data  = "ignore"
 
   lifecycle {
-    ignore_changes = [
-      datapoints_to_alarm,
-      evaluation_periods,
-      threshold,
-      metric_query,
-    ]
+    ignore_changes = local.cw_alarm_ignore_changes
   }
 
   metric_query {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- Updates the Kinesis CloudWatch alarms to match the default settings used by the [autoscale app](https://github.com/brexhq/substation/blob/main/internal/aws/cloudwatch/cloudwatch.go#L21-L35)

## Motivation and Context

This fixes resource churn that can occur between Terraform and the autoscale app. After first deployment, the autoscale app completely manages these references.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

N/A

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
