### PR TITLE
fix(kinesis): remove Kinesis aggregation size and count limits

### DIFF
--- a/internal/aws/kinesis/kinesis_test.go
+++ b/internal/aws/kinesis/kinesis_test.go
@@ -1,7 +1,6 @@
 package kinesis
 
 import (
-	"bytes"
 	"context"
 	"testing"
 
@@ -126,45 +125,6 @@ func TestGetTags(t *testing.T) {
 				t.Logf("expected %s, got %s", *test.Value, *tag.Value)
 				t.Fail()
 			}
-		}
-	}
-}
-
-// tests that the calculated record size matches the size of returned data
-func TestSize(t *testing.T) {
-	tests := []struct {
-		data   []byte
-		repeat int
-		pk     string
-	}{
-		{
-			[]byte("Lorem ipsum dolor sit amet, consectetur adipiscing elit."),
-			1,
-			"8Ex8TUWD3dWUMh6dUKaT",
-		},
-		{
-			[]byte("Lorem ipsum dolor sit amet, consectetur adipiscing elit."),
-			58,
-			"8Ex8TUWD3dWUMh6dUKaT",
-		},
-		{
-			[]byte("Lorem ipsum dolor sit amet, consectetur adipiscing elit."),
-			235,
-			"8Ex8TUWD3dWUMh6dUKaT",
-		},
-	}
-
-	rec := Aggregate{}
-	rec.New()
-
-	for _, test := range tests {
-		b := bytes.Repeat(test.data, test.repeat)
-		check := rec.calculateRecordSize(b, test.pk)
-		rec.Add(b, test.pk)
-
-		data := rec.Get()
-		if check != len(data) {
-			t.Errorf("expected %v, got %v", len(data), check)
 		}
 	}
 }


### PR DESCRIPTION
## Description

Substation uses the `internal/aggregate` package to buffer events with consideration to buffer size, record counts, and durations which shadow the checks here with adherence to Kinesis limits in a more user friendly way. 

## Motivation and Context

Inclusion of the size checks here allowed events between 25KiB and 1MiB to be sent as empty events to destinations.

## How Has This Been Tested?

The fix has been tested on the internal pipeline containing events ranging from 10KiB to 1MiB with no issues.

## Types of changes

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
