### PR TITLE
feat(transform): Add ID Settings Field

### DIFF
--- a/build/config/substation.libsonnet
+++ b/build/config/substation.libsonnet
@@ -251,6 +251,7 @@
         arr(settings={}): $.transform.aggregate.from.array(settings=settings),
         array(settings={}): {
           local default = {
+            id: $.helpers.id($.transform.aggregate.from.array.type, settings),
             object: $.config.object,
           },
 
@@ -260,6 +261,7 @@
         str(settings={}): $.transform.aggregate.from.string(settings=settings),
         string(settings={}): {
           local default = {
+            id: $.helpers.id($.transform.aggregate.from.string.type, settings),
             separator: null,
           },
 
@@ -271,6 +273,7 @@
         arr(settings={}): $.transform.aggregate.to.array(settings=settings),
         array(settings={}): {
           local default = {
+            id: $.helpers.id($.transform.aggregate.to.array.type, settings),
             object: $.config.object,
             batch: $.config.batch,
           },
@@ -281,6 +284,7 @@
         str(settings={}): $.transform.aggregate.to.string(settings=settings),
         string(settings={}): {
           local default = {
+            id: $.helpers.id($.transform.aggregate.to.string.type, settings),
             batch: $.config.batch,
             separator: null,
           },
@@ -294,6 +298,7 @@
     array: {
       join(settings={}): {
         local default = {
+          id: $.helpers.id($.transform.array.join.type, settings),
           object: $.config.object,
           separator: null,
         },
@@ -301,23 +306,10 @@
         type: 'array_join',
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
       },
-      to: {
-        obj: $.transform.array.to.object,
-        object(settings={}): {
-          local default = {
-            object: $.config.object,
-            object_keys: null,
-          },
-
-          type: 'array_to_object',
-          settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
-        },
-      },
       zip(settings={}): {
         local default = {
+          id: $.helpers.id($.transform.array.zip.type, settings),
           object: $.config.object,
-          as_object: false,
-          with_keys: null,
         },
 
         type: 'array_zip',
@@ -328,6 +320,7 @@
       aws: {
         dynamodb(settings={}): {
           local default = {
+            id: $.helpers.id($.transform.enrich.aws.dynamodb.type, settings),
             object: $.config.object,
             aws: $.config.aws,
             retry: $.config.retry,
@@ -344,6 +337,7 @@
         },
         lambda(settings={}): {
           local default = {
+            id: $.helpers.id($.transform.enrich.aws.lambda.type, settings),
             object: $.config.object,
             aws: $.config.aws,
             retry: $.config.retry,
@@ -360,19 +354,19 @@
           request: $.config.request,
         },
         domain_lookup(settings={}): {
-          local default = $.transform.enrich.dns.default,
+          local default = $.transform.enrich.dns.default { id: $.helpers.id($.transform.enrich.dns.domain_lookup.type, settings) },
 
           type: 'enrich_dns_domain_lookup',
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         ip_lookup(settings={}): {
-          local default = $.transform.enrich.dns.default,
+          local default = $.transform.enrich.dns.default { id: $.helpers.id($.transform.enrich.dns.ip_lookup.type, settings) },
 
           type: 'enrich_dns_ip_lookup',
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         txt_lookup(settings={}): {
-          local default = $.transform.enrich.dns.default,
+          local default = $.transform.enrich.dns.default { id: $.helpers.id($.transform.enrich.dns.txt_lookup.type, settings) },
 
           type: 'enrich_dns_txt_lookup',
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
@@ -386,13 +380,13 @@
           headers: null,
         },
         get(settings={}): {
-          local default = $.transform.enrich.http.default,
+          local default = $.transform.enrich.http.default { id: $.helpers.id($.transform.enrich.http.get.type, settings)},
 
           type: 'enrich_http_get',
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         post(settings={}): {
-          local default = $.transform.enrich.http.default { body_key: null },
+          local default = $.transform.enrich.http.default { body_key: null, id: $.helpers.id($.transform.enrich.http.post.type, settings) },
 
           type: 'enrich_http_post',
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
@@ -406,13 +400,13 @@
           close_kv_store: false,
         },
         get(settings={}): {
-          local default = $.transform.enrich.kv_store.default,
+          local default = $.transform.enrich.kv_store.default {id: $.helpers.id($.transform.enrich.kv_store.get.type, settings)},
 
           type: 'enrich_kv_store_get',
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         set(settings={}): {
-          local default = $.transform.enrich.kv_store.default { ttl_key: null, ttl_offset: '0s' },
+          local default = $.transform.enrich.kv_store.default { ttl_key: null, ttl_offset: '0s', id: $.helpers.id($.transform.enrich.kv_store.set.type, settings) },
 
           type: 'enrich_kv_store_set',
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
@@ -427,30 +421,39 @@
       from: {
         b64(settings={}): $.transform.format.from.base64(settings=settings),
         base64(settings={}): {
-          local default = $.transform.format.default,
+          local default = $.transform.format.default { id: $.helpers.id($.transform.format.from.base64.type, settings) },
 
           type: 'format_from_base64',
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         gz(settings={}): $.transform.format.from.gzip(settings=settings),
         gzip(settings={}): {
+          local default = { id: $.helpers.id($.transform.format.from.gzip.type, settings) },
+
           type: 'format_from_gzip',
+          settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         pretty_print(settings={}): {
+          local default = { id: $.helpers.id($.transform.format.from.pretty_print.type, settings) },
+
           type: 'format_from_pretty_print',
+          settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
       },
       to: {
         b64(settings={}): $.transform.format.to.base64(settings=settings),
         base64(settings={}): {
-          local default = $.transform.format.default,
+          local default = $.transform.format.default { id: $.helpers.id($.transform.format.to.base64.type, settings) },
 
           type: 'format_to_base64',
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         gz(settings={}): $.transform.format.to.gzip(settings=settings),
         gzip(settings={}): {
+          local default = { id: $.helpers.id($.transform.format.to.gzip.type, settings) },
+
           type: 'format_to_gzip',
+          settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
       },
     },
@@ -459,13 +462,13 @@
         object: $.config.object,
       },
       md5(settings={}): {
-        local default = $.transform.hash.default,
+        local default = $.transform.hash.default { id: $.helpers.id($.transform.hash.md5.type, settings) },
 
         type: 'hash_md5',
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
       },
       sha256(settings={}): {
-        local default = $.transform.hash.default,
+        local default = $.transform.hash.default { id: $.helpers.id($.transform.hash.sha256.type, settings) },
 
         type: 'hash_sha256',
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
@@ -479,28 +482,28 @@
         },
         add(settings={}): $.transform.number.math.addition(settings=settings),
         addition(settings={}): {
-          local default = $.transform.number.math.default,
+          local default = $.transform.number.math.default { id: $.helpers.id($.transform.number.math.addition.type, settings) },
 
           type: 'number_math_addition',
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         sub(settings={}): $.transform.number.math.subtraction(settings=settings),
         subtraction(settings={}): {
-          local default = $.transform.number.math.default,
+          local default = $.transform.number.math.default { id: $.helpers.id($.transform.number.math.subtraction.type, settings) },
 
           type: 'number_math_subtraction',
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         mul(settings={}): $.transform.number.math.multiplication(settings=settings),
         multiplication(settings={}): {
-          local default = $.transform.number.math.default,
+          local default = $.transform.number.math.default { id: $.helpers.id($.transform.number.math.multiplication.type, settings) },
 
           type: 'number_math_multiplication',
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         div(settings={}): $.transform.number.math.division(settings=settings),
         division(settings={}): {
-          local default = $.transform.number.math.default,
+          local default = $.transform.number.math.default { id: $.helpers.id($.transform.number.math.division.type, settings) },
 
           type: 'number_math_division',
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
@@ -509,13 +512,18 @@
     },
     meta: {
       err(settings={}): {
-        local default = { transform: null, error_messages: null },
+        local default = { 
+          id: $.helpers.id($.transform.meta.err.type, settings),
+          transform: null, 
+          error_messages: null, 
+        },
 
         type: 'meta_err',
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
       },
       for_each(settings={}): {
         local default = {
+          id: $.helpers.id($.transform.meta.for_each.type, settings),
           object: $.config.object,
           transform: null,
         },
@@ -526,6 +534,7 @@
       kv_store: {
         lock(settings={}): {
           local default = {
+            id: $.helpers.id($.transform.meta.kv_store.lock.type, settings),
             object: $.config.object { ttl_key: null },
             transform: null,
             kv_store: null,
@@ -540,6 +549,7 @@
       metric: {
         duration(settings={}): {
           local default = {
+            id: $.helpers.id($.transform.meta.metric.duration.type, settings),
             metric: $.config.metric,
             transform: null,
           },
@@ -551,6 +561,7 @@
       pipe(settings={}): $.transform.meta.pipeline(settings=settings),
       pipeline(settings={}): {
         local default = {
+          id: $.helpers.id($.transform.meta.pipeline.type, settings),
           object: $.config.object,
           transforms: null,
         },
@@ -559,7 +570,10 @@
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
       },
       switch(settings={}): {
-        local default = { cases: null },
+        local default = { 
+          id: $.helpers.id($.transform.meta.switch.type, settings),
+          cases: null 
+        },
 
         type: 'meta_switch',
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
@@ -572,20 +586,20 @@
           object: $.config.object,
         },
         registered_domain(settings={}): {
-          local default = $.transform.network.domain.default,
+          local default = $.transform.network.domain.default { id: $.helpers.id($.transform.network.domain.registered_domain.type, settings) },
 
           type: 'network_domain_registered_domain',
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         subdomain(settings={}): {
-          local default = $.transform.network.domain.default,
+          local default = $.transform.network.domain.default { id: $.helpers.id($.transform.network.domain.subdomain.type, settings) },
 
           type: 'network_domain_subdomain',
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         tld(settings={}): $.transform.network.domain.top_level_domain(settings=settings),
         top_level_domain(settings={}): {
-          local default = $.transform.network.domain.default,
+          local default = $.transform.network.domain.default { id: $.helpers.id($.transform.network.domain.top_level_domain.type, settings) },
 
           type: 'network_domain_top_level_domain',
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
@@ -599,26 +613,29 @@
       },
       cp(settings={}): $.transform.object.copy(settings=settings),
       copy(settings={}): {
-        local default = $.transform.object.default,
+        local default = $.transform.object.default { id: $.helpers.id($.transform.object.copy.type, settings) },
 
         type: 'object_copy',
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
       },
       del(settings={}): $.transform.object.delete(settings=settings),
       delete(settings={}): {
-        local default = $.transform.object.default,
+        local default = $.transform.object.default { id: $.helpers.id($.transform.object.delete.type, settings) },
 
         type: 'object_delete',
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
       },
       insert(settings={}): {
-        local default = $.transform.object.default,
+        local default = $.transform.object.default { id: $.helpers.id($.transform.object.insert.type, settings) },
 
         type: 'object_insert',
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
       },
       jq(settings={}): {
-        local default = { filter: null },
+        local default = { 
+          id: $.helpers.id($.transform.object.jq.type, settings),
+          filter: null 
+        },
 
         type: 'object_jq',
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
@@ -626,34 +643,34 @@
       to: {
         bool(settings={}): $.transform.object.to.boolean(settings=settings),
         boolean(settings={}): {
-          local default = $.transform.object.default,
+          local default = $.transform.object.default { id: $.helpers.id($.transform.object.to.boolean.type, settings) },
 
           type: 'object_to_boolean',
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         float(settings={}): {
-          local default = $.transform.object.default,
+          local default = $.transform.object.default { id: $.helpers.id($.transform.object.to.float.type, settings) },
 
           type: 'object_to_float',
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         int(settings={}): $.transform.object.to.integer(settings=settings),
         integer(settings={}): {
-          local default = $.transform.object.default,
+          local default = $.transform.object.default { id: $.helpers.id($.transform.object.to.integer.type, settings) },
 
           type: 'object_to_integer',
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         str(settings={}): $.transform.object.to.string(settings=settings),
         string(settings={}): {
-          local default = $.transform.object.default,
+          local default = $.transform.object.default { id: $.helpers.id($.transform.object.to.string.type, settings) },
 
           type: 'object_to_string',
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         uint(settings={}): $.transform.object.to.unsigned_integer(settings=settings),
         unsigned_integer(settings={}): {
-          local default = $.transform.object.default,
+          local default = $.transform.object.default { id: $.helpers.id($.transform.object.to.unsigned_integer.type, settings) },
 
           type: 'object_to_unsigned_integer',
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
@@ -664,6 +681,7 @@
       aws: {
         dynamodb(settings={}): {
           local default = {
+            id: $.helpers.id($.transform.send.aws.dynamodb.type, settings),
             batch: $.config.batch,
             auxiliary_transforms: null,
             aws: $.config.aws,
@@ -682,6 +700,7 @@
         firehose(settings={}): $.transform.send.aws.kinesis_data_firehose(settings=settings),
         kinesis_data_firehose(settings={}): {
           local default = {
+            id: $.helpers.id($.transform.send.aws.kinesis_data_firehose.type, settings),
             batch: $.config.batch,
             auxiliary_transforms: null,
             aws: $.config.aws,
@@ -699,6 +718,7 @@
         },
         kinesis_data_stream(settings={}): {
           local default = {
+            id: $.helpers.id($.transform.send.aws.kinesis_data_stream.type, settings),
             batch: $.config.batch,
             auxiliary_transforms: null,
             aws: $.config.aws,
@@ -718,6 +738,7 @@
         },
         lambda(settings={}): {
           local default = {
+            id: $.helpers.id($.transform.send.aws.lambda.type, settings),
             batch: $.config.batch,
             auxiliary_transforms: null,
             aws: $.config.aws,
@@ -730,6 +751,7 @@
         },
         s3(settings={}): {
           local default = {
+            id: $.helpers.id($.transform.send.aws.s3.type, settings),
             batch: $.config.batch,
             auxiliary_transforms: null,
             aws: $.config.aws,
@@ -748,6 +770,7 @@
         },
         sns(settings={}): {
           local default = {
+            id: $.helpers.id($.transform.send.aws.sns.type, settings),
             batch: $.config.batch,
             auxiliary_transforms: null,
             aws: $.config.aws,
@@ -765,6 +788,7 @@
         },
         sqs(settings={}): {
           local default = {
+            id: $.helpers.id($.transform.send.aws.sqs.type, settings),
             batch: $.config.batch,
             auxiliary_transforms: null,
             aws: $.config.aws,
@@ -783,6 +807,7 @@
       },
       file(settings={}): {
         local default = {
+          id: $.helpers.id($.transform.send.file.type, settings),
           batch: $.config.batch,
           auxiliary_transforms: null,
           file_path: $.file_path,
@@ -799,6 +824,7 @@
       http: {
         post(settings={}): {
           local default = {
+            id: $.helpers.id($.transform.send.http.post.type, settings),
             batch: $.config.batch,
             auxiliary_transforms: null,
             url: null,
@@ -818,6 +844,7 @@
       },
       stdout(settings={}): {
         local default = {
+          id: $.helpers.id($.transform.send_stdout.type, settings),
           batch: $.config.batch,
           auxiliary_transforms: null,
         },
@@ -835,6 +862,7 @@
     string: {
       append(settings={}): {
         local default = {
+          id: $.helpers.id($.transform.string.append.type, settings),
           object: $.config.object,
           suffix: null,
         },
@@ -844,6 +872,7 @@
       },
       capture(settings={}): {
         local default = {
+          id: $.helpers.id($.transform.string.capture.type, settings),
           object: $.config.object,
           pattern: null,
           count: 0,
@@ -855,6 +884,7 @@
       repl: $.transform.string.replace,
       replace(settings={}): {
         local default = {
+          id: $.helpers.id($.transform.string.replace.type, settings),
           object: $.config.object,
           pattern: null,
           replacement: null,
@@ -871,6 +901,7 @@
       },
       split(settings={}): {
         local default = {
+          id: $.helpers.id($.transform.string.split.type, settings),
           object: $.config.object,
           separator: null,
         },
@@ -888,19 +919,19 @@
           object: $.config.object,
         },
         lower(settings={}): {
-          local default = $.transform.string.to.default,
+          local default = $.transform.string.to.default { id: $.helpers.id($.transform.string.to.lower.type, settings) },
 
           type: 'string_to_lower',
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         upper(settings={}): {
-          local default = $.transform.string.to.default,
+          local default = $.transform.string.to.default { id: $.helpers.id($.transform.string.to.upper.type, settings) },
 
           type: 'string_to_upper',
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         snake(settings={}): {
-          local default = $.transform.string.to.default,
+          local default = $.transform.string.to.default { id: $.helpers.id($.transform.string.to.snake.type, settings) },
 
           type: 'string_to_snake',
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
@@ -908,6 +939,7 @@
       },
       uuid(settings={}): {
         local default = {
+          id: $.helpers.id($.transform.string.uuid.type, settings),
           object: $.config.object,
         },
 
@@ -920,6 +952,7 @@
         str(settings={}): $.transform.time.from.string(settings=settings),
         string(settings={}): {
           local default = {
+            id: $.helpers.id($.transform.time.from.string.type, settings),
             object: $.config.object,
             format: null,
             location: null,
@@ -930,6 +963,7 @@
         },
         unix(settings={}): {
           local default = {
+            id: $.helpers.id($.transform.time.from.unix.type, settings),
             object: $.config.object,
           },
 
@@ -938,6 +972,7 @@
         },
         unix_milli(settings={}): {
           local default = {
+            id: $.helpers.id($.transform.time.from.unix_milli.type, settings),
             object: $.config.object,
           },
 
@@ -947,6 +982,7 @@
       },
       now(settings={}): {
         local default = {
+          id: $.helpers.id($.transform.time.now.type, settings),
           object: $.config.object,
         },
 
@@ -957,6 +993,7 @@
         str(settings={}): $.transform.time.to.string(settings=settings),
         string(settings={}): {
           local default = {
+            id: $.helpers.id($.transform.time.to.string.type, settings),
             object: $.config.object,
             format: null,
             location: null,
@@ -968,6 +1005,7 @@
       },
       unix(settings={}): {
         local default = {
+          id: $.helpers.id($.transform.time.unix.type, settings),
           object: $.config.object,
         },
 
@@ -976,6 +1014,7 @@
       },
       unix_milli(settings={}): {
         local default = {
+          id: $.helpers.id($.transform.time.unix_milli.type, settings),
           object: $.config.object,
         },
 
@@ -987,6 +1026,7 @@
     utility: {
       control(settings={}): {
         local default = {
+          id: $.helpers.id($.transform.utility.control.type, settings),
           batch: $.config.batch,
         },
 
@@ -995,6 +1035,7 @@
       },
       delay(settings={}): {
         local default = {
+          id: $.helpers.id($.transform.utility.delay.type, settings),
           duration: null,
         },
 
@@ -1006,6 +1047,7 @@
       },
       err(settings={}): {
         local default = {
+          id: $.helpers.id($.transform.utility.err.type, settings),
           message: null,
         },
 
@@ -1015,6 +1057,7 @@
       metric: {
         bytes(settings={}): {
           local default = {
+            id: $.helpers.id($.transform.utility.metric.bytes.type, settings),
             metric: $.config.metric,
           },
 
@@ -1023,6 +1066,7 @@
         },
         count(settings={}): {
           local default = {
+            id: $.helpers.id($.transform.utility.metric.count.type, settings),
             metric: $.config.metric,
           },
 
@@ -1031,6 +1075,7 @@
         },
         freshness(settings={}): {
           local default = {
+            id: $.helpers.id($.transform.utility.metric.freshness.type, settings),
             threshold: null,
             metric: $.config.metric,
             object: $.config.object,
@@ -1041,7 +1086,10 @@
         },
       },
       secret(settings={}): {
-        local default = { secret: null },
+        local default = { 
+          id: $.helpers.id($.transform.utility.secret.type, settings),
+          secret: null 
+        },
 
         type: 'utility_secret',
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
@@ -1223,5 +1271,6 @@
       trg: null,
       batch_key: if std.objectHas(s, 'btch') then s.batch else if std.objectHas(s, 'batch_key') then s.batch_key else null,
     },
+    id(type, settings): std.join("-", [std.md5(type)[:8], std.md5(std.toString(settings))[:8]])
   },
 }

--- a/build/config/substation.libsonnet
+++ b/build/config/substation.libsonnet
@@ -250,46 +250,50 @@
       from: {
         arr(settings={}): $.transform.aggregate.from.array(settings=settings),
         array(settings={}): {
+          local type = 'aggregate_from_array',
           local default = {
-            id: $.helpers.id($.transform.aggregate.from.array.type, settings),
+            id: $.helpers.id(type, settings),
             object: $.config.object,
           },
 
-          type: 'aggregate_from_array',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         str(settings={}): $.transform.aggregate.from.string(settings=settings),
         string(settings={}): {
+          local type = 'aggregate_from_string',
           local default = {
-            id: $.helpers.id($.transform.aggregate.from.string.type, settings),
+            id: $.helpers.id(type, settings),
             separator: null,
           },
 
-          type: 'aggregate_from_string',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
       },
       to: {
         arr(settings={}): $.transform.aggregate.to.array(settings=settings),
         array(settings={}): {
+          local type = 'aggregate_to_array',
           local default = {
-            id: $.helpers.id($.transform.aggregate.to.array.type, settings),
+            id: $.helpers.id(type, settings),
             object: $.config.object,
             batch: $.config.batch,
           },
 
-          type: 'aggregate_to_array',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         str(settings={}): $.transform.aggregate.to.string(settings=settings),
         string(settings={}): {
+          local type = 'aggregate_to_string',
           local default = {
-            id: $.helpers.id($.transform.aggregate.to.string.type, settings),
+            id: $.helpers.id(type, settings),
             batch: $.config.batch,
             separator: null,
           },
 
-          type: 'aggregate_to_string',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
       },
@@ -297,30 +301,33 @@
     arr: $.transform.array,
     array: {
       join(settings={}): {
+        local type = 'array_join',
         local default = {
-          id: $.helpers.id($.transform.array.join.type, settings),
+          id: $.helpers.id(type, settings),
           object: $.config.object,
           separator: null,
         },
 
-        type: 'array_join',
+        type: type,
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
       },
       zip(settings={}): {
+        local type = 'array_zip',
         local default = {
-          id: $.helpers.id($.transform.array.zip.type, settings),
+          id: $.helpers.id(type, settings),
           object: $.config.object,
         },
 
-        type: 'array_zip',
+        type: type,
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
       },
     },
     enrich: {
       aws: {
         dynamodb(settings={}): {
+          local type = 'enrich_aws_dynamodb',
           local default = {
-            id: $.helpers.id($.transform.enrich.aws.dynamodb.type, settings),
+            id: $.helpers.id(type, settings),
             object: $.config.object,
             aws: $.config.aws,
             retry: $.config.retry,
@@ -332,19 +339,20 @@
             scan_index_forward: false,
           },
 
-          type: 'enrich_aws_dynamodb',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         lambda(settings={}): {
+          local type = 'enrich_aws_lambda',
           local default = {
-            id: $.helpers.id($.transform.enrich.aws.lambda.type, settings),
+            id: $.helpers.id(type, settings),
             object: $.config.object,
             aws: $.config.aws,
             retry: $.config.retry,
             function_name: null,
           },
 
-          type: 'enrich_aws_lambda',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
       },
@@ -354,21 +362,24 @@
           request: $.config.request,
         },
         domain_lookup(settings={}): {
-          local default = $.transform.enrich.dns.default { id: $.helpers.id($.transform.enrich.dns.domain_lookup.type, settings) },
+          local type = 'enrich_dns_domain_lookup',
+          local default = $.transform.enrich.dns.default { id: $.helpers.id(type, settings) },
 
-          type: 'enrich_dns_domain_lookup',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         ip_lookup(settings={}): {
-          local default = $.transform.enrich.dns.default { id: $.helpers.id($.transform.enrich.dns.ip_lookup.type, settings) },
+          local type = 'enrich_dns_ip_lookup',
+          local default = $.transform.enrich.dns.default { id: $.helpers.id(type, settings) },
 
-          type: 'enrich_dns_ip_lookup',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         txt_lookup(settings={}): {
-          local default = $.transform.enrich.dns.default { id: $.helpers.id($.transform.enrich.dns.txt_lookup.type, settings) },
+          local type = 'enrich_dns_txt_lookup',
+          local default = $.transform.enrich.dns.default { id: $.helpers.id(type, settings) },
 
-          type: 'enrich_dns_txt_lookup',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
       },
@@ -380,15 +391,17 @@
           headers: null,
         },
         get(settings={}): {
-          local default = $.transform.enrich.http.default { id: $.helpers.id($.transform.enrich.http.get.type, settings)},
+          local type = 'enrich_http_get',
+          local default = $.transform.enrich.http.default { id: $.helpers.id(type, settings)},
 
-          type: 'enrich_http_get',
+          type:  type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         post(settings={}): {
-          local default = $.transform.enrich.http.default { body_key: null, id: $.helpers.id($.transform.enrich.http.post.type, settings) },
+          local type = 'enrich_http_post',
+          local default = $.transform.enrich.http.default { body_key: null, id: $.helpers.id(type, settings) },
 
-          type: 'enrich_http_post',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
       },
@@ -400,15 +413,17 @@
           close_kv_store: false,
         },
         get(settings={}): {
-          local default = $.transform.enrich.kv_store.default {id: $.helpers.id($.transform.enrich.kv_store.get.type, settings)},
+          local type = 'enrich_kv_store_get',
+          local default = $.transform.enrich.kv_store.default {id: $.helpers.id(type, settings)},
 
-          type: 'enrich_kv_store_get',
+          type:   type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         set(settings={}): {
-          local default = $.transform.enrich.kv_store.default { ttl_key: null, ttl_offset: '0s', id: $.helpers.id($.transform.enrich.kv_store.set.type, settings) },
+          local type = 'enrich_kv_store_set',
+          local default = $.transform.enrich.kv_store.default { ttl_key: null, ttl_offset: '0s', id: $.helpers.id(type, settings) },
 
-          type: 'enrich_kv_store_set',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
       },
@@ -421,38 +436,43 @@
       from: {
         b64(settings={}): $.transform.format.from.base64(settings=settings),
         base64(settings={}): {
-          local default = $.transform.format.default { id: $.helpers.id($.transform.format.from.base64.type, settings) },
+          local type = 'format_from_base64',
+          local default = $.transform.format.default { id: $.helpers.id(type, settings) },
 
-          type: 'format_from_base64',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         gz(settings={}): $.transform.format.from.gzip(settings=settings),
         gzip(settings={}): {
-          local default = { id: $.helpers.id($.transform.format.from.gzip.type, settings) },
+          local type = 'format_from_gzip',
+          local default = { id: $.helpers.id(type, settings) },
 
-          type: 'format_from_gzip',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         pretty_print(settings={}): {
-          local default = { id: $.helpers.id($.transform.format.from.pretty_print.type, settings) },
+          local type = 'format_from_pretty_print',
+          local default = { id: $.helpers.id(type, settings) },
 
-          type: 'format_from_pretty_print',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
       },
       to: {
         b64(settings={}): $.transform.format.to.base64(settings=settings),
         base64(settings={}): {
-          local default = $.transform.format.default { id: $.helpers.id($.transform.format.to.base64.type, settings) },
+          local type = 'format_to_base64',
+          local default = $.transform.format.default { id: $.helpers.id(type, settings) },
 
-          type: 'format_to_base64',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         gz(settings={}): $.transform.format.to.gzip(settings=settings),
         gzip(settings={}): {
-          local default = { id: $.helpers.id($.transform.format.to.gzip.type, settings) },
+          local type = 'format_to_gzip',
+          local default = { id: $.helpers.id(type, settings) },
 
-          type: 'format_to_gzip',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
       },
@@ -462,15 +482,17 @@
         object: $.config.object,
       },
       md5(settings={}): {
-        local default = $.transform.hash.default { id: $.helpers.id($.transform.hash.md5.type, settings) },
+        local type = 'hash_md5',
+        local default = $.transform.hash.default { id: $.helpers.id(type, settings) },
 
-        type: 'hash_md5',
+        type: type,
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
       },
       sha256(settings={}): {
-        local default = $.transform.hash.default { id: $.helpers.id($.transform.hash.sha256.type, settings) },
+        local type = 'hash_sha256',
+        local default = $.transform.hash.default { id: $.helpers.id(type, settings) },
 
-        type: 'hash_sha256',
+        type: type,
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
       },
     },
@@ -482,59 +504,66 @@
         },
         add(settings={}): $.transform.number.math.addition(settings=settings),
         addition(settings={}): {
-          local default = $.transform.number.math.default { id: $.helpers.id($.transform.number.math.addition.type, settings) },
+          local type = 'number_math_addition',
+          local default = $.transform.number.math.default { id: $.helpers.id(type, settings) },
 
-          type: 'number_math_addition',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         sub(settings={}): $.transform.number.math.subtraction(settings=settings),
         subtraction(settings={}): {
-          local default = $.transform.number.math.default { id: $.helpers.id($.transform.number.math.subtraction.type, settings) },
+          local type = 'number_math_subtraction',
+          local default = $.transform.number.math.default { id: $.helpers.id(type, settings) },
 
-          type: 'number_math_subtraction',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         mul(settings={}): $.transform.number.math.multiplication(settings=settings),
         multiplication(settings={}): {
-          local default = $.transform.number.math.default { id: $.helpers.id($.transform.number.math.multiplication.type, settings) },
+          local type = 'number_math_multiplication',
+          local default = $.transform.number.math.default { id: $.helpers.id(type, settings) },
 
-          type: 'number_math_multiplication',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         div(settings={}): $.transform.number.math.division(settings=settings),
         division(settings={}): {
-          local default = $.transform.number.math.default { id: $.helpers.id($.transform.number.math.division.type, settings) },
+          local type = 'number_math_division',
+          local default = $.transform.number.math.default { id: $.helpers.id(type, settings) },
 
-          type: 'number_math_division',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
       },
     },
     meta: {
       err(settings={}): {
-        local default = { 
-          id: $.helpers.id($.transform.meta.err.type, settings),
+        local type = 'meta_err',
+        local default = {         
+          id: $.helpers.id(type, settings),
           transform: null, 
           error_messages: null, 
         },
 
-        type: 'meta_err',
+        type: type,
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
       },
       for_each(settings={}): {
+        local type = 'meta_for_each',
         local default = {
-          id: $.helpers.id($.transform.meta.for_each.type, settings),
+          id: $.helpers.id(type, settings),
           object: $.config.object,
           transform: null,
         },
 
-        type: 'meta_for_each',
+        type: type,
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
       },
       kv_store: {
         lock(settings={}): {
+          local type = 'meta_kv_store_lock',
           local default = {
-            id: $.helpers.id($.transform.meta.kv_store.lock.type, settings),
+            id: $.helpers.id(type, settings),
             object: $.config.object { ttl_key: null },
             transform: null,
             kv_store: null,
@@ -542,40 +571,43 @@
             ttl_offset: '0s',
           },
 
-          type: 'meta_kv_store_lock',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
       },
       metric: {
         duration(settings={}): {
+          local type = 'meta_metric_duration',
           local default = {
-            id: $.helpers.id($.transform.meta.metric.duration.type, settings),
+            id: $.helpers.id(type, settings),
             metric: $.config.metric,
             transform: null,
           },
 
-          type: 'meta_metric_duration',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
       },
       pipe(settings={}): $.transform.meta.pipeline(settings=settings),
       pipeline(settings={}): {
+        local type = 'meta_pipeline',
         local default = {
-          id: $.helpers.id($.transform.meta.pipeline.type, settings),
+          id: $.helpers.id(type, settings),
           object: $.config.object,
           transforms: null,
         },
 
-        type: 'meta_pipeline',
+        type: type,
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
       },
       switch(settings={}): {
+        local type = 'meta_switch',
         local default = { 
-          id: $.helpers.id($.transform.meta.switch.type, settings),
+          id: $.helpers.id(type, settings),
           cases: null 
         },
 
-        type: 'meta_switch',
+        type: type,
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
       },
     },
@@ -586,22 +618,25 @@
           object: $.config.object,
         },
         registered_domain(settings={}): {
-          local default = $.transform.network.domain.default { id: $.helpers.id($.transform.network.domain.registered_domain.type, settings) },
+          local type = 'network_domain_registered_domain',
+          local default = $.transform.network.domain.default { id: $.helpers.id(type, settings) },
 
-          type: 'network_domain_registered_domain',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         subdomain(settings={}): {
-          local default = $.transform.network.domain.default { id: $.helpers.id($.transform.network.domain.subdomain.type, settings) },
+          local type = 'network_domain_subdomain',
+          local default = $.transform.network.domain.default { id: $.helpers.id(type, settings) },
 
-          type: 'network_domain_subdomain',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         tld(settings={}): $.transform.network.domain.top_level_domain(settings=settings),
         top_level_domain(settings={}): {
-          local default = $.transform.network.domain.default { id: $.helpers.id($.transform.network.domain.top_level_domain.type, settings) },
+          local type = 'network_domain_top_level_domain',
+          local default = $.transform.network.domain.default { id: $.helpers.id(type, settings) },
 
-          type: 'network_domain_top_level_domain',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
       },
@@ -613,66 +648,75 @@
       },
       cp(settings={}): $.transform.object.copy(settings=settings),
       copy(settings={}): {
-        local default = $.transform.object.default { id: $.helpers.id($.transform.object.copy.type, settings) },
+        local type = 'object_copy',
+        local default = $.transform.object.default { id: $.helpers.id(type, settings) },
 
-        type: 'object_copy',
+        type: type,
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
       },
       del(settings={}): $.transform.object.delete(settings=settings),
       delete(settings={}): {
-        local default = $.transform.object.default { id: $.helpers.id($.transform.object.delete.type, settings) },
+        local type = 'object_delete',
+        local default = $.transform.object.default { id: $.helpers.id(type, settings) },
 
-        type: 'object_delete',
+        type: type,
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
       },
       insert(settings={}): {
-        local default = $.transform.object.default { id: $.helpers.id($.transform.object.insert.type, settings) },
+        local type = 'object_insert',
+        local default = $.transform.object.default { id: $.helpers.id(type, settings) },
 
-        type: 'object_insert',
+        type: type,
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
       },
       jq(settings={}): {
+        local type = 'object_jq',
         local default = { 
-          id: $.helpers.id($.transform.object.jq.type, settings),
+          id: $.helpers.id(type, settings),
           filter: null 
         },
 
-        type: 'object_jq',
+        type: type,
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
       },
       to: {
         bool(settings={}): $.transform.object.to.boolean(settings=settings),
         boolean(settings={}): {
-          local default = $.transform.object.default { id: $.helpers.id($.transform.object.to.boolean.type, settings) },
+          local type = 'object_to_boolean',
+          local default = $.transform.object.default { id: $.helpers.id(type, settings) },
 
-          type: 'object_to_boolean',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         float(settings={}): {
-          local default = $.transform.object.default { id: $.helpers.id($.transform.object.to.float.type, settings) },
+          local type = 'object_to_float',
+          local default = $.transform.object.default { id: $.helpers.id(type, settings) },
 
-          type: 'object_to_float',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         int(settings={}): $.transform.object.to.integer(settings=settings),
         integer(settings={}): {
-          local default = $.transform.object.default { id: $.helpers.id($.transform.object.to.integer.type, settings) },
+          local type = 'object_to_integer',
+          local default = $.transform.object.default { id: $.helpers.id(type, settings) },
 
-          type: 'object_to_integer',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         str(settings={}): $.transform.object.to.string(settings=settings),
         string(settings={}): {
-          local default = $.transform.object.default { id: $.helpers.id($.transform.object.to.string.type, settings) },
+          local type = 'object_to_string',
+          local default = $.transform.object.default { id: $.helpers.id(type, settings) },
 
-          type: 'object_to_string',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         uint(settings={}): $.transform.object.to.unsigned_integer(settings=settings),
         unsigned_integer(settings={}): {
-          local default = $.transform.object.default { id: $.helpers.id($.transform.object.to.unsigned_integer.type, settings) },
+          local type = 'object_to_unsigned_integer',
+          local default = $.transform.object.default { id: $.helpers.id(type, settings) },
 
-          type: 'object_to_unsigned_integer',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
       },
@@ -680,8 +724,9 @@
     send: {
       aws: {
         dynamodb(settings={}): {
+          local type = 'send_aws_dynamodb',
           local default = {
-            id: $.helpers.id($.transform.send.aws.dynamodb.type, settings),
+            id: $.helpers.id(type, settings),
             batch: $.config.batch,
             auxiliary_transforms: null,
             aws: $.config.aws,
@@ -694,13 +739,14 @@
             aux_tforms: null,
           }),
 
-          type: 'send_aws_dynamodb',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(s))),
         },
         firehose(settings={}): $.transform.send.aws.kinesis_data_firehose(settings=settings),
         kinesis_data_firehose(settings={}): {
+          local type = 'send_aws_kinesis_data_firehose',
           local default = {
-            id: $.helpers.id($.transform.send.aws.kinesis_data_firehose.type, settings),
+            id: $.helpers.id(type, settings),
             batch: $.config.batch,
             auxiliary_transforms: null,
             aws: $.config.aws,
@@ -713,12 +759,13 @@
             aux_tforms: null,
           }),
 
-          type: 'send_aws_kinesis_data_firehose',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(s))),
         },
         kinesis_data_stream(settings={}): {
+          local type = 'send_aws_kinesis_data_stream',
           local default = {
-            id: $.helpers.id($.transform.send.aws.kinesis_data_stream.type, settings),
+            id: $.helpers.id(type, settings),
             batch: $.config.batch,
             auxiliary_transforms: null,
             aws: $.config.aws,
@@ -733,12 +780,13 @@
             aux_tforms: null,
           }),
 
-          type: 'send_aws_kinesis_data_stream',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(s))),
         },
         lambda(settings={}): {
+          local type = 'send_aws_lambda',
           local default = {
-            id: $.helpers.id($.transform.send.aws.lambda.type, settings),
+            id: $.helpers.id(type, settings),
             batch: $.config.batch,
             auxiliary_transforms: null,
             aws: $.config.aws,
@@ -746,12 +794,13 @@
             function_name: null,
           },
 
-          type: 'send_aws_lambda',
+          type: type,
           settings: std.mergePatch(default, $.helpers.abbv(settings)),
         },
         s3(settings={}): {
+          local type = 'send_aws_s3',
           local default = {
-            id: $.helpers.id($.transform.send.aws.s3.type, settings),
+            id: $.helpers.id(type, settings),
             batch: $.config.batch,
             auxiliary_transforms: null,
             aws: $.config.aws,
@@ -765,12 +814,13 @@
             aux_tforms: null,
           }),
 
-          type: 'send_aws_s3',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(s))),
         },
         sns(settings={}): {
+          local type = 'send_aws_sns',
           local default = {
-            id: $.helpers.id($.transform.send.aws.sns.type, settings),
+            id: $.helpers.id(type, settings),
             batch: $.config.batch,
             auxiliary_transforms: null,
             aws: $.config.aws,
@@ -783,12 +833,13 @@
             aux_tforms: null,
           }),
 
-          type: 'send_aws_sns',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(s))),
         },
         sqs(settings={}): {
+          local type = 'send_aws_sqs',
           local default = {
-            id: $.helpers.id($.transform.send.aws.sqs.type, settings),
+            id: $.helpers.id(type, settings),
             batch: $.config.batch,
             auxiliary_transforms: null,
             aws: $.config.aws,
@@ -801,13 +852,14 @@
             aux_tforms: null,
           }),
 
-          type: 'send_aws_sqs',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(s))),
         },
       },
       file(settings={}): {
+        local type = 'send_file',
         local default = {
-          id: $.helpers.id($.transform.send.file.type, settings),
+          id: $.helpers.id(type, settings),
           batch: $.config.batch,
           auxiliary_transforms: null,
           file_path: $.file_path,
@@ -818,13 +870,14 @@
           aux_tforms: null,
         }),
 
-        type: 'send_file',
+        type: type,
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(s))),
       },
       http: {
         post(settings={}): {
+          local type = 'send_http_post',
           local default = {
-            id: $.helpers.id($.transform.send.http.post.type, settings),
+            id: $.helpers.id(type, settings),
             batch: $.config.batch,
             auxiliary_transforms: null,
             url: null,
@@ -838,13 +891,14 @@
             hdr: null,
           }),
 
-          type: 'send_http_post',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(s))),
         },
       },
       stdout(settings={}): {
+        local type = 'send_stdout',
         local default = {
-          id: $.helpers.id($.transform.send_stdout.type, settings),
+          id: $.helpers.id(type, settings),
           batch: $.config.batch,
           auxiliary_transforms: null,
         },
@@ -854,37 +908,40 @@
           aux_tforms: null,
         }),
 
-        type: 'send_stdout',
+        type: type,
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(s))),
       },
     },
     str: $.transform.string,
     string: {
       append(settings={}): {
+        local type = 'string_append',
         local default = {
-          id: $.helpers.id($.transform.string.append.type, settings),
+          id: $.helpers.id(type, settings),
           object: $.config.object,
           suffix: null,
         },
 
-        type: 'string_append',
+        type: type,
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
       },
       capture(settings={}): {
+        local type = 'string_capture',
         local default = {
-          id: $.helpers.id($.transform.string.capture.type, settings),
+          id: $.helpers.id(type, settings),
           object: $.config.object,
           pattern: null,
           count: 0,
         },
 
-        type: 'string_capture',
+        type: type,
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
       },
       repl: $.transform.string.replace,
       replace(settings={}): {
+        local type = 'string_replace',
         local default = {
-          id: $.helpers.id($.transform.string.replace.type, settings),
+          id: $.helpers.id(type, settings),
           object: $.config.object,
           pattern: null,
           replacement: null,
@@ -896,12 +953,13 @@
           repl: null,
         }),
 
-        type: 'string_replace',
+        type: type,
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(s))),
       },
       split(settings={}): {
+        local type = 'string_split',
         local default = {
-          id: $.helpers.id($.transform.string.split.type, settings),
+          id: $.helpers.id(type, settings),
           object: $.config.object,
           separator: null,
         },
@@ -911,7 +969,7 @@
           sep: null,
         }),
 
-        type: 'string_split',
+        type: type,
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(s))),
       },
       to: {
@@ -919,31 +977,35 @@
           object: $.config.object,
         },
         lower(settings={}): {
-          local default = $.transform.string.to.default { id: $.helpers.id($.transform.string.to.lower.type, settings) },
+          local type = 'string_to_lower',
+          local default = $.transform.string.to.default { id: $.helpers.id(type, settings) },
 
-          type: 'string_to_lower',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         upper(settings={}): {
-          local default = $.transform.string.to.default { id: $.helpers.id($.transform.string.to.upper.type, settings) },
+          local type = 'string_to_upper',
+          local default = $.transform.string.to.default { id: $.helpers.id(type, settings) },
 
-          type: 'string_to_upper',
+          type:  type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         snake(settings={}): {
-          local default = $.transform.string.to.default { id: $.helpers.id($.transform.string.to.snake.type, settings) },
+          local type = 'string_to_snake',
+          local default = $.transform.string.to.default { id: $.helpers.id(type, settings) },
 
-          type: 'string_to_snake',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
       },
       uuid(settings={}): {
+        local type = 'string_uuid',
         local default = {
-          id: $.helpers.id($.transform.string.uuid.type, settings),
+          id: $.helpers.id(type, settings),
           object: $.config.object,
         },
 
-        type: 'string_uuid',
+        type: type,
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
       },
     },
@@ -951,147 +1013,167 @@
       from: {
         str(settings={}): $.transform.time.from.string(settings=settings),
         string(settings={}): {
+          local type = 'time_from_string',
           local default = {
-            id: $.helpers.id($.transform.time.from.string.type, settings),
+            id: $.helpers.id(type, settings),
             object: $.config.object,
             format: null,
             location: null,
           },
 
-          type: 'time_from_string',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         unix(settings={}): {
+          local type = 'time_from_unix',
           local default = {
-            id: $.helpers.id($.transform.time.from.unix.type, settings),
+            id: $.helpers.id(type, settings),
             object: $.config.object,
           },
 
-          type: 'time_from_unix',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         unix_milli(settings={}): {
+          local type = 'time_from_unix_milli',
           local default = {
-            id: $.helpers.id($.transform.time.from.unix_milli.type, settings),
+            id: $.helpers.id(type, settings),
             object: $.config.object,
           },
 
-          type: 'time_from_unix_milli',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
       },
       now(settings={}): {
+        local type = 'time_now',
         local default = {
-          id: $.helpers.id($.transform.time.now.type, settings),
+          id: $.helpers.id(type, settings),
           object: $.config.object,
         },
 
-        type: 'time_now',
+        type: type,
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
       },
       to: {
         str(settings={}): $.transform.time.to.string(settings=settings),
         string(settings={}): {
+          local type = 'time_to_string',
           local default = {
-            id: $.helpers.id($.transform.time.to.string.type, settings),
+            id: $.helpers.id(type, settings),
             object: $.config.object,
             format: null,
             location: null,
           },
 
-          type: 'time_to_string',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
       },
       unix(settings={}): {
+        local type = 'time_to_unix',
         local default = {
-          id: $.helpers.id($.transform.time.unix.type, settings),
+          id: $.helpers.id(type, settings),
           object: $.config.object,
         },
 
-        type: 'time_to_unix',
+        type: type,
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
       },
       unix_milli(settings={}): {
+        local type = 'time_to_unix_milli',
         local default = {
-          id: $.helpers.id($.transform.time.unix_milli.type, settings),
+          id: $.helpers.id(type, settings),
           object: $.config.object,
         },
 
-        type: 'time_to_unix_milli',
+        type: type,
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
       },
     },
     util: $.transform.utility,
     utility: {
       control(settings={}): {
+        local type = 'utility_control',
         local default = {
-          id: $.helpers.id($.transform.utility.control.type, settings),
+          id: $.helpers.id(type, settings),
           batch: $.config.batch,
         },
 
-        type: 'utility_control',
+        type: type,
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
       },
       delay(settings={}): {
+        local type = 'utility_delay',
         local default = {
-          id: $.helpers.id($.transform.utility.delay.type, settings),
+          id: $.helpers.id(type, settings),
           duration: null,
         },
 
-        type: 'utility_delay',
+        type: type,
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
       },
       drop(settings={}): {
-        type: 'utility_drop',
+        local type = 'utility_delay',
+        local default = {
+          id: $.helpers.id(type, settings),
+        },
+
+        type: type,
+        settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
       },
       err(settings={}): {
+        local type = 'utility_err',
         local default = {
-          id: $.helpers.id($.transform.utility.err.type, settings),
+          id: $.helpers.id(type, settings),
           message: null,
         },
 
-        type: 'utility_err',
+        type: type,
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
       },
       metric: {
         bytes(settings={}): {
+          local type = 'utility_metric_bytes',
           local default = {
-            id: $.helpers.id($.transform.utility.metric.bytes.type, settings),
+            id: $.helpers.id(type, settings),
             metric: $.config.metric,
           },
 
-          type: 'utility_metric_bytes',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         count(settings={}): {
+          local type = 'utility_metric_count',
           local default = {
-            id: $.helpers.id($.transform.utility.metric.count.type, settings),
+            id: $.helpers.id(type, settings),
             metric: $.config.metric,
           },
 
-          type: 'utility_metric_count',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
         freshness(settings={}): {
+          local type = 'utility_metric_freshness',
           local default = {
-            id: $.helpers.id($.transform.utility.metric.freshness.type, settings),
+            id: $.helpers.id(type, settings),
             threshold: null,
             metric: $.config.metric,
             object: $.config.object,
           },
 
-          type: 'utility_metric_freshness',
+          type: type,
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
         },
       },
       secret(settings={}): {
+        local type = 'utility_secret',
         local default = { 
-          id: $.helpers.id($.transform.utility.secret.type, settings),
+          id: $.helpers.id(type, settings),
           secret: null 
         },
 
-        type: 'utility_secret',
+        type: type,
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
       },
     },

--- a/examples/config/config.jsonnet
+++ b/examples/config/config.jsonnet
@@ -4,7 +4,7 @@ local sub = import '../../build/config/substation.libsonnet';
   // Substation application configs always contain an array named `transforms`.
   transforms: [
     // Each transform function is defined in the `substation` library.
-    sub.transform.object.insert({ object: { target_key: 'a' }, value: 'z' }),
+    sub.transform.object.insert({ id: 'insert-z', object: { target_key: 'a' }, value: 'z' }),
     // Transform functions can be conditionally applied using the
     // `meta.switch` function.
     sub.transform.meta.switch({ cases: [

--- a/transform/aggregate.go
+++ b/transform/aggregate.go
@@ -10,6 +10,7 @@ import (
 )
 
 type aggregateArrayConfig struct {
+	ID     string         `json:"id"`
 	Object iconfig.Object `json:"object"`
 	Batch  iconfig.Batch  `json:"batch"`
 }
@@ -30,6 +31,7 @@ type aggregateStrConfig struct {
 	// Separator is the string that is used to join and split data.
 	Separator string `json:"separator"`
 
+	ID     string         `json:"id"`
 	Object iconfig.Object `json:"object"`
 	Batch  iconfig.Batch  `json:"batch"`
 }

--- a/transform/aggregate_from_array.go
+++ b/transform/aggregate_from_array.go
@@ -13,7 +13,11 @@ import (
 func newAggregateFromArray(_ context.Context, cfg config.Config) (*aggregateFromArray, error) {
 	conf := aggregateArrayConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: aggregate_from_array: %v", err)
+		return nil, fmt.Errorf("transform aggregate_from_array: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "aggregate_from_array"
 	}
 
 	tf := aggregateFromArray{
@@ -43,7 +47,7 @@ func (tf *aggregateFromArray) Transform(ctx context.Context, msg *message.Messag
 	if tf.hasObjSrc {
 		value = msg.GetValue(tf.conf.Object.SourceKey)
 		if err := msg.DeleteValue(tf.conf.Object.SourceKey); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 		}
 	} else {
 		value = bytesToValue(msg.Data())
@@ -59,14 +63,14 @@ func (tf *aggregateFromArray) Transform(ctx context.Context, msg *message.Messag
 		if tf.hasObjSrc {
 			for key, val := range msg.GetValue("@this").Map() {
 				if err := outMsg.SetValue(key, val.Value()); err != nil {
-					return nil, err
+					return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 				}
 			}
 		}
 
 		if tf.hasObjTrg {
 			if err := outMsg.SetValue(tf.conf.Object.TargetKey, res); err != nil {
-				return nil, err
+				return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 			}
 
 			output = append(output, outMsg)

--- a/transform/aggregate_from_string.go
+++ b/transform/aggregate_from_string.go
@@ -12,11 +12,15 @@ import (
 func newAggregateFromString(_ context.Context, cfg config.Config) (*aggregateFromString, error) {
 	conf := aggregateStrConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: aggregate_from_string: %v", err)
+		return nil, fmt.Errorf("transform aggregate_from_string: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "aggregate_from_string"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: aggregate_from_string: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	tf := aggregateFromString{

--- a/transform/aggregate_to_string.go
+++ b/transform/aggregate_to_string.go
@@ -14,11 +14,15 @@ import (
 func newAggregateToString(_ context.Context, cfg config.Config) (*aggregateToString, error) {
 	conf := aggregateStrConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: aggregate_to_string: %v", err)
+		return nil, fmt.Errorf("transform aggregate_to_string: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "aggregate_to_string"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: aggregate_to_string: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	tf := aggregateToString{
@@ -32,7 +36,7 @@ func newAggregateToString(_ context.Context, cfg config.Config) (*aggregateToStr
 		Duration: conf.Batch.Duration,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("transform: aggregate_to_string: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 	tf.agg = agg
 
@@ -80,7 +84,7 @@ func (tf *aggregateToString) Transform(ctx context.Context, msg *message.Message
 	// If data cannot be added after reset, then the batch is misconfgured.
 	tf.agg.Reset(key)
 	if ok := tf.agg.Add(key, msg.Data()); !ok {
-		return nil, fmt.Errorf("transform: send_stdout: %v", errSendBatchMisconfigured)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, errSendBatchMisconfigured)
 	}
 
 	return []*message.Message{outMsg}, nil

--- a/transform/array_join.go
+++ b/transform/array_join.go
@@ -16,6 +16,7 @@ type arrayJoinConfig struct {
 	// Separator is the string that is used to join data.
 	Separator string `json:"separator"`
 
+	ID     string         `json:"id"`
 	Object iconfig.Object `json:"object"`
 }
 
@@ -38,11 +39,15 @@ func (c *arrayJoinConfig) Validate() error {
 func newArrayJoin(_ context.Context, cfg config.Config) (*arrayJoin, error) {
 	conf := arrayJoinConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: array_join: %v", err)
+		return nil, fmt.Errorf("transform array_join: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "array_join"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: array_join: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	tf := arrayJoin{
@@ -92,7 +97,7 @@ func (tf *arrayJoin) Transform(ctx context.Context, msg *message.Message) ([]*me
 
 	if tf.hasObjectSetKey {
 		if err := msg.SetValue(tf.conf.Object.TargetKey, str); err != nil {
-			return nil, fmt.Errorf("transform: array_join: %v", err)
+			return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 		}
 
 		return []*message.Message{msg}, nil

--- a/transform/array_zip.go
+++ b/transform/array_zip.go
@@ -12,6 +12,7 @@ import (
 )
 
 type arrayZipConfig struct {
+	ID     string         `json:"id"`
 	Object iconfig.Object `json:"object"`
 }
 
@@ -34,11 +35,15 @@ func (c *arrayZipConfig) Validate() error {
 func newArrayZip(_ context.Context, cfg config.Config) (*arrayZip, error) {
 	conf := arrayZipConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: array_zip: %v", err)
+		return nil, fmt.Errorf("transform array_zip: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "array_zip"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: array_zip: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	tf := arrayZip{
@@ -86,7 +91,7 @@ func (tf *arrayZip) Transform(ctx context.Context, msg *message.Message) ([]*mes
 
 	if tf.hasObjDst {
 		if err := msg.SetValue(tf.conf.Object.TargetKey, b); err != nil {
-			return nil, fmt.Errorf("transform: array_zip: %v", err)
+			return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 		}
 
 		return []*message.Message{msg}, nil

--- a/transform/enrich.go
+++ b/transform/enrich.go
@@ -15,6 +15,7 @@ import (
 const enrichHTTPInterp = `${DATA}`
 
 type enrichDNSConfig struct {
+	ID      string          `json:"id"`
 	Object  iconfig.Object  `json:"object"`
 	Request iconfig.Request `json:"request"`
 }

--- a/transform/enrich_dns_domain_lookup.go
+++ b/transform/enrich_dns_domain_lookup.go
@@ -16,16 +16,20 @@ import (
 func newEnrichDNSDomainLookup(_ context.Context, cfg config.Config) (*enrichDNSDomainLookup, error) {
 	conf := enrichDNSConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: enrich_dns_domain_lookup: %v", err)
+		return nil, fmt.Errorf("transform enrich_dns_domain_lookup: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "enrich_dns_domain_lookup"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: enrich_dns_domain_lookup: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	dur, err := time.ParseDuration(conf.Request.Timeout)
 	if err != nil {
-		return nil, fmt.Errorf("transform: enrich_dns_domain_lookup: duration: %v", err)
+		return nil, fmt.Errorf("transform %s: duration: %v", conf.ID, err)
 	}
 
 	tf := enrichDNSDomainLookup{
@@ -59,7 +63,7 @@ func (tf *enrichDNSDomainLookup) Transform(ctx context.Context, msg *message.Mes
 		str := string(msg.Data())
 		names, err := tf.resolver.LookupHost(resolverCtx, str)
 		if err != nil {
-			return nil, fmt.Errorf("transform: enrich_dns_domain_lookup: %v", err)
+			return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 		}
 
 		// Return the first name.
@@ -75,11 +79,11 @@ func (tf *enrichDNSDomainLookup) Transform(ctx context.Context, msg *message.Mes
 
 	names, err := tf.resolver.LookupHost(resolverCtx, value.String())
 	if err != nil {
-		return nil, fmt.Errorf("transform: enrich_dns_domain_lookup: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	if err := msg.SetValue(tf.conf.Object.TargetKey, names); err != nil {
-		return nil, fmt.Errorf("transform: enrich_dns_domain_lookup: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	return []*message.Message{msg}, nil

--- a/transform/enrich_dns_ip_lookup.go
+++ b/transform/enrich_dns_ip_lookup.go
@@ -16,16 +16,20 @@ import (
 func newEnrichDNSIPLookup(_ context.Context, cfg config.Config) (*enrichDNSIPLookup, error) {
 	conf := enrichDNSConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: enrich_dns_ip_lookup: %v", err)
+		return nil, fmt.Errorf("transform enrich_dns_ip_lookup: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "enrich_dns_ip_lookup"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: enrich_dns_ip_lookup: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	dur, err := time.ParseDuration(conf.Request.Timeout)
 	if err != nil {
-		return nil, fmt.Errorf("transform: enrich_dns_ip_lookup: duration: %v", err)
+		return nil, fmt.Errorf("transform %s: duration: %v", conf.ID, err)
 	}
 
 	tf := enrichDNSIPLookup{
@@ -59,7 +63,7 @@ func (tf *enrichDNSIPLookup) Transform(ctx context.Context, msg *message.Message
 		str := string(msg.Data())
 		addrs, err := tf.resolver.LookupAddr(resolverCtx, str)
 		if err != nil {
-			return nil, fmt.Errorf("transform: enrich_dns_ip_lookup: %v", err)
+			return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 		}
 
 		// Return the first address.
@@ -75,11 +79,11 @@ func (tf *enrichDNSIPLookup) Transform(ctx context.Context, msg *message.Message
 
 	addrs, err := tf.resolver.LookupAddr(resolverCtx, value.String())
 	if err != nil {
-		return nil, fmt.Errorf("transform: enrich_dns_ip_lookup: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	if err := msg.SetValue(tf.conf.Object.TargetKey, addrs); err != nil {
-		return nil, fmt.Errorf("transform: enrich_dns_ip_lookup: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	return []*message.Message{msg}, nil

--- a/transform/enrich_dns_txt_lookup.go
+++ b/transform/enrich_dns_txt_lookup.go
@@ -16,16 +16,20 @@ import (
 func newEnrichDNSTxtLookup(_ context.Context, cfg config.Config) (*enrichDNSTxtLookup, error) {
 	conf := enrichDNSConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: enrich_dns_txt_lookup: %v", err)
+		return nil, fmt.Errorf("transform enrich_dns_txt_lookup: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "enrich_dns_txt_lookup"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: enrich_dns_txt_lookup: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	dur, err := time.ParseDuration(conf.Request.Timeout)
 	if err != nil {
-		return nil, fmt.Errorf("transform: enrich_dns_txt_lookup: duration: %v", err)
+		return nil, fmt.Errorf("transform %s: duration: %v", conf.ID, err)
 	}
 
 	tf := enrichDNSTxtLookup{
@@ -59,7 +63,7 @@ func (tf *enrichDNSTxtLookup) Transform(ctx context.Context, msg *message.Messag
 		str := string(msg.Data())
 		recs, err := tf.resolver.LookupTXT(resolverCtx, str)
 		if err != nil {
-			return nil, fmt.Errorf("transform: enrich_dns_txt_lookup: %v", err)
+			return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 		}
 
 		// Return the first record.
@@ -75,11 +79,11 @@ func (tf *enrichDNSTxtLookup) Transform(ctx context.Context, msg *message.Messag
 
 	recs, err := tf.resolver.LookupTXT(resolverCtx, value.String())
 	if err != nil {
-		return nil, fmt.Errorf("transform: enrich_dns_txt_lookup: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	if err := msg.SetValue(tf.conf.Object.TargetKey, recs); err != nil {
-		return nil, fmt.Errorf("transform: enrich_dns_txt_lookup: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	return []*message.Message{msg}, nil

--- a/transform/enrich_kv_store_set.go
+++ b/transform/enrich_kv_store_set.go
@@ -49,6 +49,7 @@ type enrichKVStoreSetConfig struct {
 	// This is optional and defaults to false (KV store is not closed).
 	CloseKVStore bool `json:"close_kv_store"`
 
+	ID      string                       `json:"id"`
 	Object  enrichKVStoreSetObjectConfig `json:"object"`
 	KVStore config.Config                `json:"kv_store"`
 }
@@ -76,16 +77,20 @@ func (c *enrichKVStoreSetConfig) Validate() error {
 func newEnrichKVStoreSet(_ context.Context, cfg config.Config) (*enrichKVStoreSet, error) {
 	conf := enrichKVStoreSetConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: enrich_kv_store_set: %v", err)
+		return nil, fmt.Errorf("transform enrich_kv_store_set: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "enrich_kv_store_set"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: enrich_kv_store_set: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	kvStore, err := kv.Get(conf.KVStore)
 	if err != nil {
-		return nil, fmt.Errorf("transform: enrich_kv_store_set: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	if conf.TTLOffset == "" {
@@ -94,7 +99,7 @@ func newEnrichKVStoreSet(_ context.Context, cfg config.Config) (*enrichKVStoreSe
 
 	dur, err := time.ParseDuration(conf.TTLOffset)
 	if err != nil {
-		return nil, fmt.Errorf("transform: enrich_kv_store_set: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	tf := enrichKVStoreSet{
@@ -119,7 +124,7 @@ func (tf *enrichKVStoreSet) Transform(ctx context.Context, msg *message.Message)
 		}
 
 		if err := tf.kvStore.Close(); err != nil {
-			return nil, fmt.Errorf("transform: enrich_kv_store_set: %v", err)
+			return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 		}
 
 		return []*message.Message{msg}, nil
@@ -127,7 +132,7 @@ func (tf *enrichKVStoreSet) Transform(ctx context.Context, msg *message.Message)
 
 	if !tf.kvStore.IsEnabled() {
 		if err := tf.kvStore.Setup(ctx); err != nil {
-			return nil, fmt.Errorf("transform: enrich_kv_store_set: %v", err)
+			return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 		}
 	}
 
@@ -147,24 +152,24 @@ func (tf *enrichKVStoreSet) Transform(ctx context.Context, msg *message.Message)
 		ttl := truncateTTL(value) + tf.ttl
 
 		if err := tf.kvStore.SetWithTTL(ctx, key, msg.GetValue(tf.conf.Object.TargetKey).String(), ttl); err != nil {
-			return nil, fmt.Errorf("transform: enrich_kv_store_set: %v", err)
+			return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 		}
 	} else if tf.conf.Object.TTLKey != "" {
 		value := msg.GetValue(tf.conf.Object.TTLKey)
 		ttl := truncateTTL(value)
 
 		if err := tf.kvStore.SetWithTTL(ctx, key, msg.GetValue(tf.conf.Object.TargetKey).String(), ttl); err != nil {
-			return nil, fmt.Errorf("transform: enrich_kv_store_set: %v", err)
+			return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 		}
 	} else if tf.ttl != 0 {
 		ttl := time.Now().Add(time.Duration(tf.ttl) * time.Second).Unix()
 
 		if err := tf.kvStore.SetWithTTL(ctx, key, msg.GetValue(tf.conf.Object.TargetKey).String(), ttl); err != nil {
-			return nil, fmt.Errorf("transform: enrich_kv_store_set: %v", err)
+			return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 		}
 	} else {
 		if err := tf.kvStore.Set(ctx, key, msg.GetValue(tf.conf.Object.TargetKey).String()); err != nil {
-			return nil, fmt.Errorf("transform: enrich_kv_store_set: %v", err)
+			return nil, fmt.Errorf("transform	%s: %v", tf.conf.ID, err)
 		}
 	}
 

--- a/transform/format.go
+++ b/transform/format.go
@@ -11,6 +11,7 @@ import (
 )
 
 type formatBase64Config struct {
+	ID     string         `json:"id"`
 	Object iconfig.Object `json:"object"`
 }
 
@@ -30,7 +31,9 @@ func (c *formatBase64Config) Validate() error {
 	return nil
 }
 
-type formatGzipConfig struct{}
+type formatGzipConfig struct {
+	ID string `json:"id"`
+}
 
 func (c *formatGzipConfig) Decode(in interface{}) error {
 	return iconfig.Decode(in, c)

--- a/transform/format_from_base64.go
+++ b/transform/format_from_base64.go
@@ -19,11 +19,15 @@ var errFormatFromBase64DecodeBinary = fmt.Errorf("cannot write binary as object"
 func newFormatFromBase64(_ context.Context, cfg config.Config) (*formatFromBase64, error) {
 	conf := formatBase64Config{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: format_from_base64: %v", err)
+		return nil, fmt.Errorf("transform format_from_base64: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "format_from_base64"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: format_from_base64: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	tf := formatFromBase64{
@@ -47,7 +51,7 @@ func (tf *formatFromBase64) Transform(ctx context.Context, msg *message.Message)
 	if !tf.isObject {
 		decoded, err := ibase64.Decode(msg.Data())
 		if err != nil {
-			return nil, fmt.Errorf("transform: format_from_base64: %v", err)
+			return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 		}
 
 		msg.SetData(decoded)
@@ -61,7 +65,7 @@ func (tf *formatFromBase64) Transform(ctx context.Context, msg *message.Message)
 
 	b64, err := ibase64.Decode(value.Bytes())
 	if err != nil {
-		return nil, fmt.Errorf("transform: format_from_base64: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	if !utf8.Valid(b64) {
@@ -69,7 +73,7 @@ func (tf *formatFromBase64) Transform(ctx context.Context, msg *message.Message)
 	}
 
 	if err := msg.SetValue(tf.conf.Object.TargetKey, b64); err != nil {
-		return nil, fmt.Errorf("transform: format_from_base64: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	return []*message.Message{msg}, nil

--- a/transform/format_from_gzip.go
+++ b/transform/format_from_gzip.go
@@ -12,7 +12,11 @@ import (
 func newFormatFromGzip(_ context.Context, cfg config.Config) (*formatFromGzip, error) {
 	conf := formatGzipConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: format_from_gzip: %v", err)
+		return nil, fmt.Errorf("transform format_from_gzip: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "format_from_gzip"
 	}
 
 	tf := formatFromGzip{
@@ -35,7 +39,7 @@ func (tf *formatFromGzip) Transform(ctx context.Context, msg *message.Message) (
 
 	gz, err := fmtFromGzip(msg.Data())
 	if err != nil {
-		return nil, fmt.Errorf("transform: format_from_gzip: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	msg.SetData(gz)

--- a/transform/format_from_pretty_print.go
+++ b/transform/format_from_pretty_print.go
@@ -16,7 +16,9 @@ const (
 	formatFromPPCloseCurlyBracket = 125 // }
 )
 
-type formatFromPrettyPrintConfig struct{}
+type formatFromPrettyPrintConfig struct {
+	ID string `json:"id"`
+}
 
 func (c *formatFromPrettyPrintConfig) Decode(in interface{}) error {
 	return iconfig.Decode(in, c)
@@ -25,7 +27,11 @@ func (c *formatFromPrettyPrintConfig) Decode(in interface{}) error {
 func newFormatFromPrettyPrint(_ context.Context, cfg config.Config) (*formatFromPrettyPrint, error) {
 	conf := formatFromPrettyPrintConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: format_from_pretty_print: %v", err)
+		return nil, fmt.Errorf("transform format_from_pretty_print: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "format_from_pretty_print"
 	}
 
 	tf := formatFromPrettyPrint{
@@ -61,7 +67,7 @@ func (tf *formatFromPrettyPrint) Transform(ctx context.Context, msg *message.Mes
 		if tf.count == 0 {
 			var buf bytes.Buffer
 			if err := json.Compact(&buf, tf.stack); err != nil {
-				return nil, fmt.Errorf("transform: format_from_pretty_print: json compact: %v", err)
+				return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 			}
 
 			tf.stack = []byte{}
@@ -70,7 +76,7 @@ func (tf *formatFromPrettyPrint) Transform(ctx context.Context, msg *message.Mes
 				return []*message.Message{msg}, nil
 			}
 
-			return nil, fmt.Errorf("transform: format_from_pretty_print: invalid json")
+			return nil, fmt.Errorf("transform %s: invalid json", tf.conf.ID)
 		}
 	}
 

--- a/transform/format_to_base64.go
+++ b/transform/format_to_base64.go
@@ -13,11 +13,15 @@ import (
 func newFormatToBase64(_ context.Context, cfg config.Config) (*formatToBase64, error) {
 	conf := formatBase64Config{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: format_to_base64: %v", err)
+		return nil, fmt.Errorf("transform format_to_base64: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "format_to_base64"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: format_to_base64: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	tf := formatToBase64{
@@ -53,7 +57,7 @@ func (tf *formatToBase64) Transform(ctx context.Context, msg *message.Message) (
 	b64 := ibase64.Encode(value.Bytes())
 
 	if err := msg.SetValue(tf.conf.Object.TargetKey, b64); err != nil {
-		return nil, fmt.Errorf("transform: format_to_base64: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	return []*message.Message{msg}, nil

--- a/transform/format_to_gzip.go
+++ b/transform/format_to_gzip.go
@@ -12,7 +12,11 @@ import (
 func newFormatToGzip(_ context.Context, cfg config.Config) (*formatToGzip, error) {
 	conf := formatGzipConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: format_to_gzip: %v", err)
+		return nil, fmt.Errorf("transform format_to_gzip: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "format_to_gzip"
 	}
 
 	tf := formatToGzip{
@@ -35,7 +39,7 @@ func (tf *formatToGzip) Transform(ctx context.Context, msg *message.Message) ([]
 
 	gz, err := fmtToGzip(msg.Data())
 	if err != nil {
-		return nil, fmt.Errorf("transform: format_to_gzip: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	msg.SetData(gz)

--- a/transform/hash.go
+++ b/transform/hash.go
@@ -8,6 +8,7 @@ import (
 )
 
 type hashConfig struct {
+	ID     string         `json:"id"`
 	Object iconfig.Object `json:"object"`
 }
 

--- a/transform/hash_md5.go
+++ b/transform/hash_md5.go
@@ -13,11 +13,15 @@ import (
 func newHashMD5(_ context.Context, cfg config.Config) (*hashMD5, error) {
 	conf := hashConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: hash_md5: %v", err)
+		return nil, fmt.Errorf("transform hash_md5: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "hash_md5"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: hash_md5: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	tf := hashMD5{

--- a/transform/hash_sha256.go
+++ b/transform/hash_sha256.go
@@ -13,11 +13,15 @@ import (
 func newHashSHA256(_ context.Context, cfg config.Config) (*hashSHA256, error) {
 	conf := hashConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: hash_sha256: %v", err)
+		return nil, fmt.Errorf("transform hash_sha256: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "hash_sha256"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: hash_sha256: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	tf := hashSHA256{

--- a/transform/meta_metric_duration.go
+++ b/transform/meta_metric_duration.go
@@ -13,6 +13,7 @@ import (
 )
 
 type metaMetricDurationConfig struct {
+	ID        string         `json:"id"`
 	Metric    iconfig.Metric `json:"metric"`
 	Transform config.Config  `json:"transform"`
 }
@@ -25,12 +26,16 @@ func newMetaMetricsDuration(ctx context.Context, cfg config.Config) (*metaMetric
 	// conf gets validated when calling metrics.New.
 	conf := metaMetricDurationConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: meta_metric_duration: %v", err)
+		return nil, fmt.Errorf("transform meta_metric_duration: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "meta_metric_duration"
 	}
 
 	m, err := metrics.New(ctx, conf.Metric.Destination)
 	if err != nil {
-		return nil, fmt.Errorf("transform: meta_metric_duration: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	tf := metaMetricDuration{
@@ -50,7 +55,7 @@ func newMetaMetricsDuration(ctx context.Context, cfg config.Config) (*metaMetric
 
 	tfer, err := New(ctx, tfCfg)
 	if err != nil {
-		return nil, fmt.Errorf("transform: meta_metric_duration: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 	tf.tf = tfer
 
@@ -74,12 +79,12 @@ func (tf *metaMetricDuration) Transform(ctx context.Context, msg *message.Messag
 			Value:      tf.duration,
 			Attributes: tf.conf.Metric.Attributes,
 		}); err != nil {
-			return nil, fmt.Errorf("transform: meta_metric_duration: %v", err)
+			return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 		}
 
 		msgs, err := tf.tf.Transform(ctx, msg)
 		if err != nil {
-			return nil, fmt.Errorf("transform: meta_metric_duration: %v", err)
+			return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 		}
 
 		return msgs, nil

--- a/transform/network.go
+++ b/transform/network.go
@@ -8,6 +8,7 @@ import (
 )
 
 type networkDomainConfig struct {
+	ID     string         `json:"id"`
 	Object iconfig.Object `json:"object"`
 }
 

--- a/transform/network_domain_registered_domain.go
+++ b/transform/network_domain_registered_domain.go
@@ -14,11 +14,15 @@ import (
 func newNetworkDomainRegisteredDomain(_ context.Context, cfg config.Config) (*networkDomainRegisteredDomain, error) {
 	conf := networkDomainConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: network_domain_registered_domain: %v", err)
+		return nil, fmt.Errorf("transform network_domain_registered_domain: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "network_domain_registered_domain"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: network_domain_registered_domain: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	tf := networkDomainRegisteredDomain{
@@ -43,7 +47,7 @@ func (tf *networkDomainRegisteredDomain) Transform(ctx context.Context, msg *mes
 		str := string(msg.Data())
 		domain, err := publicsuffix.EffectiveTLDPlusOne(str)
 		if err != nil {
-			return nil, fmt.Errorf("transform: network_domain_registered_domain: %v", err)
+			return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 		}
 
 		msg.SetData([]byte(domain))
@@ -57,11 +61,11 @@ func (tf *networkDomainRegisteredDomain) Transform(ctx context.Context, msg *mes
 
 	domain, err := publicsuffix.EffectiveTLDPlusOne(value.String())
 	if err != nil {
-		return nil, fmt.Errorf("transform: network_domain_registered_domain: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	if err := msg.SetValue(tf.conf.Object.TargetKey, domain); err != nil {
-		return nil, fmt.Errorf("transform: network_domain_registered_domain: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	return []*message.Message{msg}, nil

--- a/transform/network_domain_subdomain.go
+++ b/transform/network_domain_subdomain.go
@@ -19,11 +19,15 @@ var errFmtSubdomainNoSubdomain = fmt.Errorf("no subdomain")
 func newNetworkDomainSubdomain(_ context.Context, cfg config.Config) (*networkDomainSubdomain, error) {
 	conf := networkDomainConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: network_domain_subdomain: %v", err)
+		return nil, fmt.Errorf("transform network_domain_subdomain: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "network_domain_subdomain"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: network_domain_subdomain: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	tf := networkDomainSubdomain{
@@ -48,7 +52,7 @@ func (tf *networkDomainSubdomain) Transform(ctx context.Context, msg *message.Me
 		str := string(msg.Data())
 		domain, err := fmtParseSubdomain(str)
 		if err != nil {
-			return nil, fmt.Errorf("transform: network_domain_subdomain: %v", err)
+			return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 		}
 
 		msg.SetData([]byte(domain))
@@ -62,11 +66,11 @@ func (tf *networkDomainSubdomain) Transform(ctx context.Context, msg *message.Me
 
 	domain, err := fmtParseSubdomain(value.String())
 	if err != nil {
-		return nil, fmt.Errorf("transform: network_domain_subdomain: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	if err := msg.SetValue(tf.conf.Object.TargetKey, domain); err != nil {
-		return nil, fmt.Errorf("transform: network_domain_subdomain: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	return []*message.Message{msg}, nil

--- a/transform/network_domain_top_level_domain.go
+++ b/transform/network_domain_top_level_domain.go
@@ -14,11 +14,15 @@ import (
 func newNetworkDomainTopLevelDomain(_ context.Context, cfg config.Config) (*networkDomainTopLevelDomain, error) {
 	conf := networkDomainConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: network_domain_top_level_domain: %v", err)
+		return nil, fmt.Errorf("transform network_domain_top_level_domain: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "network_domain_top_level_domain"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: network_domain_top_level_domain: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	tf := networkDomainTopLevelDomain{
@@ -55,7 +59,7 @@ func (tf *networkDomainTopLevelDomain) Transform(ctx context.Context, msg *messa
 	domain, _ := publicsuffix.PublicSuffix(value.String())
 
 	if err := msg.SetValue(tf.conf.Object.TargetKey, domain); err != nil {
-		return nil, fmt.Errorf("transform: network_domain_top_level_domain: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	return []*message.Message{msg}, nil

--- a/transform/number.go
+++ b/transform/number.go
@@ -9,6 +9,7 @@ import (
 )
 
 type numberMathConfig struct {
+	ID     string         `json:"id"`
 	Object iconfig.Object `json:"object"`
 }
 

--- a/transform/number_math_addition.go
+++ b/transform/number_math_addition.go
@@ -14,11 +14,15 @@ import (
 func newNumberMathAddition(_ context.Context, cfg config.Config) (*numberMathAddition, error) {
 	conf := numberMathConfig{}
 	if err := iconfig.Decode(cfg.Settings, &conf); err != nil {
-		return nil, fmt.Errorf("transform: number_math_addition: %v", err)
+		return nil, fmt.Errorf("transform number_math_addition: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "number_math_addition"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: number_math_addition: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	tf := numberMathAddition{
@@ -73,11 +77,11 @@ func (tf *numberMathAddition) Transform(ctx context.Context, msg *message.Messag
 
 	f, err := strconv.ParseFloat(strFloat64, 64)
 	if err != nil {
-		return nil, fmt.Errorf("transform: number_math_addition: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	if err := msg.SetValue(tf.conf.Object.TargetKey, f); err != nil {
-		return nil, fmt.Errorf("transform: number_math_addition: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", err)
 	}
 
 	return []*message.Message{msg}, nil

--- a/transform/number_math_addition.go
+++ b/transform/number_math_addition.go
@@ -81,7 +81,7 @@ func (tf *numberMathAddition) Transform(ctx context.Context, msg *message.Messag
 	}
 
 	if err := msg.SetValue(tf.conf.Object.TargetKey, f); err != nil {
-		return nil, fmt.Errorf("transform %s: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	return []*message.Message{msg}, nil

--- a/transform/number_math_division.go
+++ b/transform/number_math_division.go
@@ -81,7 +81,7 @@ func (tf *numberMathDivision) Transform(ctx context.Context, msg *message.Messag
 	}
 
 	if err := msg.SetValue(tf.conf.Object.TargetKey, f); err != nil {
-		return nil, fmt.Errorf("transform %s: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	return []*message.Message{msg}, nil

--- a/transform/number_math_division.go
+++ b/transform/number_math_division.go
@@ -14,11 +14,15 @@ import (
 func newNumberMathDivision(_ context.Context, cfg config.Config) (*numberMathDivision, error) {
 	conf := numberMathConfig{}
 	if err := iconfig.Decode(cfg.Settings, &conf); err != nil {
-		return nil, fmt.Errorf("transform: number_math_division: %v", err)
+		return nil, fmt.Errorf("transform number_math_division: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "number_math_division"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: number_math_division: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	tf := numberMathDivision{
@@ -73,11 +77,11 @@ func (tf *numberMathDivision) Transform(ctx context.Context, msg *message.Messag
 
 	f, err := strconv.ParseFloat(strFloat64, 64)
 	if err != nil {
-		return nil, fmt.Errorf("transform: number_math_division: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	if err := msg.SetValue(tf.conf.Object.TargetKey, f); err != nil {
-		return nil, fmt.Errorf("transform: number_math_division: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", err)
 	}
 
 	return []*message.Message{msg}, nil

--- a/transform/number_math_multiplication.go
+++ b/transform/number_math_multiplication.go
@@ -81,7 +81,7 @@ func (tf *numberMathMultiplication) Transform(ctx context.Context, msg *message.
 	}
 
 	if err := msg.SetValue(tf.conf.Object.TargetKey, f); err != nil {
-		return nil, fmt.Errorf("transform %s: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	return []*message.Message{msg}, nil

--- a/transform/number_math_multiplication.go
+++ b/transform/number_math_multiplication.go
@@ -14,11 +14,15 @@ import (
 func newNumberMathMultiplication(_ context.Context, cfg config.Config) (*numberMathMultiplication, error) {
 	conf := numberMathConfig{}
 	if err := iconfig.Decode(cfg.Settings, &conf); err != nil {
-		return nil, fmt.Errorf("transform: number_math_multiplication: %v", err)
+		return nil, fmt.Errorf("transform number_math_multiplication: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "number_math_multiplication"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: number_math_multiplication: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	tf := numberMathMultiplication{
@@ -73,11 +77,11 @@ func (tf *numberMathMultiplication) Transform(ctx context.Context, msg *message.
 
 	f, err := strconv.ParseFloat(strFloat64, 64)
 	if err != nil {
-		return nil, fmt.Errorf("transform: number_math_multiplication: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	if err := msg.SetValue(tf.conf.Object.TargetKey, f); err != nil {
-		return nil, fmt.Errorf("transform: number_math_multiplication: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", err)
 	}
 
 	return []*message.Message{msg}, nil

--- a/transform/number_math_subtraction.go
+++ b/transform/number_math_subtraction.go
@@ -14,11 +14,15 @@ import (
 func newNumberMathSubtraction(_ context.Context, cfg config.Config) (*numberMathSubtraction, error) {
 	conf := numberMathConfig{}
 	if err := iconfig.Decode(cfg.Settings, &conf); err != nil {
-		return nil, fmt.Errorf("transform: number_math_subtraction: %v", err)
+		return nil, fmt.Errorf("transform number_math_subtraction: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "number_math_subtraction"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: number_math_subtraction: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	tf := numberMathSubtraction{
@@ -73,11 +77,11 @@ func (tf *numberMathSubtraction) Transform(ctx context.Context, msg *message.Mes
 
 	f, err := strconv.ParseFloat(strFloat64, 64)
 	if err != nil {
-		return nil, fmt.Errorf("transform: number_math_subtraction: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	if err := msg.SetValue(tf.conf.Object.TargetKey, f); err != nil {
-		return nil, fmt.Errorf("transform: number_math_subtraction: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", err)
 	}
 
 	return []*message.Message{msg}, nil

--- a/transform/number_math_subtraction.go
+++ b/transform/number_math_subtraction.go
@@ -81,7 +81,7 @@ func (tf *numberMathSubtraction) Transform(ctx context.Context, msg *message.Mes
 	}
 
 	if err := msg.SetValue(tf.conf.Object.TargetKey, f); err != nil {
-		return nil, fmt.Errorf("transform %s: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	return []*message.Message{msg}, nil

--- a/transform/object_copy.go
+++ b/transform/object_copy.go
@@ -11,6 +11,7 @@ import (
 )
 
 type objectCopyConfig struct {
+	ID     string         `json:"id"`
 	Object iconfig.Object `json:"object"`
 }
 
@@ -21,7 +22,11 @@ func (c *objectCopyConfig) Decode(in interface{}) error {
 func newObjectCopy(_ context.Context, cfg config.Config) (*objectCopy, error) {
 	conf := objectCopyConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: object_copy: %v", err)
+		return nil, fmt.Errorf("transform object_copy: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "object_copy"
 	}
 
 	tf := objectCopy{
@@ -61,7 +66,7 @@ func (tf *objectCopy) Transform(ctx context.Context, msg *message.Message) ([]*m
 
 		outMsg := message.New().SetMetadata(msg.Metadata())
 		if err := outMsg.SetValue(tf.conf.Object.TargetKey, msg.Data()); err != nil {
-			return nil, fmt.Errorf("transform: object_copy: %v", err)
+			return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 		}
 
 		return []*message.Message{outMsg}, nil
@@ -73,7 +78,7 @@ func (tf *objectCopy) Transform(ctx context.Context, msg *message.Message) ([]*m
 	}
 
 	if err := msg.SetValue(tf.conf.Object.TargetKey, value); err != nil {
-		return nil, fmt.Errorf("transform: object_copy: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	return []*message.Message{msg}, nil

--- a/transform/object_delete.go
+++ b/transform/object_delete.go
@@ -12,6 +12,7 @@ import (
 )
 
 type objectDeleteConfig struct {
+	ID     string         `json:"id"`
 	Object iconfig.Object `json:"object"`
 }
 
@@ -30,11 +31,15 @@ func (c *objectDeleteConfig) Validate() error {
 func newObjectDelete(_ context.Context, cfg config.Config) (*objectDelete, error) {
 	conf := objectDeleteConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: object_delete: %v", err)
+		return nil, fmt.Errorf("transform object_delete: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "object_delete"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: object_delete: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	proc := objectDelete{
@@ -54,7 +59,7 @@ func (tf *objectDelete) Transform(_ context.Context, msg *message.Message) ([]*m
 	}
 
 	if err := msg.DeleteValue(tf.conf.Object.SourceKey); err != nil {
-		return nil, fmt.Errorf("transform: object_delete: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	return []*message.Message{msg}, nil

--- a/transform/object_insert.go
+++ b/transform/object_insert.go
@@ -15,6 +15,7 @@ type objectInsertConfig struct {
 	// Value inserted into the object.
 	Value interface{} `json:"value"`
 
+	ID     string         `json:"id"`
 	Object iconfig.Object `json:"object"`
 }
 
@@ -37,11 +38,15 @@ func (c *objectInsertConfig) Validate() error {
 func newObjectInsert(_ context.Context, cfg config.Config) (*objectInsert, error) {
 	conf := objectInsertConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: object_insert: %v", err)
+		return nil, fmt.Errorf("transform object_insert: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "object_insert"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: object_insert: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	tf := objectInsert{
@@ -61,7 +66,7 @@ func (tf *objectInsert) Transform(ctx context.Context, msg *message.Message) ([]
 	}
 
 	if err := msg.SetValue(tf.conf.Object.TargetKey, tf.conf.Value); err != nil {
-		return nil, fmt.Errorf("transform: object_insert: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	return []*message.Message{msg}, nil

--- a/transform/object_to_boolean.go
+++ b/transform/object_to_boolean.go
@@ -12,6 +12,7 @@ import (
 )
 
 type objectToBooleanConfig struct {
+	ID     string         `json:"id"`
 	Object iconfig.Object `json:"object"`
 }
 
@@ -34,11 +35,15 @@ func (c *objectToBooleanConfig) Validate() error {
 func newObjectToBoolean(_ context.Context, cfg config.Config) (*objectToBoolean, error) {
 	conf := objectToBooleanConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: object_to_boolean: %v", err)
+		return nil, fmt.Errorf("transform object_to_boolean: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "object_to_boolean"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: object_to_boolean: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	tf := objectToBoolean{
@@ -68,7 +73,7 @@ func (tf *objectToBoolean) Transform(ctx context.Context, msg *message.Message) 
 	}
 
 	if err := msg.SetValue(tf.conf.Object.TargetKey, value.Bool()); err != nil {
-		return nil, fmt.Errorf("transform: object_to_boolean: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	return []*message.Message{msg}, nil

--- a/transform/object_to_float.go
+++ b/transform/object_to_float.go
@@ -12,6 +12,7 @@ import (
 )
 
 type objectToFloatConfig struct {
+	ID     string         `json:"id"`
 	Object iconfig.Object `json:"object"`
 }
 
@@ -34,7 +35,11 @@ func (c *objectToFloatConfig) Validate() error {
 func newObjectToFloat(_ context.Context, cfg config.Config) (*objectToFloat, error) {
 	conf := objectToFloatConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: object_to_float: %v", err)
+		return nil, fmt.Errorf("transform object_to_float: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "object_to_float"
 	}
 
 	tf := objectToFloat{
@@ -59,7 +64,7 @@ func (tf *objectToFloat) Transform(ctx context.Context, msg *message.Message) ([
 	}
 
 	if err := msg.SetValue(tf.conf.Object.TargetKey, value.Float()); err != nil {
-		return nil, fmt.Errorf("transform: object_to_float: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	return []*message.Message{msg}, nil

--- a/transform/object_to_integer.go
+++ b/transform/object_to_integer.go
@@ -12,6 +12,7 @@ import (
 )
 
 type objectToIntegerConfig struct {
+	ID     string         `json:"id"`
 	Object iconfig.Object `json:"object"`
 }
 
@@ -34,7 +35,11 @@ func (c *objectToIntegerConfig) Validate() error {
 func newObjectToInteger(_ context.Context, cfg config.Config) (*objectToInteger, error) {
 	conf := objectToIntegerConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: object_to_integer: %v", err)
+		return nil, fmt.Errorf("transform object_to_integer: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "object_to_integer"
 	}
 
 	tf := objectToInteger{
@@ -59,7 +64,7 @@ func (tf *objectToInteger) Transform(ctx context.Context, msg *message.Message) 
 	}
 
 	if err := msg.SetValue(tf.conf.Object.TargetKey, value.Int()); err != nil {
-		return nil, fmt.Errorf("transform: object_to_integer: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	return []*message.Message{msg}, nil

--- a/transform/object_to_string.go
+++ b/transform/object_to_string.go
@@ -12,6 +12,7 @@ import (
 )
 
 type objectToStringConfig struct {
+	ID     string         `json:"id"`
 	Object iconfig.Object `json:"object"`
 }
 
@@ -34,7 +35,11 @@ func (c *objectToStringConfig) Validate() error {
 func newObjectToString(_ context.Context, cfg config.Config) (*objectToString, error) {
 	conf := objectToStringConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: object_to_string: %v", err)
+		return nil, fmt.Errorf("transform object_to_string: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "object_to_string"
 	}
 
 	tf := objectToString{
@@ -59,7 +64,7 @@ func (tf *objectToString) Transform(ctx context.Context, msg *message.Message) (
 	}
 
 	if err := msg.SetValue(tf.conf.Object.TargetKey, value.String()); err != nil {
-		return nil, fmt.Errorf("transform: object_to_string: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	return []*message.Message{msg}, nil

--- a/transform/object_to_unsigned_integer.go
+++ b/transform/object_to_unsigned_integer.go
@@ -12,6 +12,7 @@ import (
 )
 
 type objectToUnsignedIntegerConfig struct {
+	ID     string         `json:"id"`
 	Object iconfig.Object `json:"object"`
 }
 
@@ -34,7 +35,11 @@ func (c *objectToUnsignedIntegerConfig) Validate() error {
 func newObjectToUnsignedInteger(_ context.Context, cfg config.Config) (*objectToUnsignedInteger, error) {
 	conf := objectToUnsignedIntegerConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: object_to_unsigned_integer: %v", err)
+		return nil, fmt.Errorf("transform object_to_unsigned_integer: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "object_to_unsigned_integer"
 	}
 
 	tf := objectToUnsignedInteger{
@@ -59,7 +64,7 @@ func (tf *objectToUnsignedInteger) Transform(ctx context.Context, msg *message.M
 	}
 
 	if err := msg.SetValue(tf.conf.Object.TargetKey, value.Uint()); err != nil {
-		return nil, fmt.Errorf("transform: object_to_unsigned_integer: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	return []*message.Message{msg}, nil

--- a/transform/send_aws_kinesis_data_firehose.go
+++ b/transform/send_aws_kinesis_data_firehose.go
@@ -142,7 +142,7 @@ func (tf *sendAWSKinesisDataFirehose) Transform(ctx context.Context, msg *messag
 	}
 
 	if err := tf.send(ctx, key); err != nil {
-		return nil, fmt.Errorf("transform %s: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	// If data cannot be added after reset, then the batch is misconfgured.

--- a/transform/send_aws_kinesis_data_firehose.go
+++ b/transform/send_aws_kinesis_data_firehose.go
@@ -30,6 +30,7 @@ type sendAWSKinesisDataFirehoseConfig struct {
 	// AuxTransforms are applied to batched data before it is sent.
 	AuxTransforms []config.Config `json:"auxiliary_transforms"`
 
+	ID     string         `json:"id"`
 	Object iconfig.Object `json:"object"`
 	Batch  iconfig.Batch  `json:"batch"`
 	AWS    iconfig.AWS    `json:"aws"`
@@ -51,11 +52,15 @@ func (c *sendAWSKinesisDataFirehoseConfig) Validate() error {
 func newSendAWSKinesisDataFirehose(_ context.Context, cfg config.Config) (*sendAWSKinesisDataFirehose, error) {
 	conf := sendAWSKinesisDataFirehoseConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: send_aws_kinesis_data_firehose: %v", err)
+		return nil, fmt.Errorf("transform send_aws_kinesis_data_firehose: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "send_aws_kinesis_data_firehose"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: send_aws_kinesis_data_firehose: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	tf := sendAWSKinesisDataFirehose{
@@ -86,7 +91,7 @@ func newSendAWSKinesisDataFirehose(_ context.Context, cfg config.Config) (*sendA
 		for i, c := range conf.AuxTransforms {
 			t, err := New(context.Background(), c)
 			if err != nil {
-				return nil, fmt.Errorf("transform: send_aws_kinesis_data_firehose: %v", err)
+				return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 			}
 
 			tf.tforms[i] = t
@@ -118,7 +123,7 @@ func (tf *sendAWSKinesisDataFirehose) Transform(ctx context.Context, msg *messag
 			}
 
 			if err := tf.send(ctx, key); err != nil {
-				return nil, fmt.Errorf("transform: send_aws_kinesis_data_firehose: %v", err)
+				return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 			}
 		}
 
@@ -127,7 +132,7 @@ func (tf *sendAWSKinesisDataFirehose) Transform(ctx context.Context, msg *messag
 	}
 
 	if len(msg.Data()) > sendAWSKinesisDataFirehoseMessageSizeLimit {
-		return nil, fmt.Errorf("transform: send_aws_kinesis_data_firehose: %v", errSendAWSKinesisDataFirehoseRecordSizeLimit)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, errSendAWSKinesisDataFirehoseRecordSizeLimit)
 	}
 
 	// If this value does not exist, then all data is batched together.
@@ -137,13 +142,13 @@ func (tf *sendAWSKinesisDataFirehose) Transform(ctx context.Context, msg *messag
 	}
 
 	if err := tf.send(ctx, key); err != nil {
-		return nil, fmt.Errorf("transform: send_aws_kinesis_data_firehose: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", err)
 	}
 
 	// If data cannot be added after reset, then the batch is misconfgured.
 	tf.agg.Reset(key)
 	if ok := tf.agg.Add(key, msg.Data()); !ok {
-		return nil, fmt.Errorf("transform: send_aws_kinesis_data_firehose: %v", errSendBatchMisconfigured)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, errSendBatchMisconfigured)
 	}
 
 	return []*message.Message{msg}, nil

--- a/transform/send_aws_s3.go
+++ b/transform/send_aws_s3.go
@@ -136,7 +136,7 @@ func (tf *sendAWSS3) Transform(ctx context.Context, msg *message.Message) ([]*me
 	}
 
 	if err := tf.send(ctx, key); err != nil {
-		return nil, fmt.Errorf("transform %s: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	// If data cannot be added after reset, then the batch is misconfgured.

--- a/transform/send_aws_sns.go
+++ b/transform/send_aws_sns.go
@@ -30,6 +30,7 @@ type sendAWSSNSConfig struct {
 	// AuxTransforms are applied to batched data before it is sent.
 	AuxTransforms []config.Config `json:"auxiliary_transforms"`
 
+	ID     string         `json:"id"`
 	Object iconfig.Object `json:"object"`
 	Batch  iconfig.Batch  `json:"batch"`
 	AWS    iconfig.AWS    `json:"aws"`
@@ -51,11 +52,15 @@ func (c *sendAWSSNSConfig) Validate() error {
 func newSendAWSSNS(_ context.Context, cfg config.Config) (*sendAWSSNS, error) {
 	conf := sendAWSSNSConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: send_aws_sns: %v", err)
+		return nil, fmt.Errorf("transform send_aws_sns: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "send_aws_sns"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: send_aws_sns: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	tf := sendAWSSNS{
@@ -87,7 +92,7 @@ func newSendAWSSNS(_ context.Context, cfg config.Config) (*sendAWSSNS, error) {
 		for i, c := range conf.AuxTransforms {
 			t, err := New(context.Background(), c)
 			if err != nil {
-				return nil, fmt.Errorf("transform: send_aws_sns: %v", err)
+				return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 			}
 
 			tf.tforms[i] = t
@@ -119,7 +124,7 @@ func (tf *sendAWSSNS) Transform(ctx context.Context, msg *message.Message) ([]*m
 			}
 
 			if err := tf.send(ctx, key); err != nil {
-				return nil, fmt.Errorf("transform: send_aws_sns: %v", err)
+				return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 			}
 		}
 
@@ -128,7 +133,7 @@ func (tf *sendAWSSNS) Transform(ctx context.Context, msg *message.Message) ([]*m
 	}
 
 	if len(msg.Data()) > sendAWSSNSMessageSizeLimit {
-		return nil, fmt.Errorf("transform: send_aws_sns: %v", errSendAWSSNSMessageSizeLimit)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, errSendAWSSNSMessageSizeLimit)
 	}
 
 	// If this value does not exist, then all data is batched together.
@@ -138,13 +143,13 @@ func (tf *sendAWSSNS) Transform(ctx context.Context, msg *message.Message) ([]*m
 	}
 
 	if err := tf.send(ctx, key); err != nil {
-		return nil, fmt.Errorf("transform: send_aws_sns: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	// If data cannot be added after reset, then the batch is misconfgured.
 	tf.agg.Reset(key)
 	if ok := tf.agg.Add(key, msg.Data()); !ok {
-		return nil, fmt.Errorf("transform: send_aws_sns: %v", errSendBatchMisconfigured)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, errSendBatchMisconfigured)
 	}
 	return []*message.Message{msg}, nil
 }

--- a/transform/send_aws_sqs.go
+++ b/transform/send_aws_sqs.go
@@ -153,7 +153,7 @@ func (tf *sendAWSSQS) Transform(ctx context.Context, msg *message.Message) ([]*m
 	}
 
 	if err := tf.send(ctx, key); err != nil {
-		return nil, fmt.Errorf("transform %s: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	// If data cannot be added after reset, then the batch is misconfgured.

--- a/transform/send_aws_sqs.go
+++ b/transform/send_aws_sqs.go
@@ -31,6 +31,7 @@ type sendAWSSQSConfig struct {
 	// AuxTransforms are applied to batched data before it is sent.
 	AuxTransforms []config.Config `json:"auxiliary_transforms"`
 
+	ID     string         `json:"id"`
 	Object iconfig.Object `json:"object"`
 	Batch  iconfig.Batch  `json:"batch"`
 	AWS    iconfig.AWS    `json:"aws"`
@@ -52,11 +53,15 @@ func (c *sendAWSSQSConfig) Validate() error {
 func newSendAWSSQS(_ context.Context, cfg config.Config) (*sendAWSSQS, error) {
 	conf := sendAWSSQSConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: send_aws_sqs: %v", err)
+		return nil, fmt.Errorf("transform send_aws_sqs: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "send_aws_sqs"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: send_aws_sqs: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	// arn:aws:sqs:region:account_id:queue_name
@@ -96,7 +101,7 @@ func newSendAWSSQS(_ context.Context, cfg config.Config) (*sendAWSSQS, error) {
 		for i, c := range conf.AuxTransforms {
 			t, err := New(context.Background(), c)
 			if err != nil {
-				return nil, fmt.Errorf("transform: send_aws_sqs: %v", err)
+				return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 			}
 
 			tf.tforms[i] = t
@@ -129,7 +134,7 @@ func (tf *sendAWSSQS) Transform(ctx context.Context, msg *message.Message) ([]*m
 			}
 
 			if err := tf.send(ctx, key); err != nil {
-				return nil, fmt.Errorf("transform: send_aws_sqs: %v", err)
+				return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 			}
 		}
 
@@ -138,7 +143,7 @@ func (tf *sendAWSSQS) Transform(ctx context.Context, msg *message.Message) ([]*m
 	}
 
 	if len(msg.Data()) > sendSQSMessageSizeLimit {
-		return nil, fmt.Errorf("transform: send_aws_sqs: %v", errSendSQSMessageSizeLimit)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, errSendSQSMessageSizeLimit)
 	}
 
 	// If this value does not exist, then all data is batched together.
@@ -148,13 +153,13 @@ func (tf *sendAWSSQS) Transform(ctx context.Context, msg *message.Message) ([]*m
 	}
 
 	if err := tf.send(ctx, key); err != nil {
-		return nil, fmt.Errorf("transform: send_aws_sqs: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", err)
 	}
 
 	// If data cannot be added after reset, then the batch is misconfgured.
 	tf.agg.Reset(key)
 	if ok := tf.agg.Add(key, msg.Data()); !ok {
-		return nil, fmt.Errorf("transform: send_aws_sqs: %v", errSendBatchMisconfigured)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, errSendBatchMisconfigured)
 	}
 	return []*message.Message{msg}, nil
 }

--- a/transform/send_http_post.go
+++ b/transform/send_http_post.go
@@ -129,7 +129,7 @@ func (tf *sendHTTPPost) Transform(ctx context.Context, msg *message.Message) ([]
 	}
 
 	if err := tf.send(ctx, key); err != nil {
-		return nil, fmt.Errorf("transform %s: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	// If data cannot be added after reset, then the batch is misconfgured.

--- a/transform/send_http_post.go
+++ b/transform/send_http_post.go
@@ -27,6 +27,7 @@ type sendHTTPPostConfig struct {
 	// AuxTransforms are applied to batched data before it is sent.
 	AuxTransforms []config.Config `json:"auxiliary_transforms"`
 
+	ID     string         `json:"id"`
 	Object iconfig.Object `json:"object"`
 	Batch  iconfig.Batch  `json:"batch"`
 }
@@ -46,11 +47,15 @@ func (c *sendHTTPPostConfig) Validate() error {
 func newSendHTTPPost(_ context.Context, cfg config.Config) (*sendHTTPPost, error) {
 	conf := sendHTTPPostConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: send_http_post: %v", err)
+		return nil, fmt.Errorf("transform send_http_post: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "send_http_post"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: send_http_post: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	tf := sendHTTPPost{
@@ -77,7 +82,7 @@ func newSendHTTPPost(_ context.Context, cfg config.Config) (*sendHTTPPost, error
 		for i, c := range conf.AuxTransforms {
 			t, err := New(context.Background(), c)
 			if err != nil {
-				return nil, fmt.Errorf("transform: send_http_post: %v", err)
+				return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 			}
 
 			tf.tforms[i] = t
@@ -109,7 +114,7 @@ func (tf *sendHTTPPost) Transform(ctx context.Context, msg *message.Message) ([]
 			}
 
 			if err := tf.send(ctx, key); err != nil {
-				return nil, fmt.Errorf("transform: send_http_post: %v", err)
+				return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 			}
 		}
 
@@ -124,13 +129,13 @@ func (tf *sendHTTPPost) Transform(ctx context.Context, msg *message.Message) ([]
 	}
 
 	if err := tf.send(ctx, key); err != nil {
-		return nil, fmt.Errorf("transform: send_http_post: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", err)
 	}
 
 	// If data cannot be added after reset, then the batch is misconfgured.
 	tf.agg.Reset(key)
 	if ok := tf.agg.Add(key, msg.Data()); !ok {
-		return nil, fmt.Errorf("transform: send_http_post: %v", errSendBatchMisconfigured)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, errSendBatchMisconfigured)
 	}
 
 	return []*message.Message{msg}, nil

--- a/transform/string.go
+++ b/transform/string.go
@@ -8,6 +8,7 @@ import (
 )
 
 type strCaseConfig struct {
+	ID     string         `json:"id"`
 	Object iconfig.Object `json:"object"`
 }
 

--- a/transform/string_append.go
+++ b/transform/string_append.go
@@ -15,6 +15,7 @@ type stringAppendConfig struct {
 	// Suffix is the string appended to the end of the string.
 	Suffix string `json:"suffix"`
 
+	ID     string         `json:"id"`
 	Object iconfig.Object `json:"object"`
 }
 
@@ -48,11 +49,15 @@ type stringAppend struct {
 func newStringAppend(_ context.Context, cfg config.Config) (*stringAppend, error) {
 	conf := stringAppendConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: string_append: %v", err)
+		return nil, fmt.Errorf("transform string_append: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "string_append"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: string_append: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	tf := stringAppend{
@@ -85,7 +90,7 @@ func (tf *stringAppend) Transform(ctx context.Context, msg *message.Message) ([]
 	str := value.String() + tf.conf.Suffix
 
 	if err := msg.SetValue(tf.conf.Object.TargetKey, str); err != nil {
-		return nil, fmt.Errorf("transform: string_append: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	return []*message.Message{msg}, nil

--- a/transform/string_replace.go
+++ b/transform/string_replace.go
@@ -19,6 +19,7 @@ type stringReplaceConfig struct {
 	// Replacement is the string to replace the matched values with.
 	Replacement string `json:"replacement"`
 
+	ID     string         `json:"id"`
 	Object iconfig.Object `json:"object"`
 }
 
@@ -52,11 +53,15 @@ func (c *stringReplaceConfig) Validate() error {
 func newStringReplace(_ context.Context, cfg config.Config) (*stringReplace, error) {
 	conf := stringReplaceConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: string_replace: %v", err)
+		return nil, fmt.Errorf("transform string_replace: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "string_replace"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: string_replace: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	tf := stringReplace{
@@ -94,7 +99,7 @@ func (tf *stringReplace) Transform(ctx context.Context, msg *message.Message) ([
 
 	s := tf.conf.re.ReplaceAllString(value.String(), string(tf.r))
 	if err := msg.SetValue(tf.conf.Object.TargetKey, s); err != nil {
-		return nil, fmt.Errorf("transform: string_replace: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	return []*message.Message{msg}, nil

--- a/transform/string_split.go
+++ b/transform/string_split.go
@@ -17,6 +17,7 @@ type stringSplitConfig struct {
 	// Separator splits the string into elements of the array.
 	Separator string `json:"separator"`
 
+	ID     string         `json:"id"`
 	Object iconfig.Object `json:"object"`
 }
 
@@ -50,11 +51,15 @@ type stringSplit struct {
 func newStringSplit(_ context.Context, cfg config.Config) (*stringSplit, error) {
 	conf := stringSplitConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: string_split: %v", err)
+		return nil, fmt.Errorf("transform string_split: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "string_split"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: string_split: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	tf := stringSplit{
@@ -77,7 +82,7 @@ func (tf *stringSplit) Transform(ctx context.Context, msg *message.Message) ([]*
 		b := bytes.Split(msg.Data(), tf.separator)
 		for _, v := range b {
 			if err := tmpMsg.SetValue("key.-1", v); err != nil {
-				return nil, fmt.Errorf("transform: string_split: %v", err)
+				return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 			}
 		}
 
@@ -95,7 +100,7 @@ func (tf *stringSplit) Transform(ctx context.Context, msg *message.Message) ([]*
 	str := strings.Split(value.String(), tf.conf.Separator)
 
 	if err := msg.SetValue(tf.conf.Object.TargetKey, str); err != nil {
-		return nil, fmt.Errorf("transform: string_split: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	return []*message.Message{msg}, nil

--- a/transform/string_to_lower.go
+++ b/transform/string_to_lower.go
@@ -14,11 +14,15 @@ import (
 func newStringToLower(_ context.Context, cfg config.Config) (*stringToLower, error) {
 	conf := strCaseConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: string_to_lower: %v", err)
+		return nil, fmt.Errorf("transform string_to_lower: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "string_to_lower"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: string_to_lower: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	tf := stringToLower{
@@ -53,7 +57,7 @@ func (tf *stringToLower) Transform(ctx context.Context, msg *message.Message) ([
 
 	s := strings.ToLower(value.String())
 	if err := msg.SetValue(tf.conf.Object.TargetKey, s); err != nil {
-		return nil, fmt.Errorf("transform: string_to_lower: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	return []*message.Message{msg}, nil

--- a/transform/string_to_snake.go
+++ b/transform/string_to_snake.go
@@ -13,11 +13,15 @@ import (
 func newStringToSnake(_ context.Context, cfg config.Config) (*stringToSnake, error) {
 	conf := strCaseConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: string_to_snake: %v", err)
+		return nil, fmt.Errorf("transform string_to_snake: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "string_to_snake"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: string_to_snake: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	tf := stringToSnake{
@@ -52,7 +56,7 @@ func (tf *stringToSnake) Transform(ctx context.Context, msg *message.Message) ([
 
 	s := strcase.ToSnake(value.String())
 	if err := msg.SetValue(tf.conf.Object.TargetKey, s); err != nil {
-		return nil, fmt.Errorf("transform: string_to_snake: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	return []*message.Message{msg}, nil

--- a/transform/string_to_upper.go
+++ b/transform/string_to_upper.go
@@ -14,11 +14,15 @@ import (
 func newStringToUpper(_ context.Context, cfg config.Config) (*stringToUpper, error) {
 	conf := strCaseConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: string_to_lower: %v", err)
+		return nil, fmt.Errorf("transform string_to_lower: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "string_to_upper"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: string_to_lower: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	tf := stringToUpper{
@@ -53,7 +57,7 @@ func (tf *stringToUpper) Transform(ctx context.Context, msg *message.Message) ([
 
 	s := strings.ToUpper(value.String())
 	if err := msg.SetValue(tf.conf.Object.TargetKey, s); err != nil {
-		return nil, fmt.Errorf("transform: string_to_lower: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	return []*message.Message{msg}, nil

--- a/transform/string_uuid.go
+++ b/transform/string_uuid.go
@@ -12,6 +12,7 @@ import (
 )
 
 type stringUUIDConfig struct {
+	ID     string         `json:"id"`
 	Object iconfig.Object `json:"object"`
 }
 
@@ -22,7 +23,11 @@ func (c *stringUUIDConfig) Decode(in interface{}) error {
 func newStringUUID(_ context.Context, cfg config.Config) (*stringUUID, error) {
 	conf := stringUUIDConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: string_uuid: %v", err)
+		return nil, fmt.Errorf("transform string_uuid: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "string_uuid"
 	}
 
 	tf := stringUUID{
@@ -46,7 +51,7 @@ func (tf *stringUUID) Transform(_ context.Context, msg *message.Message) ([]*mes
 	uid := uuid.NewString()
 	if tf.hasObjectSetKey {
 		if err := msg.SetValue(tf.conf.Object.TargetKey, uid); err != nil {
-			return nil, fmt.Errorf("transform: string_uuid: %v", err)
+			return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 		}
 
 		return []*message.Message{msg}, nil

--- a/transform/time.go
+++ b/transform/time.go
@@ -13,6 +13,7 @@ const (
 )
 
 type timeUnixConfig struct {
+	ID     string         `json:"id"`
 	Object iconfig.Object `json:"object"`
 }
 
@@ -33,6 +34,7 @@ func (c *timeUnixConfig) Validate() error {
 }
 
 type timePatternConfig struct {
+	ID     string         `json:"id"`
 	Object iconfig.Object `json:"object"`
 
 	Format   string `json:"format"`

--- a/transform/time_from_string.go
+++ b/transform/time_from_string.go
@@ -12,11 +12,15 @@ import (
 func newTimeFromString(_ context.Context, cfg config.Config) (*timeFromString, error) {
 	conf := timePatternConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: time_from_stringing: %v", err)
+		return nil, fmt.Errorf("transform time_from_string: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "time_from_string"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: time_from_stringing: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	tf := timeFromString{
@@ -50,12 +54,12 @@ func (tf *timeFromString) Transform(ctx context.Context, msg *message.Message) (
 
 	date, err := timeStrToUnix(value.String(), tf.conf.Format, tf.conf.Location)
 	if err != nil {
-		return nil, fmt.Errorf("transform: time_from_string: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	if tf.isObject {
 		if err := msg.SetValue(tf.conf.Object.TargetKey, date.UnixNano()); err != nil {
-			return nil, fmt.Errorf("transform: time_from_string: %v", err)
+			return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 		}
 	} else {
 		value := timeUnixToBytes(date)

--- a/transform/time_from_unix.go
+++ b/transform/time_from_unix.go
@@ -13,11 +13,15 @@ import (
 func newTimeFromUnix(_ context.Context, cfg config.Config) (*timeFromUnix, error) {
 	conf := timeUnixConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: time_from_unix: %v", err)
+		return nil, fmt.Errorf("transform time_from_unix: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "time_from_unix"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: time_from_unix: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	tf := timeFromUnix{
@@ -55,7 +59,7 @@ func (tf *timeFromUnix) Transform(ctx context.Context, msg *message.Message) ([]
 
 	if tf.isObject {
 		if err := msg.SetValue(tf.conf.Object.TargetKey, ns); err != nil {
-			return nil, fmt.Errorf("transform: time_from_unix: %v", err)
+			return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 		}
 	} else {
 		value := []byte(fmt.Sprintf("%d", ns))

--- a/transform/time_from_unix_milli.go
+++ b/transform/time_from_unix_milli.go
@@ -13,11 +13,15 @@ import (
 func newTimeFromUnixMilli(_ context.Context, cfg config.Config) (*timeFromUnixMilli, error) {
 	conf := timeUnixConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: time_from_unix_milli: %v", err)
+		return nil, fmt.Errorf("transform time_from_unix_milli: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "time_from_unix_milli"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: time_from_unix_milli: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	tf := timeFromUnixMilli{
@@ -55,7 +59,7 @@ func (tf *timeFromUnixMilli) Transform(ctx context.Context, msg *message.Message
 
 	if tf.isObject {
 		if err := msg.SetValue(tf.conf.Object.TargetKey, ns); err != nil {
-			return nil, fmt.Errorf("transform: time_from_unix_milli: %v", err)
+			return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 		}
 	} else {
 		value := []byte(fmt.Sprintf("%d", ns))

--- a/transform/time_now.go
+++ b/transform/time_now.go
@@ -12,6 +12,7 @@ import (
 )
 
 type timeNowConfig struct {
+	ID     string         `json:"id"`
 	Object iconfig.Object `json:"object"`
 }
 
@@ -26,11 +27,15 @@ func (c *timeNowConfig) Validate() error {
 func newTimeNow(_ context.Context, cfg config.Config) (*timeNow, error) {
 	conf := timeNowConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: time_now: %v", err)
+		return nil, fmt.Errorf("transform time_now: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "time_now"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: time_now: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	tf := timeNow{
@@ -55,7 +60,7 @@ func (tf *timeNow) Transform(ctx context.Context, msg *message.Message) ([]*mess
 
 	if tf.hasObjectSetKey {
 		if err := msg.SetValue(tf.conf.Object.TargetKey, date.UnixNano()); err != nil {
-			return nil, fmt.Errorf("time: now: %v", err)
+			return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 		}
 
 		return []*message.Message{msg}, nil

--- a/transform/time_to_string.go
+++ b/transform/time_to_string.go
@@ -12,11 +12,15 @@ import (
 func newTimeToString(_ context.Context, cfg config.Config) (*timeToString, error) {
 	conf := timePatternConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: time_to_string: %v", err)
+		return nil, fmt.Errorf("transform time_to_string: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "time_to_string"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: time_to_string: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	tf := timeToString{
@@ -50,12 +54,12 @@ func (tf *timeToString) Transform(ctx context.Context, msg *message.Message) ([]
 
 	pattern, err := timeUnixToStr(value.Int(), tf.conf.Format, tf.conf.Location)
 	if err != nil {
-		return nil, fmt.Errorf("transform: time_to_string: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 
 	if tf.isObject {
 		if err := msg.SetValue(tf.conf.Object.TargetKey, pattern); err != nil {
-			return nil, fmt.Errorf("transform: time_to_string: %v", err)
+			return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 		}
 	} else {
 		msg.SetData([]byte(pattern))

--- a/transform/time_to_unix.go
+++ b/transform/time_to_unix.go
@@ -13,11 +13,15 @@ import (
 func newTimeToUnix(_ context.Context, cfg config.Config) (*timeToUnix, error) {
 	conf := timeUnixConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: time_to_unix: %v", err)
+		return nil, fmt.Errorf("transform time_to_unix: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "time_to_unix"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: time_to_unix: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	tf := timeToUnix{
@@ -55,7 +59,7 @@ func (tf *timeToUnix) Transform(ctx context.Context, msg *message.Message) ([]*m
 
 	if tf.isObject {
 		if err := msg.SetValue(tf.conf.Object.TargetKey, unix); err != nil {
-			return nil, fmt.Errorf("transform: time_to_unix: %v", err)
+			return nil, fmt.Errorf("transform %s: %v", err)
 		}
 	} else {
 		value := []byte(fmt.Sprintf("%d", unix))

--- a/transform/time_to_unix.go
+++ b/transform/time_to_unix.go
@@ -59,7 +59,7 @@ func (tf *timeToUnix) Transform(ctx context.Context, msg *message.Message) ([]*m
 
 	if tf.isObject {
 		if err := msg.SetValue(tf.conf.Object.TargetKey, unix); err != nil {
-			return nil, fmt.Errorf("transform %s: %v", err)
+			return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 		}
 	} else {
 		value := []byte(fmt.Sprintf("%d", unix))

--- a/transform/time_to_unix_milli.go
+++ b/transform/time_to_unix_milli.go
@@ -59,7 +59,7 @@ func (tf *timeToUnixMilli) Transform(ctx context.Context, msg *message.Message) 
 
 	if tf.isObject {
 		if err := msg.SetValue(tf.conf.Object.TargetKey, ms); err != nil {
-			return nil, fmt.Errorf("transform %s: %v", err)
+			return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 		}
 	} else {
 		value := []byte(fmt.Sprintf("%d", ms))

--- a/transform/time_to_unix_milli.go
+++ b/transform/time_to_unix_milli.go
@@ -13,11 +13,15 @@ import (
 func newTimeToUnixMilli(_ context.Context, cfg config.Config) (*timeToUnixMilli, error) {
 	conf := timeUnixConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: time_to_unix_milli: %v", err)
+		return nil, fmt.Errorf("transform time_to_unix_milli: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "time_to_unix_milli"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: time_to_unix_milli: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	tf := timeToUnixMilli{
@@ -55,7 +59,7 @@ func (tf *timeToUnixMilli) Transform(ctx context.Context, msg *message.Message) 
 
 	if tf.isObject {
 		if err := msg.SetValue(tf.conf.Object.TargetKey, ms); err != nil {
-			return nil, fmt.Errorf("transform: time_to_unix_milli: %v", err)
+			return nil, fmt.Errorf("transform %s: %v", err)
 		}
 	} else {
 		value := []byte(fmt.Sprintf("%d", ms))

--- a/transform/transform.go
+++ b/transform/transform.go
@@ -193,7 +193,7 @@ func New(ctx context.Context, cfg config.Config) (Transformer, error) { //nolint
 	case "utility_secret":
 		return newUtilitySecret(ctx, cfg)
 	default:
-		return nil, fmt.Errorf("transform: new: type %q settings %+v: %v", cfg.Type, cfg.Settings, errors.ErrInvalidFactoryInput)
+		return nil, fmt.Errorf("transform %s: %w", cfg.Type, errors.ErrInvalidFactoryInput)
 	}
 }
 

--- a/transform/utility_control.go
+++ b/transform/utility_control.go
@@ -13,6 +13,7 @@ import (
 )
 
 type utilityControlConfig struct {
+	ID    string        `json:"id"`
 	Batch iconfig.Batch `json:"batch"`
 }
 
@@ -23,7 +24,11 @@ func (c *utilityControlConfig) Decode(in interface{}) error {
 func newUtilityControl(_ context.Context, cfg config.Config) (*utilityControl, error) {
 	conf := utilityControlConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: utility_control: %v", err)
+		return nil, fmt.Errorf("transform utility_control: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "utility_control"
 	}
 
 	agg, err := aggregate.New(aggregate.Config{
@@ -32,7 +37,7 @@ func newUtilityControl(_ context.Context, cfg config.Config) (*utilityControl, e
 		Duration: conf.Batch.Duration,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("transform: utility_control: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	tf := utilityControl{
@@ -68,7 +73,7 @@ func (tf *utilityControl) Transform(_ context.Context, msg *message.Message) ([]
 
 	tf.agg.Reset("")
 	if ok := tf.agg.Add("", msg.Data()); !ok {
-		return nil, fmt.Errorf("transform: utility_control: %v", errSendBatchMisconfigured)
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, errSendBatchMisconfigured)
 	}
 
 	ctrl := message.New().AsControl()

--- a/transform/utility_delay.go
+++ b/transform/utility_delay.go
@@ -15,6 +15,8 @@ import (
 type utilityDelayConfig struct {
 	// Duration is the amount of time to delay.
 	Duration string `json:"duration"`
+
+	ID string `json:"id"`
 }
 
 func (c *utilityDelayConfig) Decode(in interface{}) error {
@@ -32,16 +34,20 @@ func (c *utilityDelayConfig) Validate() error {
 func newUtilityDelay(_ context.Context, cfg config.Config) (*utilityDelay, error) {
 	conf := utilityDelayConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: utility_delay: %v", err)
+		return nil, fmt.Errorf("transform utility_delay: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "utility_delay"
 	}
 
 	if err := conf.Validate(); err != nil {
-		return nil, fmt.Errorf("transform: utility_delay: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	dur, err := time.ParseDuration(conf.Duration)
 	if err != nil {
-		return nil, fmt.Errorf("transform: utility_delay: duration: %v", err)
+		return nil, fmt.Errorf("transform %s: duration: %v", conf.ID, err)
 	}
 
 	tf := utilityDelay{

--- a/transform/utility_drop.go
+++ b/transform/utility_drop.go
@@ -10,7 +10,9 @@ import (
 	"github.com/brexhq/substation/message"
 )
 
-type utilityDropConfig struct{}
+type utilityDropConfig struct {
+	ID string `json:"id"`
+}
 
 func (c *utilityDropConfig) Decode(in interface{}) error {
 	return iconfig.Decode(in, c)
@@ -19,7 +21,11 @@ func (c *utilityDropConfig) Decode(in interface{}) error {
 func newUtilityDrop(_ context.Context, cfg config.Config) (*utilityDrop, error) {
 	conf := utilityDropConfig{}
 	if err := iconfig.Decode(cfg.Settings, &conf); err != nil {
-		return nil, fmt.Errorf("transform: utility_drop: %v", err)
+		return nil, fmt.Errorf("transform utility_drop: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "utility_drop"
 	}
 
 	tf := utilityDrop{

--- a/transform/utility_err.go
+++ b/transform/utility_err.go
@@ -13,6 +13,8 @@ import (
 type utilityErrConfig struct {
 	// Message is the error message to return.
 	Message string `json:"message"`
+
+	ID string `json:"id"`
 }
 
 func (c *utilityErrConfig) Decode(in interface{}) error {
@@ -22,7 +24,11 @@ func (c *utilityErrConfig) Decode(in interface{}) error {
 func newUtilityErr(_ context.Context, cfg config.Config) (*utilityErr, error) {
 	conf := utilityErrConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: utility_err: %v", err)
+		return nil, fmt.Errorf("transform utility_err: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "utility_err"
 	}
 
 	tf := utilityErr{

--- a/transform/utility_metric_bytes.go
+++ b/transform/utility_metric_bytes.go
@@ -14,6 +14,8 @@ import (
 
 type utilityMetricBytesConfig struct {
 	Metric iconfig.Metric `json:"metric"`
+
+	ID string `json:"id"`
 }
 
 func (c *utilityMetricBytesConfig) Decode(in interface{}) error {
@@ -24,12 +26,16 @@ func newUtilityMetricBytes(ctx context.Context, cfg config.Config) (*utilityMetr
 	// conf gets validated when calling metrics.New.
 	conf := utilityMetricBytesConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: utility_metric_bytes: %v", err)
+		return nil, fmt.Errorf("transform utility_metric_bytes: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "utility_metric_bytes"
 	}
 
 	m, err := metrics.New(ctx, conf.Metric.Destination)
 	if err != nil {
-		return nil, fmt.Errorf("transform: utility_metric_bytes: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	tf := utilityMetricBytes{
@@ -54,7 +60,7 @@ func (tf *utilityMetricBytes) Transform(ctx context.Context, msg *message.Messag
 			Value:      tf.bytes,
 			Attributes: tf.conf.Metric.Attributes,
 		}); err != nil {
-			return nil, fmt.Errorf("transform: utility_metric_bytes: %v", err)
+			return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 		}
 
 		atomic.StoreUint32(&tf.bytes, 0)

--- a/transform/utility_metric_count.go
+++ b/transform/utility_metric_count.go
@@ -14,6 +14,8 @@ import (
 
 type utilityMetricsCountConfig struct {
 	Metric iconfig.Metric `json:"metric"`
+
+	ID string `json:"id"`
 }
 
 func (c *utilityMetricsCountConfig) Decode(in interface{}) error {
@@ -24,12 +26,16 @@ func newUtilityMetricCount(ctx context.Context, cfg config.Config) (*utilityMetr
 	// conf gets validated when calling metrics.New.
 	conf := utilityMetricsCountConfig{}
 	if err := conf.Decode(cfg.Settings); err != nil {
-		return nil, fmt.Errorf("transform: utility_metric_count: %v", err)
+		return nil, fmt.Errorf("transform utility_metric_count: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "utility_metric_count"
 	}
 
 	m, err := metrics.New(ctx, conf.Metric.Destination)
 	if err != nil {
-		return nil, fmt.Errorf("transform: utility_metric_count: %v", err)
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
 	}
 
 	tf := utilityMetricsCount{
@@ -54,7 +60,7 @@ func (tf *utilityMetricsCount) Transform(ctx context.Context, msg *message.Messa
 			Value:      tf.count,
 			Attributes: tf.conf.Metric.Attributes,
 		}); err != nil {
-			return nil, fmt.Errorf("transform: utility_metric_count: %v", err)
+			return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 		}
 
 		atomic.StoreUint32(&tf.count, 0)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Adds an `ID` field to all transform settings and updates error messages to use auto-generated IDs

<!--- Describe your changes in detail -->

## Motivation and Context

Identifying the location of errors in large config files is a challenge due to the high reuse of transform functions and existing error message format (`transform: foo: err goes here`), but this is easier when there is a way to uniquely identify each transform. 

This PR makes these types of error message possible (where `foo` is the transform function):
- `transform foo: err goes here` (this happens if the transform is not configurable or if the ID field value is missing)
- `transform my-unique-foo: err goes here` (this is an ID configured by the user)
- `transform 5f4ae672-6b9cc21d: err goes here` (this is an ID auto-generated by the app)

Users who do nothing will start to see auto-gen IDs in places where they used to see transform function names. In the future a pseudo-random default ID would be preferred, but Jsonnet doesn't have any functions to support that. 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Tested locally (this can be seen by building any existing configs).

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
