### PR TITLE
feat(transform): Add Customizable Errors to MetaErr

### DIFF
--- a/build/config/substation.libsonnet
+++ b/build/config/substation.libsonnet
@@ -509,7 +509,7 @@
     },
     meta: {
       err(settings={}): {
-        local default = { transform: null },
+        local default = { transform: null, error_messages: null },
 
         type: 'meta_err',
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),

--- a/transform/meta_err_test.go
+++ b/transform/meta_err_test.go
@@ -34,6 +34,26 @@ var metaErrTests = []struct {
 			[]byte(`{"a":"b"}`),
 		},
 	},
+	{
+		"error_messages",
+		config.Config{
+			Settings: map[string]interface{}{
+				"transform": config.Config{
+					Settings: map[string]interface{}{
+						"message": "test error",
+					},
+					Type: "utility_err",
+				},
+				"error_messages": []string{
+					"test error",
+				},
+			},
+		},
+		[]byte(`{"a":"b"}`),
+		[][]byte{
+			[]byte(`{"a":"b"}`),
+		},
+	},
 }
 
 func TestMetaErr(t *testing.T) {

--- a/transform/meta_err_test.go
+++ b/transform/meta_err_test.go
@@ -35,7 +35,7 @@ var metaErrTests = []struct {
 		},
 	},
 	{
-		"error_messages",
+		"error_messages string",
 		config.Config{
 			Settings: map[string]interface{}{
 				"transform": config.Config{
@@ -46,6 +46,26 @@ var metaErrTests = []struct {
 				},
 				"error_messages": []string{
 					"test error",
+				},
+			},
+		},
+		[]byte(`{"a":"b"}`),
+		[][]byte{
+			[]byte(`{"a":"b"}`),
+		},
+	},
+	{
+		"error_messages regex",
+		config.Config{
+			Settings: map[string]interface{}{
+				"transform": config.Config{
+					Settings: map[string]interface{}{
+						"message": "test error",
+					},
+					Type: "utility_err",
+				},
+				"error_messages": []string{
+					"^test",
 				},
 			},
 		},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- Adds an option to configure which error messages should be caught using the Meta Err transform

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This transform catches all errors, but there are some cases where only specific errors should be caught while others should crash the application. By default this option is the same as the existing solution, and it matches the behavior used by `ErrorMessages` elsewhere in the app (https://github.com/brexhq/substation/blob/main/internal/aws/config.go#L96).

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added unit test that shows it catching errors when configured.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [x] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
