### PR TITLE
refactor(transform): Use Object SourceKey in KV Store Lock

### DIFF
--- a/build/config/substation.libsonnet
+++ b/build/config/substation.libsonnet
@@ -412,7 +412,7 @@
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         set(settings={}): {
-          local default = $.transform.enrich.kv_store.default { ttl_key: null, ttl_offset: "0s" },
+          local default = $.transform.enrich.kv_store.default { ttl_key: null, ttl_offset: '0s' },
 
           type: 'enrich_kv_store_set',
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
@@ -526,11 +526,11 @@
       kv_store: {
         lock(settings={}): {
           local default = {
-            object: $.config.object { lock_key: null, ttl_key: null },
+            object: $.config.object { ttl_key: null },
             transform: null,
             kv_store: null,
             prefix: null,
-            ttl_offset: "0s",
+            ttl_offset: '0s',
           },
 
           type: 'meta_kv_store_lock',

--- a/transform/meta_kv_store_lock.go
+++ b/transform/meta_kv_store_lock.go
@@ -15,10 +15,6 @@ import (
 )
 
 type metaVStoreLockObjectConfig struct {
-	// LockKey retrieves a value from an object that is used as the key to lock
-	// the item in the KV store. If this value is not set, then the SHA256 hash
-	// of the message is used as the key.
-	LockKey string `json:"lock_key"`
 	// TTLKey retrieves a value from an object that is used as the time-to-live (TTL)
 	// of the item locked in the KV store. This value must be an integer that represents
 	// the Unix time when the item will be evicted from the store. Any precision greater
@@ -146,7 +142,7 @@ func (tf *metaKVStoreLock) Transform(ctx context.Context, msg *message.Message) 
 
 	// By default, the lock key is the SHA256 hash of the message.
 	var lockKey string
-	v := msg.GetValue(tf.conf.Object.LockKey)
+	v := msg.GetValue(tf.conf.Object.SourceKey)
 	if !v.Exists() {
 		sum := sha256.Sum256(msg.Data())
 		lockKey = fmt.Sprintf("%x", sum)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Replaces the `Object.LockKey` setting with `Object.SourceKey` in the meta_kv_store_lock transform

<!--- Describe your changes in detail -->

## Motivation and Context

This matches the pattern used by the two existing KV Store transforms. 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Source code and config file linting.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
