### PR TITLE
fix(config): updated type for drop transform

### DIFF
--- a/build/config/substation.libsonnet
+++ b/build/config/substation.libsonnet
@@ -1139,7 +1139,7 @@
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
       },
       drop(settings={}): {
-        local type = 'utility_delay',
+        local type = 'utility_drop',
         local default = {
           id: $.helpers.id(type, settings),
         },


### PR DESCRIPTION
Fixed 'type' attribute of drop transform to `utility_drop` instead of `utility_delay`.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [ ] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
