### PR TITLE
fix(transform): Empty Aggregated Kinesis Records

### DIFF
--- a/transform/send_aws_kinesis_data_stream.go
+++ b/transform/send_aws_kinesis_data_stream.go
@@ -192,19 +192,18 @@ func (tf *sendAWSKinesisDataStream) send(ctx context.Context, key string) error 
 func (tf *sendAWSKinesisDataStream) aggregateRecords(partitionKey string, data [][]byte) [][]byte {
 	var records [][]byte
 
+	// Aggregation silently drops any data that is between ~0.9999 MB and 1 MB.
 	agg := &kinesis.Aggregate{}
 	agg.New()
 
 	for _, d := range data {
 		if ok := agg.Add(d, partitionKey); ok {
 			continue
+		} else if agg.Count > 0 {
+			records = append(records, agg.Get())
 		}
 
-		records = append(records, agg.Get())
-
 		agg.New()
-
-		// This silently drops any data that is between ~0.9999 MB and 1 MB.
 		_ = agg.Add(d, partitionKey)
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- Fixes an edge case where the AWS Kinesis send transform can send an empty aggregated record

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is a fix that is in addition to https://github.com/brexhq/substation/pull/168. 

There's an edge case where an empty aggregated Kinesis record can be sent if a single record is between ~0.9999 MB and 1 MB. Aggregated Kinesis records have [a format](https://github.com/awslabs/amazon-kinesis-producer/blob/master/aggregation-format.md) and contain more data than a naked record, so there is a small chance that the naked record cannot actually fit inside an aggregated record and be successfully sent to the Kinesis service (due to the 1 MB record service limit). 

This record is silently dropped, but since this causes an issue identical [to this](https://github.com/brexhq/substation/blob/main/transform/send_aws_kinesis_data_stream.go#L135-L137), it may be worth raising the same error for this edge case.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This is running on some high-volume production data pipelines that are known to have this edge case.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
