### PR TITLE
fix(metrics): AWS CloudWatch Embedded Metrics Dimensions

### DIFF
--- a/internal/metrics/aws_cloudwatch_embedded_metrics.go
+++ b/internal/metrics/aws_cloudwatch_embedded_metrics.go
@@ -45,16 +45,19 @@ func (m *awsCloudWatchEmbeddedMetrics) Generate(ctx context.Context, data Data) 
 		return fmt.Errorf("metrics log_embedded_metrics: %v", err)
 	}
 
+	var dimensions []string
 	for key, val := range data.Attributes {
-		emf, err = sjson.SetBytes(emf, "_aws.CloudWatchMetrics.0.Dimensions.-1.-1", key)
-		if err != nil {
-			return fmt.Errorf("metrics log_embedded_metrics: %v", err)
-		}
+		dimensions = append(dimensions, key)
 
 		emf, err = sjson.SetBytes(emf, key, val)
 		if err != nil {
 			return fmt.Errorf("metrics log_embedded_metrics: %v", err)
 		}
+	}
+
+	emf, err = sjson.SetBytes(emf, "_aws.CloudWatchMetrics.0.Dimensions.-1", dimensions)
+	if err != nil {
+		return fmt.Errorf("metrics log_embedded_metrics: %v", err)
 	}
 
 	emf, err = sjson.SetBytes(emf, "_aws.CloudWatchMetrics.0.Metrics.0.Name", data.Name)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- Fixes dimensions in the AWS CloudWatch Embedded Metrics destination

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This fixes a bug that causes multiple attributes to be incorrectly assigned to dimensions in the metric (discovered while testing https://github.com/brexhq/substation/pull/178 in a production pipeline). The fix has these dimensions:
```
"Dimensions":[["FunctionName","FreshnessType"]]
```

The incorrect dimensions are:
```
"Dimensions":[["FunctionName"],["FreshnessType"]]
```

This bug doesn't impact the metric value, but it does affect filters in CloudWatch (and may affect downstream systems).

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
