### PR TITLE
feat(condition): Add Number Less Than Inspector

### DIFF
--- a/build/config/substation.libsonnet
+++ b/build/config/substation.libsonnet
@@ -24,6 +24,17 @@
     },
     num: $.condition.number,
     number: {
+      default: {
+      object: $.config.object,
+      value: null,
+      },
+    lt(settings={}): $.condition.number.less_than(settings=settings),
+    less_than(settings={}): {
+          local default = $.condition.number.default,
+
+          type: 'number_equal_to',
+          settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
+      },
       bitwise: {
         and(settings={}): {
           local default = {

--- a/build/config/substation.libsonnet
+++ b/build/config/substation.libsonnet
@@ -32,7 +32,7 @@
     less_than(settings={}): {
           local default = $.condition.number.default,
 
-          type: 'number_equal_to',
+          type: 'number_less_than',
           settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
       },
       bitwise: {

--- a/build/config/substation_test.jsonnet
+++ b/build/config/substation_test.jsonnet
@@ -9,7 +9,7 @@ local inspector = sub.condition.format.json();
 {
   condition: {
     number: {
-      equal_to: sub.condition.number.less_than({obj: {src: src}, value: 1}),
+      less_than: sub.condition.number.less_than({obj: {src: src}, value: 1}),
     }
   },
   transform: {

--- a/build/config/substation_test.jsonnet
+++ b/build/config/substation_test.jsonnet
@@ -7,6 +7,11 @@ local transform = sub.transform.object.copy(settings={ obj: { src: src, trg: trg
 local inspector = sub.condition.format.json();
 
 {
+  condition: {
+    number: {
+      equal_to: sub.condition.number.less_than({obj: {src: src}, value: 1}),
+    }
+  },
   transform: {
     send: {
       http: {

--- a/condition/condition.go
+++ b/condition/condition.go
@@ -58,6 +58,8 @@ func newInspector(ctx context.Context, cfg config.Config) (inspector, error) { /
 	case "network_ip_valid":
 		return newNetworkIPValid(ctx, cfg)
 	// Number inspectors.
+	case "number_less_than":
+		return newNumberLessThan(ctx, cfg)
 	case "number_bitwise_and":
 		return newNumberBitwiseAND(ctx, cfg)
 	case "number_bitwise_or":

--- a/condition/condition.go
+++ b/condition/condition.go
@@ -24,7 +24,7 @@ type inspector interface {
 }
 
 // newInspector returns a configured Inspector from an Inspector configuration.
-func newInspector(ctx context.Context, cfg config.Config) (inspector, error) { //nolint: cyclop // ignore cyclomatic complexity
+func newInspector(ctx context.Context, cfg config.Config) (inspector, error) { //nolint: cyclop, gocyclo // ignore cyclomatic complexity
 	switch cfg.Type {
 	// Format inspectors.
 	case "format_mime":

--- a/condition/number.go
+++ b/condition/number.go
@@ -49,3 +49,14 @@ func numberLengthMeasurement(b []byte, measurement string) int {
 		return len(b)
 	}
 }
+
+type numberConfig struct {
+	// Value used for comparison during inspection.
+	Value float64 `json:"value"`
+
+	Object iconfig.Object `json:"object"`
+}
+
+func (c *numberConfig) Decode(in interface{}) error {
+	return iconfig.Decode(in, c)
+}

--- a/condition/number_less_than.go
+++ b/condition/number_less_than.go
@@ -1,0 +1,51 @@
+package condition
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+
+	"github.com/brexhq/substation/config"
+	"github.com/brexhq/substation/message"
+)
+
+func newNumberLessThan(_ context.Context, cfg config.Config) (*numberLessThan, error) {
+	conf := numberConfig{}
+	if err := conf.Decode(cfg.Settings); err != nil {
+		return nil, err
+	}
+	insp := numberLessThan{
+		conf: conf,
+	}
+	return &insp, nil
+}
+
+type numberLessThan struct {
+	conf numberConfig
+}
+
+func (insp *numberLessThan) Inspect(ctx context.Context, msg *message.Message) (output bool, err error) {
+	if msg.IsControl() {
+		return false, nil
+	}
+
+	if insp.conf.Object.SourceKey == "" {
+		f, err := strconv.ParseFloat(string(msg.Data()), 64)
+		if err != nil {
+			return false, err
+		}
+
+		return insp.match(f), nil
+	}
+	v := msg.GetValue(insp.conf.Object.SourceKey)
+	return insp.match(v.Float()), nil
+}
+
+func (c *numberLessThan) match(f float64) bool {
+	return f < c.conf.Value
+}
+
+func (c *numberLessThan) String() string {
+	b, _ := json.Marshal(c.conf)
+	return string(b)
+}

--- a/condition/number_less_than_test.go
+++ b/condition/number_less_than_test.go
@@ -1,0 +1,158 @@
+package condition
+
+import (
+	"context"
+	"testing"
+
+	"github.com/brexhq/substation/config"
+	"github.com/brexhq/substation/message"
+)
+
+var _ inspector = &numberLessThan{}
+
+var numberLessThanTests = []struct {
+	name     string
+	cfg      config.Config
+	test     []byte
+	expected bool
+}{
+	// Integers
+	{
+		"pass",
+		config.Config{
+			Settings: map[string]interface{}{
+				"object": map[string]interface{}{
+					"source_key": "foo",
+				},
+				"value": 14,
+			},
+		},
+		[]byte(`{"foo":10}`),
+		true,
+	},
+	{
+		"fail",
+		config.Config{
+			Settings: map[string]interface{}{
+				"value": 1,
+			},
+		},
+		[]byte(`10`),
+		false,
+	},
+	{
+		"pass",
+		config.Config{
+			Settings: map[string]interface{}{
+				"object": map[string]interface{}{
+					"source_key": "foo",
+				},
+				"value": 10,
+			},
+		},
+		[]byte(`{"foo":1}`),
+		true,
+	},
+	{
+		"fail",
+		config.Config{
+			Settings: map[string]interface{}{
+				"value": 5,
+			},
+		},
+		[]byte(`15`),
+		false,
+	},
+	// Floats
+	{
+		"fail",
+		config.Config{
+			Settings: map[string]interface{}{
+				"value": 1,
+			},
+		},
+		[]byte(`1.5`),
+		false,
+	},
+	{
+		"fail",
+		config.Config{
+			Settings: map[string]interface{}{
+				"value": 0.1,
+			},
+		},
+		[]byte(`1.5`),
+		false,
+	},
+	{
+		"pass",
+		config.Config{
+			Settings: map[string]interface{}{
+				"object": map[string]interface{}{
+					"source_key": "foo",
+				},
+				"value": 1.5,
+			},
+		},
+		[]byte(`{"foo":1.1}`),
+		true,
+	},
+	{
+		"pass",
+		config.Config{
+			Settings: map[string]interface{}{
+				"value": 1.5,
+			},
+		},
+		[]byte(`1`),
+		true,
+	},
+}
+
+func TestNumberLessThan(t *testing.T) {
+	ctx := context.TODO()
+
+	for _, test := range numberLessThanTests {
+		t.Run(test.name, func(t *testing.T) {
+			message := message.New().SetData(test.test)
+			insp, err := newNumberLessThan(ctx, test.cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			check, err := insp.Inspect(ctx, message)
+			if err != nil {
+				t.Error(err)
+			}
+
+			if test.expected != check {
+				t.Errorf("expected %v, got %v", test.expected, check)
+				t.Errorf("settings: %+v", test.cfg)
+				t.Errorf("test: %+v", string(test.test))
+			}
+		})
+	}
+}
+
+func benchmarkNumberLessThan(b *testing.B, insp *numberLessThan, message *message.Message) {
+	ctx := context.TODO()
+	for i := 0; i < b.N; i++ {
+		_, _ = insp.Inspect(ctx, message)
+	}
+}
+
+func BenchmarkNumberLessThan(b *testing.B) {
+	for _, test := range numberLessThanTests {
+		insp, err := newNumberLessThan(context.TODO(), test.cfg)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		b.Run(test.name,
+			func(b *testing.B) {
+				message := message.New().SetData(test.test)
+				benchmarkNumberLessThan(b, insp, message)
+			},
+		)
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds `number_less_than` inspector

## Motivation and Context

Ref: https://github.com/brexhq/substation/pull/183

This is for comparing a number's value, which is currently only possible using the string_match function like this:

`sub.cnd.str.match({ object: {source_key: 'FIELD'}, pattern: '^[0-9]{4,}$'}), `

This inspector is simpler to understand:

`sub.cnd.num.less_than({ object: {source_key: 'FIELD'}, value: 999 }),  // < 999`

The target value type is float64, but this works just as well with integers.

## How Has This Been Tested?

Added unit tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [ ] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
