### PR TITLE
build(terraform): Add BatchWriteItem to DynamoDB Module

### DIFF
--- a/build/terraform/aws/dynamodb/main.tf
+++ b/build/terraform/aws/dynamodb/main.tf
@@ -79,6 +79,7 @@ data "aws_iam_policy_document" "access" {
       # Write actions
       "dynamodb:PutItem",
       "dynamodb:UpdateItem",
+      "dynamodb:BatchWriteItem",
     ]
 
     resources = [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- Adds the `BatchWriteItem` permission to the DynamoDB Terraform module

## Motivation and Context

This is required to support the write pattern in the send_aws_dynamodb transform.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Discovered this while working on https://github.com/brexhq/substation/pull/160.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
