### PR TITLE
docs: Add Example Dev App for Reading from a Kinesis Data Stream

### DIFF
--- a/cmd/README.md
+++ b/cmd/README.md
@@ -6,10 +6,6 @@ This directory contains applications that run Substation. Applications are organ
 
 Applications that run on AWS Lambda.
 
-## client/
-
-Applications that run on a client machine.
-
 ## development/
 
 Applications that are used for development.

--- a/cmd/development/kinesis-tap/substation/README.md
+++ b/cmd/development/kinesis-tap/substation/README.md
@@ -1,0 +1,52 @@
+# kinesis-tap/substation
+
+`kinesis-tap` is a tool for tapping into and transforming data from an AWS Kinesis Data Stream in real-time with Substation.
+
+This is intended as a Substation development aid, but it has other uses as well, such as:
+- Previewing live data in a stream by printing it to the console (default behavior)
+- Sampling live data from a stream and saving it to a local file
+- Forwarding live data between data pipeline stages for testing
+
+Warning: This is a development tool intended to provide temporary access to live data in a Kinesis Data Stream; if you need to process data from a Kinesis Data Stream with strict reliability guarantees, use the [AWS Lambda applications](/cmd/aws/lambda/).
+
+## Usage
+
+```
+% ./substation -h
+Usage of ./substation:
+  -config string
+        The Substation configuration file used to transform records (default "./config.json")
+  -stream-name string
+        The AWS Kinesis Data Stream to fetch records from
+  -stream-offset string
+        Determines the offset of the stream (earliest, latest) (default "earliest")
+```
+
+Use the `SUBSTATION_DEBUG=1` environment variable to enable debug logging:
+```
+% SUBSTATION_DEBUG=1 ./substation -stream-name my-stream
+DEBU[0000] Retrieved active shards from Kinesis stream.  count=2 stream=my-stream
+DEBU[0001] Retrieved records from Kinesis shard.         count=981 shard=0x140004a6f80 stream=my-stream
+DEBU[0002] Retrieved records from Kinesis shard.         count=1055 shard=0x140004a6fe0 stream=my-stream
+DEBU[0003] Retrieved records from Kinesis shard.         count=2333 shard=0x140004a6f80 stream=my-stream
+DEBU[0003] Retrieved records from Kinesis shard.         count=1110 shard=0x140004a6fe0 stream=my-stream
+DEBU[0004] Retrieved records from Kinesis shard.         count=2109 shard=0x140004a6f80 stream=my-stream
+DEBU[0004] Retrieved records from Kinesis shard.         count=1094 shard=0x140004a6fe0 stream=my-stream
+^CDEBU[0004] Closed connections to the Kinesis stream.    
+DEBU[0004] Closed Substation pipeline.                  
+DEBU[0004] Flushed Substation pipeline.
+```
+
+## Build
+
+```
+git clone github.com/brexhq/substation && \
+cd substation/cmd/development/kinesis-tap/substation && \
+go build .
+```
+
+## Authentication
+
+`kinesis-tap` uses the AWS SDK for Go to authenticate with AWS. The SDK uses the same authentication methods as the AWS CLI, so you can use the same environment variables or configuration files to authenticate.
+
+For more information, see the [AWS CLI documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html).

--- a/cmd/development/kinesis-tap/substation/config.jsonnet
+++ b/cmd/development/kinesis-tap/substation/config.jsonnet
@@ -1,0 +1,7 @@
+local sub = import '../../../../build/config/substation.libsonnet';
+
+{
+  transforms: [
+    sub.tf.send.stdout(),
+  ]
+}

