### PR TITLE
fix(transform): Change Kinesis Payload Limit to MB

### DIFF
--- a/transform/send_aws_kinesis_data_stream.go
+++ b/transform/send_aws_kinesis_data_stream.go
@@ -16,9 +16,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// Records greater than 1 MiB in size cannot be
+// Records greater than 1 MB in size cannot be
 // put into a Kinesis Data Stream.
-const sendAWSKinesisDataStreamMessageSizeLimit = 1024 * 1024 * 1
+const sendAWSKinesisDataStreamMessageSizeLimit = 1000 * 1000
 
 // errSendAWSKinesisDataStreamMessageSizeLimit is returned when data
 // exceeds the Kinesis record size limit. If this error occurs, then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Changes the payload size limit for Kinesis Data Streams from MiB to MB

<!--- Describe your changes in detail -->

## Motivation and Context

Discovered an edge case where the system generated a Kinesis Data Stream payload of more than 5 MB when using the PutRecords API. Changing the limit of each record from 1 MiB (1048576 bytes) to 1 MB (1000000 bytes) fixed the problem. According to the AWS docs, Firehose uses 1 MiB as its message size limit.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Tested E2E in the production data pipeline the bug was discovered in.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
