### PR TITLE
fix(transform): Remove Temporary Files from AWS S3

### DIFF
--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -43,7 +43,6 @@ func Get(ctx context.Context, location string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("get %s: %v", location, err)
 	}
-	defer os.Remove(dst.Name())
 	defer dst.Close()
 
 	if _, err := os.Stat(location); err == nil {

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -43,6 +43,7 @@ func Get(ctx context.Context, location string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("get %s: %v", location, err)
 	}
+	defer os.Remove(dst.Name())
 	defer dst.Close()
 
 	if _, err := os.Stat(location); err == nil {

--- a/transform/send_aws_s3.go
+++ b/transform/send_aws_s3.go
@@ -180,6 +180,7 @@ func (tf *sendAWSS3) send(ctx context.Context, key string) error {
 	if err != nil {
 		return err
 	}
+	defer os.Remove(temp.Name())
 	defer temp.Close()
 
 	data, err := withTransforms(ctx, tf.tforms, tf.agg.Get(key))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Fixes an instance where temporary files are not removed in the AWS S3 send transform

<!--- Describe your changes in detail -->

## Motivation and Context

This was discovered while upgrading a large AWS S3 pipeline, over time files build up in the `/tmp` directory of the Lambda container and cause the application to crash. This only occurs if the size of all files is more than 500 MB, but the error is obvious:

```
{
    "errorMessage": "transform 119330de-398867f3: write /tmp/substation4083518264: no space left on device",
    "errorType": "errorString"
}
```

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Tested E2E in the production data pipeline mentioned above.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
