### PR TITLE
perf(aws): Reduce Aggregated Kinesis Record Size

### DIFF
--- a/internal/aws/kinesis/kinesis.go
+++ b/internal/aws/kinesis/kinesis.go
@@ -20,9 +20,9 @@ import (
 )
 
 const (
-	kplMagicLen   = 4  // Length of magic header for KPL Aggregate Record checking.
-	kplDigestSize = 16 // MD5 Message size for protobuf.
-	kplMaxBytes   = 1024 * 1024
+	kplMagicLen   = 4         // Length of magic header for KPL Aggregate Record checking.
+	kplDigestSize = 16        // MD5 Message size for protobuf.
+	kplMaxBytes   = 1000 * 25 // 25KB is the minimum size of a PUT Payload unit.
 	kplMaxCount   = 10000
 )
 
@@ -188,23 +188,6 @@ func (a *API) Setup(cfg iaws.Config) {
 // IsEnabled returns true if the client is enabled and ready for use.
 func (a *API) IsEnabled() bool {
 	return a.Client != nil
-}
-
-// PutRecord is a convenience wrapper for putting a record into a Kinesis stream.
-func (a *API) PutRecord(ctx aws.Context, stream, partitionKey string, data []byte) (*kinesis.PutRecordOutput, error) {
-	ctx = context.WithoutCancel(ctx)
-	resp, err := a.Client.PutRecordWithContext(
-		ctx,
-		&kinesis.PutRecordInput{
-			Data:         data,
-			StreamName:   aws.String(stream),
-			PartitionKey: aws.String(partitionKey),
-		})
-	if err != nil {
-		return nil, fmt.Errorf("putrecord stream %s partitionkey %s: %v", stream, partitionKey, err)
-	}
-
-	return resp, nil
 }
 
 // PutRecords is a convenience wrapper for putting multiple records into a Kinesis stream.

--- a/internal/aws/kinesis/kinesis.go
+++ b/internal/aws/kinesis/kinesis.go
@@ -20,10 +20,16 @@ import (
 )
 
 const (
-	kplMagicLen   = 4         // Length of magic header for KPL Aggregate Record checking.
-	kplDigestSize = 16        // MD5 Message size for protobuf.
-	kplMaxBytes   = 1000 * 25 // 25KB is the minimum size of a PUT Payload unit.
-	kplMaxCount   = 10000
+	// kplMaxBytes ensures that an aggregated Kinesis record will not exceed 25 KB, which is
+	// the minimum record size charged by the Kinesis service ("PUT Payload Unit"). Any record
+	// smaller than 25 KB will be charged as 25 KB and any record larger than 25 KB will be
+	// charged in 25 KB increments. See the Kinesis pricing page for more details:
+	// https://aws.amazon.com/kinesis/data-streams/pricing/.
+	kplMaxBytes = 1000 * 25
+	// kplMaxCount is the maximum number of records that can be aggregated into a single Kinesis
+	// record. There is no limit imposed by the Kinesis service on the number of records that can
+	// be aggregated into a single Kinesis record, so this value is set to a reasonable upper bound.
+	kplMaxCount = 10000
 )
 
 // Aggregate produces a KPL-compliant Kinesis record

--- a/internal/aws/kinesis/kinesis_test.go
+++ b/internal/aws/kinesis/kinesis_test.go
@@ -11,47 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/kinesis/kinesisiface"
 )
 
-type mockedPutRecord struct {
-	kinesisiface.KinesisAPI
-	Resp kinesis.PutRecordOutput
-}
-
-func (m mockedPutRecord) PutRecordWithContext(ctx aws.Context, in *kinesis.PutRecordInput, opts ...request.Option) (*kinesis.PutRecordOutput, error) {
-	return &m.Resp, nil
-}
-
-func TestPutRecord(t *testing.T) {
-	tests := []struct {
-		resp     kinesis.PutRecordOutput
-		expected string
-	}{
-		{
-			resp: kinesis.PutRecordOutput{
-				EncryptionType: aws.String("NONE"),
-				SequenceNumber: aws.String("ABCDEF"),
-				ShardId:        aws.String("XYZ"),
-			},
-			expected: "ABCDEF",
-		},
-	}
-
-	ctx := context.TODO()
-
-	for _, test := range tests {
-		a := API{
-			mockedPutRecord{Resp: test.resp},
-		}
-		resp, err := a.PutRecord(ctx, "", "", []byte(""))
-		if err != nil {
-			t.Fatalf("%v", err)
-		}
-
-		if *resp.SequenceNumber != test.expected {
-			t.Errorf("expected %+v, got %s", resp.SequenceNumber, test.expected)
-		}
-	}
-}
-
 type mockedPutRecords struct {
 	kinesisiface.KinesisAPI
 	Resp kinesis.PutRecordsOutput
@@ -185,12 +144,12 @@ func TestSize(t *testing.T) {
 		},
 		{
 			[]byte("Lorem ipsum dolor sit amet, consectetur adipiscing elit."),
-			235,
+			58,
 			"8Ex8TUWD3dWUMh6dUKaT",
 		},
 		{
 			[]byte("Lorem ipsum dolor sit amet, consectetur adipiscing elit."),
-			5678,
+			235,
 			"8Ex8TUWD3dWUMh6dUKaT",
 		},
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- Reduces the aggregated Kinesis record size from 1 MB to 25 KB
- Replaces `PutRecord` call with `PutRecords`

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Kinesis Data Streams charge based on [PUT payload units](https://aws.amazon.com/kinesis/data-streams/pricing/#:~:text=A%20PUT%20Payload%20Unit%20is,million%20PUT%20Payload%20Units%20rate.), which have a minimum size of 25 KB. Historically the project aggregated up to the Kinesis limit of 1 MB because there was no support for the `PutRecords` API, but as of v1.0 there is. There's little (or no) value in sending aggregated records larger than 25 KB and by sending them via `PutRecords` the throughput performance increases by ~33% to ~50% (see screenshot). 

<img width="706" alt="25kb_put_records" src="https://github.com/brexhq/substation/assets/5711448/537163c7-e6f7-44d9-9538-03747389f19b">

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This was tested on a high-volume, production data pipeline. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
