### PR TITLE
Fix: Update go-retryablehttp to v0.7.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/awslabs/kinesis-aggregation/go v0.0.0-20230808105340-e631fe742486
 	github.com/golang/protobuf v1.5.3
 	github.com/google/uuid v1.6.0
-	github.com/hashicorp/go-retryablehttp v0.7.5
+	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/iancoleman/strcase v0.3.0
 	github.com/itchyny/gojq v0.12.14
 	github.com/klauspost/compress v1.17.7


### PR DESCRIPTION
Update go-retryablehttp to v0.7.7. 

## Motivation and Context

This came up as a dependabot alert for: https://github.com/advisories/GHSA-v6v8-xj6m-xwqh

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [ ] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
