### PR TITLE
build(scripts): Add Bulk Delete from DynamoDB Script

### DIFF
--- a/build/scripts/aws/dynamodb/bulk_delete_items.py
+++ b/build/scripts/aws/dynamodb/bulk_delete_items.py
@@ -1,7 +1,12 @@
 """
 Bulk delete items from a DynamoDB table.
 
-The file should contain a list of items, in JSON Lines format, to delete.
+The file should contain a list of items, in JSON Lines format, to delete
+and each item must match the schema of the table. For example, the primary
+key of the table is "id":
+    {"id": "1"}
+    {"id": "2"}
+    {"id": "3"}
 
 Example usage:
     python3 bulk_delete_items.py my-table my-file.jsonl

--- a/build/scripts/aws/dynamodb/bulk_delete_items.py
+++ b/build/scripts/aws/dynamodb/bulk_delete_items.py
@@ -7,7 +7,6 @@ Example usage:
     python3 bulk_delete_items.py my-table my-file.jsonl
 """
 
-
 import argparse
 import boto3
 import json

--- a/build/scripts/aws/dynamodb/bulk_delete_items.py
+++ b/build/scripts/aws/dynamodb/bulk_delete_items.py
@@ -2,8 +2,8 @@
 Bulk delete items from a DynamoDB table.
 
 The file should contain a list of items, in JSON Lines format, to delete
-and each item must match the schema of the table. For example, the primary
-key of the table is "id":
+and each item must match the schema of the table. For example, if the 
+primary key of the table is "id" then the file should contain items like:
     {"id": "1"}
     {"id": "2"}
     {"id": "3"}

--- a/build/scripts/aws/dynamodb/bulk_delete_items.py
+++ b/build/scripts/aws/dynamodb/bulk_delete_items.py
@@ -1,0 +1,34 @@
+"""
+Bulk delete items from a DynamoDB table.
+
+The file should contain a list of items, in JSON Lines format, to delete.
+
+Example usage:
+    python3 bulk_delete_items.py my-table my-file.jsonl
+"""
+
+
+import argparse
+import boto3
+import json
+
+DDB = boto3.resource("dynamodb")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Bulk delete items from a DynamoDB table."
+    )
+    parser.add_argument("table_name")
+    parser.add_argument("file")
+    args = parser.parse_args()
+
+    TABLE = DDB.Table(args.table_name)
+    with open(args.file, "rb") as f, TABLE.batch_writer() as batch:
+        for item in f.readlines():
+            item = item.decode("utf-8").strip()
+            batch.delete_item(Key=json.loads(item))
+
+
+if __name__ == "__main__":
+    main()

--- a/build/scripts/aws/dynamodb/bulk_delete_items.py
+++ b/build/scripts/aws/dynamodb/bulk_delete_items.py
@@ -22,8 +22,8 @@ def main():
     parser.add_argument("file")
     args = parser.parse_args()
 
-    TABLE = DDB.Table(args.table_name)
-    with open(args.file, "rb") as f, TABLE.batch_writer() as batch:
+    t = DDB.Table(args.table_name)
+    with open(args.file, "rb") as f, t.batch_writer() as batch:
         for item in f.readlines():
             item = item.decode("utf-8").strip()
             batch.delete_item(Key=json.loads(item))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Adds a Python script to bulk delete items from DynamoDB

<!--- Describe your changes in detail -->

## Motivation and Context

This is useful when you need to bulk delete items from DynamoDB. The JSONL file should contain entries that match the table's schema, like:

```json
{"PK": "abc", "SK":"foo"}
{"PK": "def", "SK":"bar"}
{"PK": "ghi", "SK":"baz"}
```

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Tested against a production DynamoDB table.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
