### PR TITLE
feat(condition): Add Number Equal To Inspector

### DIFF
--- a/build/config/substation.libsonnet
+++ b/build/config/substation.libsonnet
@@ -24,6 +24,17 @@
     },
     num: $.condition.number,
     number: {
+      default: {
+        object: $.config.object,
+        value: null,
+        },
+      eq(settings={}): $.condition.number.equal_to(settings=settings),
+      equal_to(settings={}): {
+            local default = $.condition.number.default,
+
+            type: 'number_equal_to',
+            settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
+        },
       bitwise: {
         and(settings={}): {
           local default = {

--- a/build/config/substation_test.jsonnet
+++ b/build/config/substation_test.jsonnet
@@ -7,6 +7,11 @@ local transform = sub.transform.object.copy(settings={ obj: { src: src, trg: trg
 local inspector = sub.condition.format.json();
 
 {
+  condition: {
+    number: {
+      equal_to: sub.condition.number.equal_to({obj: {src: src}, value: 1}),
+    }
+  },
   transform: {
     send: {
       http: {

--- a/condition/condition.go
+++ b/condition/condition.go
@@ -58,6 +58,8 @@ func newInspector(ctx context.Context, cfg config.Config) (inspector, error) { /
 	case "network_ip_valid":
 		return newNetworkIPValid(ctx, cfg)
 	// Number inspectors.
+	case "number_equal_to":
+		return newNumberEqualTo(ctx, cfg)
 	case "number_bitwise_and":
 		return newNumberBitwiseAND(ctx, cfg)
 	case "number_bitwise_or":

--- a/condition/condition.go
+++ b/condition/condition.go
@@ -24,7 +24,7 @@ type inspector interface {
 }
 
 // newInspector returns a configured Inspector from an Inspector configuration.
-func newInspector(ctx context.Context, cfg config.Config) (inspector, error) { //nolint: cyclop // ignore cyclomatic complexity
+func newInspector(ctx context.Context, cfg config.Config) (inspector, error) { //nolint: cyclop, gocyclo // ignore cyclomatic complexity
 	switch cfg.Type {
 	// Format inspectors.
 	case "format_mime":

--- a/condition/number.go
+++ b/condition/number.go
@@ -49,3 +49,14 @@ func numberLengthMeasurement(b []byte, measurement string) int {
 		return len(b)
 	}
 }
+
+type numberConfig struct {
+	// Value used for comparison during inspection.
+	Value float64 `json:"value"`
+
+	Object iconfig.Object `json:"object"`
+}
+
+func (c *numberConfig) Decode(in interface{}) error {
+	return iconfig.Decode(in, c)
+}

--- a/condition/number_equal_to.go
+++ b/condition/number_equal_to.go
@@ -42,7 +42,7 @@ func (insp *numberEqualTo) Inspect(ctx context.Context, msg *message.Message) (o
 }
 
 func (c *numberEqualTo) match(f float64) bool {
-	return f < c.conf.Value
+	return f == c.conf.Value
 }
 
 func (c *numberEqualTo) String() string {

--- a/condition/number_equal_to.go
+++ b/condition/number_equal_to.go
@@ -1,0 +1,51 @@
+package condition
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+
+	"github.com/brexhq/substation/config"
+	"github.com/brexhq/substation/message"
+)
+
+func newNumberEqualTo(_ context.Context, cfg config.Config) (*numberEqualTo, error) {
+	conf := numberConfig{}
+	if err := conf.Decode(cfg.Settings); err != nil {
+		return nil, err
+	}
+	insp := numberEqualTo{
+		conf: conf,
+	}
+	return &insp, nil
+}
+
+type numberEqualTo struct {
+	conf numberConfig
+}
+
+func (insp *numberEqualTo) Inspect(ctx context.Context, msg *message.Message) (output bool, err error) {
+	if msg.IsControl() {
+		return false, nil
+	}
+
+	if insp.conf.Object.SourceKey == "" {
+		f, err := strconv.ParseFloat(string(msg.Data()), 64)
+		if err != nil {
+			return false, err
+		}
+
+		return insp.match(f), nil
+	}
+	v := msg.GetValue(insp.conf.Object.SourceKey)
+	return insp.match(v.Float()), nil
+}
+
+func (c *numberEqualTo) match(f float64) bool {
+	return f < c.conf.Value
+}
+
+func (c *numberEqualTo) String() string {
+	b, _ := json.Marshal(c.conf)
+	return string(b)
+}

--- a/condition/number_equal_to_test.go
+++ b/condition/number_equal_to_test.go
@@ -27,17 +27,17 @@ var numberEqualToTests = []struct {
 				"value": 14,
 			},
 		},
-		[]byte(`{"foo":10}`),
+		[]byte(`{"foo":14}`),
 		true,
 	},
 	{
 		"fail",
 		config.Config{
 			Settings: map[string]interface{}{
-				"value": 1,
+				"value": 10,
 			},
 		},
-		[]byte(`10`),
+		[]byte(`1`),
 		false,
 	},
 	{
@@ -47,10 +47,10 @@ var numberEqualToTests = []struct {
 				"object": map[string]interface{}{
 					"source_key": "foo",
 				},
-				"value": 10,
+				"value": 0,
 			},
 		},
-		[]byte(`{"foo":1}`),
+		[]byte(`{"foo":0}`),
 		true,
 	},
 	{
@@ -91,7 +91,7 @@ var numberEqualToTests = []struct {
 				"object": map[string]interface{}{
 					"source_key": "foo",
 				},
-				"value": 1.5,
+				"value": 1.1,
 			},
 		},
 		[]byte(`{"foo":1.1}`),
@@ -101,10 +101,10 @@ var numberEqualToTests = []struct {
 		"pass",
 		config.Config{
 			Settings: map[string]interface{}{
-				"value": 1.5,
+				"value": 1.4,
 			},
 		},
-		[]byte(`1`),
+		[]byte(`1.4`),
 		true,
 	},
 }

--- a/condition/number_equal_to_test.go
+++ b/condition/number_equal_to_test.go
@@ -1,0 +1,158 @@
+package condition
+
+import (
+	"context"
+	"testing"
+
+	"github.com/brexhq/substation/config"
+	"github.com/brexhq/substation/message"
+)
+
+var _ inspector = &numberEqualTo{}
+
+var numberEqualToTests = []struct {
+	name     string
+	cfg      config.Config
+	test     []byte
+	expected bool
+}{
+	// Integers
+	{
+		"pass",
+		config.Config{
+			Settings: map[string]interface{}{
+				"object": map[string]interface{}{
+					"source_key": "foo",
+				},
+				"value": 14,
+			},
+		},
+		[]byte(`{"foo":10}`),
+		true,
+	},
+	{
+		"fail",
+		config.Config{
+			Settings: map[string]interface{}{
+				"value": 1,
+			},
+		},
+		[]byte(`10`),
+		false,
+	},
+	{
+		"pass",
+		config.Config{
+			Settings: map[string]interface{}{
+				"object": map[string]interface{}{
+					"source_key": "foo",
+				},
+				"value": 10,
+			},
+		},
+		[]byte(`{"foo":1}`),
+		true,
+	},
+	{
+		"fail",
+		config.Config{
+			Settings: map[string]interface{}{
+				"value": 5,
+			},
+		},
+		[]byte(`15`),
+		false,
+	},
+	// Floats
+	{
+		"fail",
+		config.Config{
+			Settings: map[string]interface{}{
+				"value": 1,
+			},
+		},
+		[]byte(`1.5`),
+		false,
+	},
+	{
+		"fail",
+		config.Config{
+			Settings: map[string]interface{}{
+				"value": 0.1,
+			},
+		},
+		[]byte(`1.5`),
+		false,
+	},
+	{
+		"pass",
+		config.Config{
+			Settings: map[string]interface{}{
+				"object": map[string]interface{}{
+					"source_key": "foo",
+				},
+				"value": 1.5,
+			},
+		},
+		[]byte(`{"foo":1.1}`),
+		true,
+	},
+	{
+		"pass",
+		config.Config{
+			Settings: map[string]interface{}{
+				"value": 1.5,
+			},
+		},
+		[]byte(`1`),
+		true,
+	},
+}
+
+func TestNumberEqualTo(t *testing.T) {
+	ctx := context.TODO()
+
+	for _, test := range numberEqualToTests {
+		t.Run(test.name, func(t *testing.T) {
+			message := message.New().SetData(test.test)
+			insp, err := newNumberEqualTo(ctx, test.cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			check, err := insp.Inspect(ctx, message)
+			if err != nil {
+				t.Error(err)
+			}
+
+			if test.expected != check {
+				t.Errorf("expected %v, got %v", test.expected, check)
+				t.Errorf("settings: %+v", test.cfg)
+				t.Errorf("test: %+v", string(test.test))
+			}
+		})
+	}
+}
+
+func benchmarkNumberEqualTo(b *testing.B, insp *numberEqualTo, message *message.Message) {
+	ctx := context.TODO()
+	for i := 0; i < b.N; i++ {
+		_, _ = insp.Inspect(ctx, message)
+	}
+}
+
+func BenchmarkNumberEqualTo(b *testing.B) {
+	for _, test := range numberEqualToTests {
+		insp, err := newNumberEqualTo(context.TODO(), test.cfg)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		b.Run(test.name,
+			func(b *testing.B) {
+				message := message.New().SetData(test.test)
+				benchmarkNumberEqualTo(b, insp, message)
+			},
+		)
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds `number_equal_to` inspector

## Motivation and Context

Ref: https://github.com/brexhq/substation/pull/183

This is for comparing a number's value, which is currently only possible using the string_match function like this:

`sub.cnd.str.match({ object: {source_key: 'FIELD'}, pattern: '^[0-9]{4,}$'}), `

This inspector is simpler to understand:

`sub.cnd.num.equal_to({ object: {source_key: 'FIELD'}, value: 999 }),  // 999`

The target value type is float64, but this works just as well with integers.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [x] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
