### PR TITLE
fix(kinesis): Limit Aggregated Records to 1MB

### DIFF
--- a/transform/send_aws_kinesis_data_stream.go
+++ b/transform/send_aws_kinesis_data_stream.go
@@ -203,6 +203,8 @@ func (tf *sendAWSKinesisDataStream) aggregateRecords(partitionKey string, data [
 		records = append(records, agg.Get())
 
 		agg.New()
+
+		// This silently drops any data that is between ~0.9999 MB and 1 MB.
 		_ = agg.Add(d, partitionKey)
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- Adds a 1MB limit to the Kinesis KPL aggregator

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

KPL records still need a limit, otherwise the Kinesis transform may generate a record bigger than the 1 MB service limit.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Integration tested on data that is known to cause this issue.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
