### PR TITLE
feat(transform): Add Metric Freshness Transform

### DIFF
--- a/build/config/substation.libsonnet
+++ b/build/config/substation.libsonnet
@@ -1015,6 +1015,16 @@
           type: 'utility_metric_count',
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
+        freshness(settings={}): {
+          local default = {
+            threshold: null,
+            metric: $.config.metric,
+            object: $.config.object,
+          },
+
+          type: 'utility_metric_freshness',
+          settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
+        },
       },
       secret(settings={}): {
         local default = { secret: null },

--- a/examples/config/transform/utility/message_freshness/config.jsonnet
+++ b/examples/config/transform/utility/message_freshness/config.jsonnet
@@ -1,0 +1,24 @@
+// This example shows how to use the `utility_metric_freshness` transform to
+// determine if data was processed by the system within a certain time frame.
+//
+// Freshness is calculated by comparing a time value in the message to the current
+// time and determining if the difference is less than a threshold:
+// - Success: current time - timestamp < threshold
+// - Failure: current time - timestamp >= threshold
+// 
+// The transform emits two metrics that describe success and failure, annotated
+// in the `FreshnessType` attribute.
+local sub = import '../../../../../build/config/substation.libsonnet';
+
+local attr = { AppName: 'example' };
+local dest = { type: 'aws_cloudwatch_embedded_metrics' };
+
+{
+  transforms: [
+    sub.transform.utility.metric.freshness({ 
+      threshold: '5s',  // Amount of time spent in the system before considered stale.
+      object: { source_key: 'timestamp' },  // Used as the reference to determine freshness.
+      metric: { name: 'MessageFreshness', attributes: attr, destination: dest } 
+    }),
+  ],
+}

--- a/transform/transform.go
+++ b/transform/transform.go
@@ -185,6 +185,8 @@ func New(ctx context.Context, cfg config.Config) (Transformer, error) { //nolint
 		return newUtilityMetricBytes(ctx, cfg)
 	case "utility_metric_count":
 		return newUtilityMetricCount(ctx, cfg)
+	case "utility_metric_freshness":
+		return newUtilityMetricFreshness(ctx, cfg)
 	case "utility_secret":
 		return newUtilitySecret(ctx, cfg)
 	default:

--- a/transform/utility_metric_freshness.go
+++ b/transform/utility_metric_freshness.go
@@ -1,0 +1,124 @@
+package transform
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/brexhq/substation/config"
+	iconfig "github.com/brexhq/substation/internal/config"
+	"github.com/brexhq/substation/internal/errors"
+	"github.com/brexhq/substation/internal/metrics"
+	"github.com/brexhq/substation/message"
+)
+
+type utilityMetricFreshnessConfig struct {
+	Threshold string `json:"threshold"`
+
+	Object iconfig.Object `json:"object"`
+	Metric iconfig.Metric `json:"metric"`
+}
+
+func (c *utilityMetricFreshnessConfig) Decode(in interface{}) error {
+	return iconfig.Decode(in, c)
+}
+
+func (c *utilityMetricFreshnessConfig) Validate() error {
+	if c.Threshold == "" {
+		return fmt.Errorf("threshold: %v", errors.ErrMissingRequiredOption)
+	}
+
+	if c.Object.SourceKey == "" {
+		return fmt.Errorf("object_source_key: %v", errors.ErrMissingRequiredOption)
+	}
+
+	return nil
+}
+
+func newUtilityMetricFreshness(ctx context.Context, cfg config.Config) (*utilityMetricFreshness, error) {
+	conf := utilityMetricFreshnessConfig{}
+	if err := conf.Decode(cfg.Settings); err != nil {
+		return nil, fmt.Errorf("transform: utility_metric_freshness: %v", err)
+	}
+
+	if err := conf.Validate(); err != nil {
+		return nil, fmt.Errorf("transform: utility_metric_freshness: %v", err)
+	}
+
+	m, err := metrics.New(ctx, conf.Metric.Destination)
+	if err != nil {
+		return nil, fmt.Errorf("transform: utility_metric_freshness: %v", err)
+	}
+
+	dur, err := time.ParseDuration(conf.Threshold)
+	if err != nil {
+		return nil, fmt.Errorf("transform: utility_metric_freshness: duration: %v", err)
+	}
+
+	tf := utilityMetricFreshness{
+		conf:   conf,
+		metric: m,
+		dur:    dur,
+	}
+
+	return &tf, nil
+}
+
+type utilityMetricFreshness struct {
+	conf   utilityMetricFreshnessConfig
+	metric metrics.Generator
+	dur    time.Duration
+
+	success uint32
+	failure uint32
+}
+
+func (tf *utilityMetricFreshness) Transform(ctx context.Context, msg *message.Message) ([]*message.Message, error) {
+	// ctrl messages are handled by only one process, so the map
+	// updates below are safe for concurrency.
+	if msg.IsControl() {
+		tf.conf.Metric.Attributes["FreshnessType"] = "Success"
+		if err := tf.metric.Generate(ctx, metrics.Data{
+			Name:       tf.conf.Metric.Name,
+			Value:      tf.success,
+			Attributes: tf.conf.Metric.Attributes,
+		}); err != nil {
+			return nil, fmt.Errorf("transform: utility_metric_freshness: %v", err)
+		}
+
+		tf.conf.Metric.Attributes["FreshnessType"] = "Failure"
+		if err := tf.metric.Generate(ctx, metrics.Data{
+			Name:       tf.conf.Metric.Name,
+			Value:      tf.failure,
+			Attributes: tf.conf.Metric.Attributes,
+		}); err != nil {
+			return nil, fmt.Errorf("transform: utility_metric_freshness: %v", err)
+		}
+
+		atomic.StoreUint32(&tf.success, 0)
+		atomic.StoreUint32(&tf.failure, 0)
+		return []*message.Message{msg}, nil
+	}
+
+	// This is a time value expected to be in nanoseconds.
+	val := msg.GetValue(tf.conf.Object.SourceKey).Int()
+	if val == 0 {
+		return []*message.Message{msg}, nil
+	}
+
+	ts := time.Unix(0, val)
+	if time.Since(ts) < tf.dur {
+		atomic.AddUint32(&tf.success, 1)
+	} else {
+		atomic.AddUint32(&tf.failure, 1)
+	}
+
+	return []*message.Message{msg}, nil
+}
+
+func (tf *utilityMetricFreshness) String() string {
+	b, _ := json.Marshal(tf.conf)
+	return string(b)
+}

--- a/transform/utility_metric_freshness.go
+++ b/transform/utility_metric_freshness.go
@@ -76,7 +76,7 @@ type utilityMetricFreshness struct {
 }
 
 func (tf *utilityMetricFreshness) Transform(ctx context.Context, msg *message.Message) ([]*message.Message, error) {
-	// ctrl messages are handled by only one process, so the map
+	// ctrl messages are handled by only one thread, so the map
 	// updates below are safe for concurrency.
 	if msg.IsControl() {
 		tf.conf.Metric.Attributes["FreshnessType"] = "Success"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Adds a `utility_metric_freshness` transform with an example

<!--- Describe your changes in detail -->

## Motivation and Context

This makes it possible to measure message / data freshness ([commonly used to measure data processing systems](https://sre.google/workbook/data-processing/)). Unlike other metric transforms, this emits two metrics with unique attributes to differentiate them in the downstream monitoring platform. A freshness SLO can be calculated by turning these metrics into a percentage (e.g., `SLO = success / (success + failure)` for a particular pipeline). 

It's up to the user to determine when to begin measuring freshness (as determined by the `object.source_key` timestamp value), but two examples are:
- Measure freshness of an individual pipeline component (using the `time_now` transform)
- Measure end-to-end freshness of an entire pipeline (using the timestamp value from the data source)

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Integration tested using the example config. End-to-end testing will come after this is merged to main (as part of testing the next release).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [x] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
