### PR TITLE
fix(transform): Update Default KV Store TTL offset to 0

### DIFF
--- a/build/config/substation.libsonnet
+++ b/build/config/substation.libsonnet
@@ -412,7 +412,7 @@
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         set(settings={}): {
-          local default = $.transform.enrich.kv_store.default { ttl_key: null, ttl_offset: null },
+          local default = $.transform.enrich.kv_store.default { ttl_key: null, ttl_offset: "0s" },
 
           type: 'enrich_kv_store_set',
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),

--- a/transform/enrich_kv_store_set.go
+++ b/transform/enrich_kv_store_set.go
@@ -89,6 +89,10 @@ func newEnrichKVStoreSet(_ context.Context, cfg config.Config) (*enrichKVStoreSe
 		return nil, fmt.Errorf("transform: enrich_kv_store_set: %v", err)
 	}
 
+	if conf.TTLOffset == "" {
+		conf.TTLOffset = "0s"
+	}
+
 	dur, err := time.ParseDuration(conf.TTLOffset)
 	if err != nil {
 		return nil, fmt.Errorf("transform: enrich_kv_store_set: %v", err)


### PR DESCRIPTION
## Description

Fixes a bug in the initializer for the `enrich_kv_store_set` transform. Documentation states that this is an optional parameter, but the initializing function will return an error if it's not set.


Error received:
> transform: enrich_kv_store_set: time: invalid duration ""

## Motivation and Context

This resolved a bug where the application was inconsistent with the documentation.

## How Has This Been Tested?

Validated that the config from the documentation can be loaded by the application, previously this errored during load.

```jsonnet
sub.transform.enrich.kv_store.set(
  // The value of `domain` is put into the KV store as the value of `ip`.
  settings={kv_store: sub.kv_store.memory(settings={}), object: {source_key: 'ip', target_key: 'domain'}}
)
```

## Types of changes

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