--- a/examples/cmd/development/tap_kinesis/substation/main.go
+++ b/examples/cmd/development/tap_kinesis/substation/main.go
@@ -1,0 +1,281 @@
+// Used as a development tool to test Substation configurations against live data
+// by "tapping" an AWS Kinesis stream.
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"runtime"
+	"syscall"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/awslabs/kinesis-aggregation/go/deaggregator"
+	"github.com/brexhq/substation"
+	"github.com/brexhq/substation/internal/aws"
+	"github.com/brexhq/substation/internal/aws/kinesis"
+	"github.com/brexhq/substation/internal/channel"
+	"github.com/brexhq/substation/internal/file"
+	"github.com/brexhq/substation/internal/log"
+	"github.com/brexhq/substation/message"
+)
+
+type options struct {
+	Config string
+
+	// StreamName is the name of the Kinesis stream to read from.
+	StreamName string
+	// StreamOffset is the read offset of the stream (earliest, latest).
+	StreamOffset string
+}
+
+// getConfig contextually retrieves a Substation configuration.
+func getConfig(ctx context.Context, cfg string) (io.Reader, error) {
+	path, err := file.Get(ctx, cfg)
+	defer os.Remove(path)
+
+	if err != nil {
+		return nil, err
+	}
+
+	conf, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer conf.Close()
+
+	buf := new(bytes.Buffer)
+	if _, err := io.Copy(buf, conf); err != nil {
+		return nil, err
+	}
+
+	return buf, nil
+}
+
+func main() {
+	var opts options
+
+	flag.StringVar(&opts.Config, "config", "", "The Substation configuration file used to transform records")
+	flag.StringVar(&opts.StreamName, "stream-name", "", "The AWS Kinesis Data Stream to read records from")
+	flag.StringVar(&opts.StreamOffset, "stream-offset", "earliest", "Determines the read offset of the stream (earliest, latest)")
+	flag.Parse()
+
+	if err := run(context.Background(), opts); err != nil {
+		panic(fmt.Errorf("main: %v", err))
+	}
+}
+
+func run(ctx context.Context, opts options) error {
+	// If no config file is provided, then the app prints Kinesis
+	// record data to stdout every 100 records or 5 seconds, whichever
+	// happens first.
+	cfg := substation.Config{}
+	if opts.Config != "" {
+		c, err := getConfig(ctx, opts.Config)
+		if err != nil {
+			return err
+		}
+
+		if err := json.NewDecoder(c).Decode(&cfg); err != nil {
+			return err
+		}
+	} else {
+		c := []byte(`{"transforms":[
+			{
+				"type": "send_stdout",
+				"settings": {
+					"batch": {
+						"count": 100,
+						"duration": "5s"
+					}
+				}
+			}	
+		]}`)
+		if err := json.Unmarshal(c, &cfg); err != nil {
+			panic(err)
+		}
+	}
+
+	sub, err := substation.New(ctx, cfg)
+	if err != nil {
+		return err
+	}
+
+	ch := channel.New[*message.Message]()
+	group, ctx := errgroup.WithContext(ctx)
+
+	// This group is responsible for transforming records using the Substation
+	// configuration. The group finishes when the channel is closed and all
+	// messages have been processed, including flushing the pipeline with a ctrl
+	// message.
+	group.Go(func() error {
+		defer log.Info("Closing Substation transforms.")
+
+		tfGroup, tfCtx := errgroup.WithContext(ctx)
+		tfGroup.SetLimit(runtime.NumCPU())
+
+		for message := range ch.Recv() {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
+
+			msg := message
+			tfGroup.Go(func() error {
+				if _, err := sub.Transform(tfCtx, msg); err != nil {
+					return err
+				}
+
+				return nil
+			})
+		}
+
+		if err := tfGroup.Wait(); err != nil {
+			return err
+		}
+
+		// ctrl messages flush the pipeline. This must be done
+		// after all messages have been processed.
+		ctrl := message.New().AsControl()
+		if _, err := sub.Transform(tfCtx, ctrl); err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	// This group is responsible for retrieving records from the Kinesis stream.
+	//
+	// When the user sends a SIGINT signal (CTRL+C in the terminal) to the app,
+	// the workers in this group are interrupted by cancelling the context. This
+	// allows the app to gracefully shutdown by continuing to process in-progress
+	// messages until the channel is empty (see the transform group above).
+	group.Go(func() error {
+		defer ch.Close() // Producing goroutines must close the channel when they are done.
+
+		// The client uses settings from environment variables.
+		//
+		// This can be made configurable in the future.
+		client := kinesis.API{}
+		client.Setup(aws.Config{})
+
+		ctx, cancel := signal.NotifyContext(ctx, syscall.SIGINT)
+		defer cancel()
+
+		recvGroup, recvCtx := errgroup.WithContext(ctx)
+		defer log.Info("Closing connections to the Kinesis stream.")
+
+		res, err := client.ListShards(ctx, opts.StreamName)
+		if err != nil {
+			return err
+		}
+
+		log.WithField("stream", opts.StreamName).WithField("count", len(res.Shards)).Info("Retrieved active shards from Kinesis stream.")
+
+		// This iterates over a snapshot of active shards in the stream and will not
+		// be updated if shard changes (opened, closed) occur. New shards can be identified
+		// in the response from GetRecords.
+		//
+		// Reminder that this is a development tool and is not meant for production use.
+
+		var iType string
+		switch opts.StreamOffset {
+		case "earliest":
+			iType = "TRIM_HORIZON"
+		case "latest":
+			iType = "LATEST"
+		default:
+			return fmt.Errorf("invalid offset: %s", opts.StreamOffset)
+		}
+
+		for _, shard := range res.Shards {
+			iterator, err := client.GetShardIterator(ctx, opts.StreamName, *shard.ShardId, iType)
+			if err != nil {
+				return err
+			}
+
+			recvGroup.Go(func() error {
+				shardIterator := *iterator.ShardIterator
+
+				for {
+					select {
+					case <-ctx.Done():
+						return ctx.Err()
+					default:
+					}
+
+					res, err := client.GetRecords(recvCtx, shardIterator)
+					if err != nil {
+						return err
+					}
+
+					// This paginates through the shard until it's closed.
+					if res.NextShardIterator == nil {
+						log.WithField("stream", opts.StreamName).WithField("shard", shard.ShardId).Debug("Reached end of Kinesis shard.")
+
+						break
+					} else {
+						shardIterator = *res.NextShardIterator
+					}
+
+					log.WithField("stream", opts.StreamName).WithField("shard", shard.ShardId).WithField("count", len(res.Records)).Debug("Retrieved records from Kinesis shard.")
+
+					if len(res.Records) == 0 {
+						// GetRecords has a limit of 5 transactions per second
+						// per shard. This sleep is configured to not overload
+						// the API, in case other consumers are reading from the
+						// same shard.
+						//
+						// This can be made configurable in the future.
+						time.Sleep(500 * time.Millisecond)
+
+						continue
+					}
+
+					deaggregated, err := deaggregator.DeaggregateRecords(res.Records)
+					if err != nil {
+						return err
+					}
+
+					log.WithField("stream", opts.StreamName).WithField("shard", shard.ShardId).WithField("count", len(deaggregated)).Debug("Parsed deaggregated records from Kinesis shard.")
+
+					for _, record := range deaggregated {
+						msg := message.New().SetData(record.Data)
+						ch.Send(msg)
+					}
+				}
+
+				return nil
+			})
+		}
+
+		// AWS errors are expected when the context is cancelled
+		// by the user. All other errors are unexpected and returned
+		// to the caller.
+		if err := recvGroup.Wait(); err != nil {
+			if _, ok := err.(awserr.Error); ok {
+				return nil
+			}
+
+			return err
+		}
+
+		return nil
+	})
+
+	// Wait for all goroutines to complete.
+	if err := group.Wait(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/aws/kinesis/kinesis.go
+++ b/internal/aws/kinesis/kinesis.go
@@ -170,6 +170,29 @@ func (a *API) IsEnabled() bool {
 	return a.Client != nil
 }
 
+// ListShards wraps the ListShardsWithContext API.
+func (a *API) ListShards(ctx aws.Context, stream string) (*kinesis.ListShardsOutput, error) {
+	return a.Client.ListShardsWithContext(ctx, &kinesis.ListShardsInput{
+		StreamName: aws.String(stream),
+	})
+}
+
+// GetShardIterator wraps the GetShardIteratorWithContext API.
+func (a *API) GetShardIterator(ctx aws.Context, stream, shard, iteratorType string) (*kinesis.GetShardIteratorOutput, error) {
+	return a.Client.GetShardIteratorWithContext(ctx, &kinesis.GetShardIteratorInput{
+		ShardId:           aws.String(shard),
+		ShardIteratorType: aws.String(iteratorType),
+		StreamName:        aws.String(stream),
+	})
+}
+
+// GetRecords wraps the GetRecordsWithContext API.
+func (a *API) GetRecords(ctx aws.Context, iterator string) (*kinesis.GetRecordsOutput, error) {
+	return a.Client.GetRecordsWithContext(ctx, &kinesis.GetRecordsInput{
+		ShardIterator: aws.String(iterator),
+	})
+}
+
 // PutRecords is a convenience wrapper for putting multiple records into a Kinesis stream.
 func (a *API) PutRecords(ctx aws.Context, stream, partitionKey string, data [][]byte) (*kinesis.PutRecordsOutput, error) {
 	var records []*kinesis.PutRecordsRequestEntry


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- Adds an example development app for tapping an AWS Kinesis Data Stream.

## Motivation and Context

This is useful for testing configurations against live data, but not an app that I think we should commit to maintaining (i.e. tracking with SemVer). It's also an easy way to preview data in a Kinesis Data Stream.

Run this command to preview data in the stream:
```sh
./examples/cmd/development/tap_kinesis/substation -stream-name my-stream
```

Run this command to use a custom configuration:
```sh
./examples/cmd/development/tap_kinesis/substation -stream-name my-stream -config path/to/my/config.json
```

Run this command to choose the stream's offset (defaults to earliest):
```sh
./examples/cmd/development/tap_kinesis/substation -stream-name my-stream -stream-offset latest
```

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

This was tested against several production Kinesis Data Streams. 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
