### PR TITLE
build(config): add ID to conditional pattern

### DIFF
--- a/build/config/substation.libsonnet
+++ b/build/config/substation.libsonnet
@@ -1378,10 +1378,11 @@
       // the condition does not contain a valid operator, then it is assumed
       // to be an ANY operator.
       conditional(condition, transform): {
+        local type = 'meta_switch',
         local c = if std.objectHas(condition, 'type') then { operator: 'any', inspectors: [condition] } else condition,
-
-        type: 'meta_switch',
-        settings: { cases: [{ condition: c, transform: transform }] },
+        
+        type: type,
+        settings: { id: $.helpers.id(type, transform),  cases: [{ condition: c, transform: transform }] },
       },
       fmt: $.pattern.transform.format,
       format: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds the configuration ID in the Substation conditional pattern to locate troublesome configurations from logs.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This was missed during the feature work in #181. Brings feature parity when debugging configurations.

## How Has This Been Tested?

Outputted config.json files now have an `ID` field.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [ ] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
