### PR TITLE
build(terraform): Remove Lifecycle Locals in KDS Module

### DIFF
--- a/build/terraform/aws/kinesis_data_stream/main.tf
+++ b/build/terraform/aws/kinesis_data_stream/main.tf
@@ -1,14 +1,3 @@
-locals {
-  # These are managed by the Autoscale application.
-  # https://github.com/brexhq/substation/blob/main/internal/aws/cloudwatch/cloudwatch.go
-  cw_alarm_ignore_changes = [
-    "datapoints_to_alarm",
-    "evaluation_periods",
-    "threshold",
-    "metric_query",
-  ]
-}
-
 resource "random_uuid" "id" {}
 
 resource "aws_kinesis_stream" "stream" {
@@ -103,7 +92,9 @@ resource "aws_cloudwatch_metric_alarm" "metric_alarm_downscale" {
   treat_missing_data  = "ignore"
 
   lifecycle {
-    ignore_changes = local.cw_alarm_ignore_changes
+    # These are managed by the Autoscale application.
+    # https://github.com/brexhq/substation/blob/main/internal/aws/cloudwatch/cloudwatch.go
+    ignore_changes = [metric_query, datapoints_to_alarm, evaluation_periods, threshold]
   }
 
   metric_query {
@@ -188,7 +179,9 @@ resource "aws_cloudwatch_metric_alarm" "metric_alarm_upscale" {
   treat_missing_data  = "ignore"
 
   lifecycle {
-    ignore_changes = local.cw_alarm_ignore_changes
+    # These are managed by the Autoscale application.
+    # https://github.com/brexhq/substation/blob/main/internal/aws/cloudwatch/cloudwatch.go
+    ignore_changes = [metric_query, datapoints_to_alarm, evaluation_periods, threshold]
   }
 
   metric_query {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Removes the lifecycle locals in the Terraform Kinesis Data Stream module

<!--- Describe your changes in detail -->

## Motivation and Context

Terraform won't accept variables in lifecycle.ignore_changes and returns the error `A static list expression is required.`. This has been widely discussed in several issues on the Terraform project, with a [particularly long and unresolved discussion here](https://github.com/hashicorp/terraform/issues/3116).

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
