### PR TITLE
feat(condition): Add Number Greater Than Inspector

### DIFF
--- a/build/config/substation.libsonnet
+++ b/build/config/substation.libsonnet
@@ -24,6 +24,17 @@
     },
     num: $.condition.number,
     number: {
+      default: {
+        object: $.config.object,
+        value: null,
+      },
+      gt(settings={}): $.condition.number.greater_than(settings=settings),
+      greater_than(settings={}): {
+        local default = $.condition.number.default,
+
+        type: 'number_greater_than',
+        settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
+      },
       bitwise: {
         and(settings={}): {
           local default = {

--- a/build/config/substation_test.jsonnet
+++ b/build/config/substation_test.jsonnet
@@ -7,6 +7,11 @@ local transform = sub.transform.object.copy(settings={ obj: { src: src, trg: trg
 local inspector = sub.condition.format.json();
 
 {
+  condition: {
+    number: {
+      greater_than: sub.condition.number.greater_than({obj: {src: src}, value: 1}),
+    }
+  },
   transform: {
     send: {
       http: {

--- a/condition/condition.go
+++ b/condition/condition.go
@@ -58,6 +58,8 @@ func newInspector(ctx context.Context, cfg config.Config) (inspector, error) { /
 	case "network_ip_valid":
 		return newNetworkIPValid(ctx, cfg)
 	// Number inspectors.
+	case "number_greater_than":
+		return newNumberGreaterThan(ctx, cfg)
 	case "number_bitwise_and":
 		return newNumberBitwiseAND(ctx, cfg)
 	case "number_bitwise_or":

--- a/condition/condition.go
+++ b/condition/condition.go
@@ -24,7 +24,7 @@ type inspector interface {
 }
 
 // newInspector returns a configured Inspector from an Inspector configuration.
-func newInspector(ctx context.Context, cfg config.Config) (inspector, error) { //nolint: cyclop // ignore cyclomatic complexity
+func newInspector(ctx context.Context, cfg config.Config) (inspector, error) { //nolint: cyclop, gocyclo // ignore cyclomatic complexity
 	switch cfg.Type {
 	// Format inspectors.
 	case "format_mime":

--- a/condition/number.go
+++ b/condition/number.go
@@ -49,3 +49,14 @@ func numberLengthMeasurement(b []byte, measurement string) int {
 		return len(b)
 	}
 }
+
+type numberConfig struct {
+	// Value used for comparison during inspection.
+	Value float64 `json:"value"`
+
+	Object iconfig.Object `json:"object"`
+}
+
+func (c *numberConfig) Decode(in interface{}) error {
+	return iconfig.Decode(in, c)
+}

--- a/condition/number_greater_than.go
+++ b/condition/number_greater_than.go
@@ -1,0 +1,54 @@
+package condition
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+
+	"github.com/brexhq/substation/config"
+	"github.com/brexhq/substation/message"
+)
+
+func newNumberGreaterThan(_ context.Context, cfg config.Config) (*numberGreaterThan, error) {
+	conf := numberConfig{}
+	if err := conf.Decode(cfg.Settings); err != nil {
+		return nil, err
+	}
+
+	insp := numberGreaterThan{
+		conf: conf,
+	}
+
+	return &insp, nil
+}
+
+type numberGreaterThan struct {
+	conf numberConfig
+}
+
+func (insp *numberGreaterThan) Inspect(ctx context.Context, msg *message.Message) (output bool, err error) {
+	if msg.IsControl() {
+		return false, nil
+	}
+
+	if insp.conf.Object.SourceKey == "" {
+		f, err := strconv.ParseFloat(string(msg.Data()), 64)
+		if err != nil {
+			return false, err
+		}
+
+		return insp.match(f), nil
+	}
+
+	v := msg.GetValue(insp.conf.Object.SourceKey)
+	return insp.match(v.Float()), nil
+}
+
+func (c *numberGreaterThan) match(length float64) bool {
+	return length > c.conf.Value
+}
+
+func (c *numberGreaterThan) String() string {
+	b, _ := json.Marshal(c.conf)
+	return string(b)
+}

--- a/condition/number_greater_than.go
+++ b/condition/number_greater_than.go
@@ -44,8 +44,8 @@ func (insp *numberGreaterThan) Inspect(ctx context.Context, msg *message.Message
 	return insp.match(v.Float()), nil
 }
 
-func (c *numberGreaterThan) match(length float64) bool {
-	return length > c.conf.Value
+func (c *numberGreaterThan) match(f float64) bool {
+	return f > c.conf.Value
 }
 
 func (c *numberGreaterThan) String() string {

--- a/condition/number_greater_than_test.go
+++ b/condition/number_greater_than_test.go
@@ -16,6 +16,7 @@ var numberGreaterThanTests = []struct {
 	test     []byte
 	expected bool
 }{
+	// Integers
 	{
 		"pass",
 		config.Config{
@@ -57,6 +58,50 @@ var numberGreaterThanTests = []struct {
 		config.Config{
 			Settings: map[string]interface{}{
 				"value": 10,
+			},
+		},
+		[]byte(`1`),
+		false,
+	},
+	// Floats
+	{
+		"pass",
+		config.Config{
+			Settings: map[string]interface{}{
+				"value": 1,
+			},
+		},
+		[]byte(`1.5`),
+		true,
+	},
+	{
+		"pass",
+		config.Config{
+			Settings: map[string]interface{}{
+				"value": 1.1,
+			},
+		},
+		[]byte(`1.5`),
+		true,
+	},
+	{
+		"fail",
+		config.Config{
+			Settings: map[string]interface{}{
+				"object": map[string]interface{}{
+					"source_key": "foo",
+				},
+				"value": 1.5,
+			},
+		},
+		[]byte(`{"foo":1.1}`),
+		false,
+	},
+	{
+		"fail",
+		config.Config{
+			Settings: map[string]interface{}{
+				"value": 1.5,
 			},
 		},
 		[]byte(`1`),

--- a/condition/number_greater_than_test.go
+++ b/condition/number_greater_than_test.go
@@ -1,0 +1,113 @@
+package condition
+
+import (
+	"context"
+	"testing"
+
+	"github.com/brexhq/substation/config"
+	"github.com/brexhq/substation/message"
+)
+
+var _ inspector = &numberGreaterThan{}
+
+var numberGreaterThanTests = []struct {
+	name     string
+	cfg      config.Config
+	test     []byte
+	expected bool
+}{
+	{
+		"pass",
+		config.Config{
+			Settings: map[string]interface{}{
+				"object": map[string]interface{}{
+					"source_key": "foo",
+				},
+				"value": 1,
+			},
+		},
+		[]byte(`{"foo":10}`),
+		true,
+	},
+	{
+		"pass",
+		config.Config{
+			Settings: map[string]interface{}{
+				"value": 1,
+			},
+		},
+		[]byte(`10`),
+		true,
+	},
+	{
+		"fail",
+		config.Config{
+			Settings: map[string]interface{}{
+				"object": map[string]interface{}{
+					"source_key": "foo",
+				},
+				"value": 10,
+			},
+		},
+		[]byte(`{"foo":1}`),
+		false,
+	},
+	{
+		"fail",
+		config.Config{
+			Settings: map[string]interface{}{
+				"value": 10,
+			},
+		},
+		[]byte(`1`),
+		false,
+	},
+}
+
+func TestNumberGreaterThan(t *testing.T) {
+	ctx := context.TODO()
+
+	for _, test := range numberGreaterThanTests {
+		t.Run(test.name, func(t *testing.T) {
+			message := message.New().SetData(test.test)
+			insp, err := newNumberGreaterThan(ctx, test.cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			check, err := insp.Inspect(ctx, message)
+			if err != nil {
+				t.Error(err)
+			}
+
+			if test.expected != check {
+				t.Errorf("expected %v, got %v", test.expected, check)
+				t.Errorf("settings: %+v", test.cfg)
+				t.Errorf("test: %+v", string(test.test))
+			}
+		})
+	}
+}
+
+func benchmarkNumberGreaterThan(b *testing.B, insp *numberGreaterThan, message *message.Message) {
+	ctx := context.TODO()
+	for i := 0; i < b.N; i++ {
+		_, _ = insp.Inspect(ctx, message)
+	}
+}
+
+func BenchmarkNumberGreaterThan(b *testing.B) {
+	for _, test := range numberGreaterThanTests {
+		insp, err := newNumberGreaterThan(context.TODO(), test.cfg)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		b.Run(test.name,
+			func(b *testing.B) {
+				message := message.New().SetData(test.test)
+				benchmarkNumberGreaterThan(b, insp, message)
+			},
+		)
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Adds `number_greater_than` inspector

<!--- Describe your changes in detail -->

## Motivation and Context

This is for comparing a number's value, which is currently only possible using the `string_match` function like this:
```jsonnet
sub.cnd.str.match({ object: {source_key: 'FIELD'}, pattern: '^[0-9]{4,}$'}),  // 1,000+
```

This inspector is simpler to understand:
```jsonnet
sub.cnd.num.greater_than({ object: {source_key: 'FIELD'}, value: 999 }),  // 1,000+
```

The target value type is float64, but this works just as well with integers.

Additional functions can be added later (e.g. `equal_to`, `less_than`). This is nested directly under the `number.*` tree to mimic the naming convention of the `string.*` functions. This probably needs to be considered along with #64, which could either be a new set of nested functions (e.g. `string.compare.equal_to`, `number.compare.less_than`) or be added to existing functions (e.g., if `object.target_key` exists, then it overrides `value`).

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added new unit tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [x] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
