### PR TITLE
feat(transform): Add Send for AWS Lambda

### DIFF
--- a/build/config/substation.libsonnet
+++ b/build/config/substation.libsonnet
@@ -702,6 +702,18 @@
           type: 'send_aws_kinesis_data_stream',
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(s))),
         },
+        lambda(settings={}): {
+          local default = {
+            batch: $.config.batch,
+            auxiliary_transforms: null,
+            aws: $.config.aws,
+            retry: $.config.retry,
+            function_name: null,
+          },
+
+          type: 'send_aws_lambda',
+          settings: std.mergePatch(default, $.helpers.abbv(settings)),
+        },
         s3(settings={}): {
           local default = {
             batch: $.config.batch,

--- a/examples/terraform/aws/README.md
+++ b/examples/terraform/aws/README.md
@@ -289,6 +289,30 @@ flowchart LR
     sendS3y --> bucket
 ```
 
+## Retry on Failure
+
+Deploys a data pipeline that reads data from an S3 bucket and automatically retries failed events using an SQS queue as a [failure destination](https://aws.amazon.com/blogs/compute/introducing-aws-lambda-destinations/). This example will retry forever until the error is resolved.
+
+```mermaid
+
+flowchart LR
+    %% resources
+    bucket([S3 Bucket])
+    queue([SQS Queue])
+    %% connections
+    bucket --> handler
+    N -.-> queue
+    queue --> R
+    rTransforms --> handler
+    
+    subgraph N["Substation Node"]
+    handler[[Handler]] --> transforms[Transforms]
+    end
+    subgraph R["Substation Retrier"]
+    rHandler[[Handler]] --> rTransforms[Transforms]
+    end
+```
+
 ## SNS
 
 Deploys a data pipeline that reads data from an S3 bucket via an SNS topic.

--- a/examples/terraform/aws/s3/retry_on_failure/config/node/config.jsonnet
+++ b/examples/terraform/aws/s3/retry_on_failure/config/node/config.jsonnet
@@ -1,0 +1,13 @@
+// This config generates an error to engage the retry on failure feature.
+// The pipeline will retry forever until the error is resolved. Change the
+// transform to `sub.tf.send.stdout()` to resolve the error and print the logs
+// from S3.
+local sub = import '../../../../../../../build/config/substation.libsonnet';
+
+{
+  concurrency: 1,
+  transforms: [
+    sub.tf.util.err(settings={ message: 'simulating error to trigger retries' }),
+    // sub.tf.send.stdout(),
+  ],
+}

--- a/examples/terraform/aws/s3/retry_on_failure/config/retrier/config.jsonnet
+++ b/examples/terraform/aws/s3/retry_on_failure/config/retrier/config.jsonnet
@@ -1,0 +1,17 @@
+// This config transforms the failure record sent by the node Lambda function
+// so that it becomes a new request. The new request bypasses S3 and is sent
+// directly to the Lambda function.
+//
+// Additional information is available in the payload and can be used to make
+// decisions about the new request or notify external systems about the failure.
+local sub = import '../../../../../../../build/config/substation.libsonnet';
+
+{
+  concurrency: 1,
+  transforms: [
+    // If needed, then use other information from the failure record to
+    // decide what to do or notify external systems about the failure.
+    sub.tf.obj.cp(settings={ object: { source_key: 'requestPayload' } }),
+    sub.tf.send.aws.lambda(settings={ function_name: 'node' }),
+  ],
+}

--- a/examples/terraform/aws/s3/retry_on_failure/terraform/_provider.tf
+++ b/examples/terraform/aws/s3/retry_on_failure/terraform/_provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  # profile = "default"
+  region = "us-east-1"
+}

--- a/examples/terraform/aws/s3/retry_on_failure/terraform/_resources.tf
+++ b/examples/terraform/aws/s3/retry_on_failure/terraform/_resources.tf
@@ -1,0 +1,57 @@
+module "appconfig" {
+  source = "../../../../../../build/terraform/aws/appconfig"
+
+  config = {
+    name = "substation"
+    environments = [{name = "example"}]
+  }
+}
+
+module "ecr" {
+  source = "../../../../../../build/terraform/aws/ecr"
+
+  config = {
+    name         = "substation"
+    force_delete = true
+  }
+}
+
+resource "random_uuid" "s3" {}
+
+# Monolithic S3 bucket used to store all data.
+module "s3" {
+  source = "../../../../../../build/terraform/aws/s3"
+
+  config = {
+    # Bucket name is randomized to avoid collisions.
+    name = "${random_uuid.s3.result}-substation"
+  }
+
+  access = [
+    # Reads objects from the bucket.
+    module.lambda_node.role.name,
+  ]
+}
+
+module "sqs" {
+  source = "../../../../../../build/terraform/aws/sqs"
+
+  config = {
+    name = "substation_retries"
+
+    # Delay for 30 seconds to allow the pipeline to recover.
+    delay = 30
+
+    # Timeout should be at least 6x the timeout of any consuming Lambda functions, plus the batch window.
+    # Refer to the Lambda documentation for more information: 
+    # https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html.
+    timeout = 60
+  }
+
+  access = [
+    # Sends messages to the queue.
+    module.lambda_retrier.role.name,
+    # Receives messages from the queue.
+    module.lambda_node.role.name,
+  ]
+}

--- a/examples/terraform/aws/s3/retry_on_failure/terraform/node_with_retrier.tf
+++ b/examples/terraform/aws/s3/retry_on_failure/terraform/node_with_retrier.tf
@@ -1,0 +1,86 @@
+module "lambda_node" {
+  source = "../../../../../../build/terraform/aws/lambda"
+  appconfig = module.appconfig
+
+  config = {
+    name        = "node"
+    description = "Substation node that reads data from S3. The node will retry forever if it fails."
+    image_uri   = "${module.ecr.url}:latest"
+    image_arm   = true
+
+    env = {
+      "SUBSTATION_CONFIG" : "http://localhost:2772/applications/substation/environments/example/configurations/node"
+      "SUBSTATION_LAMBDA_HANDLER" : "AWS_S3"
+      "SUBSTATION_DEBUG" : true
+    }
+  }
+
+  # The retrier Lambda must be able to invoke this 
+  # Lambda function to retry failed S3 events.
+  access = [
+    module.lambda_retrier.role.name,
+  ]
+}
+
+resource "aws_lambda_permission" "node" {
+  statement_id  = "AllowExecutionFromS3Bucket"
+  action        = "lambda:InvokeFunction"
+  function_name = module.lambda_node.name
+  principal     = "s3.amazonaws.com"
+  source_arn    = module.s3.arn
+}
+
+resource "aws_s3_bucket_notification" "node" {
+  bucket = module.s3.id
+
+  lambda_function {
+    lambda_function_arn = module.lambda_node.arn
+    events              = ["s3:ObjectCreated:*"]
+  }
+
+  depends_on = [
+    aws_lambda_permission.node
+  ]
+}
+
+# Configures the Lambda function to send failed events to the SQS queue.
+resource "aws_lambda_function_event_invoke_config" "node" {
+  function_name = module.lambda_node.name
+
+  # This example disables the built-in retry mechanism.
+  maximum_retry_attempts = 0
+
+  destination_config {
+    on_failure {
+      destination = module.sqs.arn
+    }
+  }
+}
+
+module "lambda_retrier" {
+  source = "../../../../../../build/terraform/aws/lambda"
+  appconfig = module.appconfig
+
+  config = {
+    name        = "retrier"
+    description = "Substation node that receives events from the retry queue and invokes the original Lambda function."
+    image_uri   = "${module.ecr.url}:latest"
+    image_arm   = true
+
+    # This value should be 1/6th of the visibility timeout of the SQS queue.
+    timeout = 5
+
+    env = {
+      "SUBSTATION_CONFIG" : "http://localhost:2772/applications/substation/environments/example/configurations/retrier"
+      "SUBSTATION_LAMBDA_HANDLER" : "AWS_SQS"
+      "SUBSTATION_DEBUG" : true
+    }
+  }
+}
+
+resource "aws_lambda_event_source_mapping" "retrier" {
+  event_source_arn                   = module.sqs.arn
+  function_name                      = module.lambda_retrier.arn
+  maximum_batching_window_in_seconds = 30
+  batch_size                         = 10
+}

--- a/internal/aws/lambda/lambda.go
+++ b/internal/aws/lambda/lambda.go
@@ -50,9 +50,25 @@ func (a *API) Invoke(ctx aws.Context, function string, payload []byte) (resp *la
 			InvocationType: aws.String("RequestResponse"),
 			Payload:        payload,
 		})
-
 	if err != nil {
 		return nil, fmt.Errorf("invoke function %s: %v", function, err)
+	}
+
+	return resp, nil
+}
+
+// InvokeAsync is a convenience wrapper for asynchronously invoking a Lambda function.
+func (a *API) InvokeAsync(ctx aws.Context, function string, payload []byte) (resp *lambda.InvokeOutput, err error) {
+	ctx = context.WithoutCancel(ctx)
+	resp, err = a.Client.InvokeWithContext(
+		ctx,
+		&lambda.InvokeInput{
+			FunctionName:   aws.String(function),
+			InvocationType: aws.String("Event"),
+			Payload:        payload,
+		})
+	if err != nil {
+		return nil, fmt.Errorf("invoke_async function %s: %v", function, err)
 	}
 
 	return resp, nil

--- a/transform/send_aws_lambda.go
+++ b/transform/send_aws_lambda.go
@@ -1,0 +1,171 @@
+package transform
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/brexhq/substation/config"
+	"github.com/brexhq/substation/internal/aggregate"
+	"github.com/brexhq/substation/internal/aws"
+	"github.com/brexhq/substation/internal/aws/lambda"
+	iconfig "github.com/brexhq/substation/internal/config"
+	"github.com/brexhq/substation/internal/errors"
+	"github.com/brexhq/substation/message"
+)
+
+// Payloads greater than 256 KB in size cannot be
+// sent to an AWS Lambda function.
+const sendLambdaPayloadSizeLimit = 1024 * 1024 * 256
+
+// errSendLambdaPayloadSizeLimit is returned when data exceeds the Lambda
+// payload size limit. If this error occurs, then conditions or transforms
+// should be applied to either drop or reduce the size of the data.
+var errSendLambdaPayloadSizeLimit = fmt.Errorf("data exceeded size limit")
+
+type sendAWSLambdaConfig struct {
+	// FunctionName is the AWS Lambda function to asynchronously invoke.
+	FunctionName string `json:"function_name"`
+	// AuxTransforms are applied to batched data before it is sent.
+	AuxTransforms []config.Config `json:"auxiliary_transforms"`
+
+	Object iconfig.Object `json:"object"`
+	Batch  iconfig.Batch  `json:"batch"`
+	AWS    iconfig.AWS    `json:"aws"`
+	Retry  iconfig.Retry  `json:"retry"`
+}
+
+func (c *sendAWSLambdaConfig) Decode(in interface{}) error {
+	return iconfig.Decode(in, c)
+}
+
+func (c *sendAWSLambdaConfig) Validate() error {
+	if c.FunctionName == "" {
+		return fmt.Errorf("function_name: %v", errors.ErrMissingRequiredOption)
+	}
+
+	return nil
+}
+
+func newSendAWSLambda(_ context.Context, cfg config.Config) (*sendAWSLambda, error) {
+	conf := sendAWSLambdaConfig{}
+	if err := conf.Decode(cfg.Settings); err != nil {
+		return nil, fmt.Errorf("transform: send_aws_lambda: %v", err)
+	}
+
+	if err := conf.Validate(); err != nil {
+		return nil, fmt.Errorf("transform: send_aws_lambda: %v", err)
+	}
+
+	tf := sendAWSLambda{
+		conf:     conf,
+		function: conf.FunctionName,
+	}
+
+	agg, err := aggregate.New(aggregate.Config{
+		Count:    conf.Batch.Count,
+		Size:     conf.Batch.Size,
+		Duration: conf.Batch.Duration,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("transform: send_aws_lambda: %v", err)
+	}
+	tf.agg = agg
+
+	if len(conf.AuxTransforms) > 0 {
+		tf.tforms = make([]Transformer, len(conf.AuxTransforms))
+		for i, c := range conf.AuxTransforms {
+			t, err := New(context.Background(), c)
+			if err != nil {
+				return nil, fmt.Errorf("transform: send_aws_lambda: %v", err)
+			}
+
+			tf.tforms[i] = t
+		}
+	}
+
+	// Setup the AWS client.
+	tf.client.Setup(aws.Config{
+		Region:          conf.AWS.Region,
+		RoleARN:         conf.AWS.RoleARN,
+		MaxRetries:      conf.Retry.Count,
+		RetryableErrors: conf.Retry.ErrorMessages,
+	})
+
+	return &tf, nil
+}
+
+type sendAWSLambda struct {
+	conf     sendAWSLambdaConfig
+	function string
+
+	// client is safe for concurrent use.
+	client lambda.API
+
+	mu     sync.Mutex
+	agg    *aggregate.Aggregate
+	tforms []Transformer
+}
+
+func (tf *sendAWSLambda) Transform(ctx context.Context, msg *message.Message) ([]*message.Message, error) {
+	tf.mu.Lock()
+	defer tf.mu.Unlock()
+
+	if msg.IsControl() {
+		for key := range tf.agg.GetAll() {
+			if tf.agg.Count(key) == 0 {
+				continue
+			}
+
+			if err := tf.send(ctx, key); err != nil {
+				return nil, fmt.Errorf("transform: send_aws_lambda: %v", err)
+			}
+		}
+
+		tf.agg.ResetAll()
+		return []*message.Message{msg}, nil
+	}
+
+	if len(msg.Data()) > sendLambdaPayloadSizeLimit {
+		return nil, fmt.Errorf("transform: send_aws_lambda: %v", errSendLambdaPayloadSizeLimit)
+	}
+
+	// If this value does not exist, then all data is batched together.
+	key := msg.GetValue(tf.conf.Object.BatchKey).String()
+	if ok := tf.agg.Add(key, msg.Data()); ok {
+		return []*message.Message{msg}, nil
+	}
+
+	if err := tf.send(ctx, key); err != nil {
+		return nil, fmt.Errorf("transform: send_aws_lambda: %v", err)
+	}
+
+	// If data cannot be added after reset, then the batch is misconfgured.
+	tf.agg.Reset(key)
+	if ok := tf.agg.Add(key, msg.Data()); !ok {
+		return nil, fmt.Errorf("transform: send_aws_lambda: %v", errSendBatchMisconfigured)
+	}
+
+	return []*message.Message{msg}, nil
+}
+
+func (tf *sendAWSLambda) send(ctx context.Context, key string) error {
+	data, err := withTransforms(ctx, tf.tforms, tf.agg.Get(key))
+	if err != nil {
+		return err
+	}
+
+	for _, b := range data {
+		if _, err := tf.client.InvokeAsync(ctx, tf.function, b); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (tf *sendAWSLambda) String() string {
+	b, _ := json.Marshal(tf.conf)
+	return string(b)
+}

--- a/transform/transform.go
+++ b/transform/transform.go
@@ -126,6 +126,8 @@ func New(ctx context.Context, cfg config.Config) (Transformer, error) { //nolint
 		return newSendAWSKinesisDataFirehose(ctx, cfg)
 	case "send_aws_kinesis_data_stream":
 		return newSendAWSKinesisDataStream(ctx, cfg)
+	case "send_aws_lambda":
+		return newSendAWSLambda(ctx, cfg)
 	case "send_aws_s3":
 		return newSendAWSS3(ctx, cfg)
 	case "send_aws_sns":


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- Adds a `send_aws_lambda` transform
- Adds an example of using the new transform to continuously retry a failed S3 trigger

## Motivation and Context

This resolves https://github.com/brexhq/substation/issues/57 with an emphasis on adding as little new code as possible. It's mostly trivial to build a retry pipeline using existing Substation components. You can test the new example by running this and then uploading a file to the created S3 bucket:

```sh
make check
make build-aws
make deploy-aws DEPLOYMENT_DIR=examples/terraform/aws/s3/retry_on_failure AWS_APPCONFIG_ENV=example
```

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

End-to-end tested using the added example.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [ ] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
