### PR TITLE
feat(condition): Update conditions to support source and target key comparisons

### DIFF
--- a/condition/number_equal_to.go
+++ b/condition/number_equal_to.go
@@ -30,12 +30,6 @@ func (insp *numberEqualTo) Inspect(ctx context.Context, msg *message.Message) (o
 	}
 	compare := insp.conf.Value
 
-	target := msg.GetValue(insp.conf.Object.TargetKey)
-
-	if target.Exists() {
-		compare = target.Float()
-	}
-
 	if insp.conf.Object.SourceKey == "" {
 		f, err := strconv.ParseFloat(string(msg.Data()), 64)
 		if err != nil {
@@ -43,6 +37,12 @@ func (insp *numberEqualTo) Inspect(ctx context.Context, msg *message.Message) (o
 		}
 
 		return insp.match(f, compare), nil
+	}
+
+	target := msg.GetValue(insp.conf.Object.TargetKey)
+
+	if target.Exists() {
+		compare = target.Float()
 	}
 
 	v := msg.GetValue(insp.conf.Object.SourceKey)

--- a/condition/number_equal_to.go
+++ b/condition/number_equal_to.go
@@ -28,6 +28,13 @@ func (insp *numberEqualTo) Inspect(ctx context.Context, msg *message.Message) (o
 	if msg.IsControl() {
 		return false, nil
 	}
+	compare := insp.conf.Value
+
+	target := msg.GetValue(insp.conf.Object.TargetKey)
+
+	if target.Exists() {
+		compare = target.Float()
+	}
 
 	if insp.conf.Object.SourceKey == "" {
 		f, err := strconv.ParseFloat(string(msg.Data()), 64)
@@ -35,14 +42,15 @@ func (insp *numberEqualTo) Inspect(ctx context.Context, msg *message.Message) (o
 			return false, err
 		}
 
-		return insp.match(f), nil
+		return insp.match(f, compare), nil
 	}
+
 	v := msg.GetValue(insp.conf.Object.SourceKey)
-	return insp.match(v.Float()), nil
+	return insp.match(v.Float(), compare), nil
 }
 
-func (c *numberEqualTo) match(f float64) bool {
-	return f == c.conf.Value
+func (c *numberEqualTo) match(f float64, t float64) bool {
+	return f == t
 }
 
 func (c *numberEqualTo) String() string {

--- a/condition/number_equal_to_test.go
+++ b/condition/number_equal_to_test.go
@@ -107,6 +107,33 @@ var numberEqualToTests = []struct {
 		[]byte(`1.4`),
 		true,
 	},
+	{
+		"pass",
+		config.Config{
+			Settings: map[string]interface{}{
+				"object": map[string]interface{}{
+					"source_key": "foo",
+					"target_key": "bar",
+				},
+			},
+		},
+		[]byte(`{"foo": 10, "bar": 10}`),
+		true,
+	},
+	{
+		"fail",
+		config.Config{
+			Settings: map[string]interface{}{
+				"object": map[string]interface{}{
+					"source_key": "foo",
+					"target_key": "bar",
+				},
+				"value": 100,
+			},
+		},
+		[]byte(`{"foo": 100, "bar": 200}`),
+		false,
+	},
 }
 
 func TestNumberEqualTo(t *testing.T) {

--- a/condition/number_greater_than.go
+++ b/condition/number_greater_than.go
@@ -31,21 +31,29 @@ func (insp *numberGreaterThan) Inspect(ctx context.Context, msg *message.Message
 		return false, nil
 	}
 
+	compare := insp.conf.Value
+
+	target := msg.GetValue(insp.conf.Object.TargetKey)
+
+	if target.Exists() {
+		compare = target.Float()
+	}
+
 	if insp.conf.Object.SourceKey == "" {
 		f, err := strconv.ParseFloat(string(msg.Data()), 64)
 		if err != nil {
 			return false, err
 		}
 
-		return insp.match(f), nil
+		return insp.match(f, compare), nil
 	}
 
 	v := msg.GetValue(insp.conf.Object.SourceKey)
-	return insp.match(v.Float()), nil
+	return insp.match(v.Float(), compare), nil
 }
 
-func (c *numberGreaterThan) match(f float64) bool {
-	return f > c.conf.Value
+func (c *numberGreaterThan) match(f float64, t float64) bool {
+	return f > t
 }
 
 func (c *numberGreaterThan) String() string {

--- a/condition/number_greater_than.go
+++ b/condition/number_greater_than.go
@@ -33,12 +33,6 @@ func (insp *numberGreaterThan) Inspect(ctx context.Context, msg *message.Message
 
 	compare := insp.conf.Value
 
-	target := msg.GetValue(insp.conf.Object.TargetKey)
-
-	if target.Exists() {
-		compare = target.Float()
-	}
-
 	if insp.conf.Object.SourceKey == "" {
 		f, err := strconv.ParseFloat(string(msg.Data()), 64)
 		if err != nil {
@@ -46,6 +40,12 @@ func (insp *numberGreaterThan) Inspect(ctx context.Context, msg *message.Message
 		}
 
 		return insp.match(f, compare), nil
+	}
+
+	target := msg.GetValue(insp.conf.Object.TargetKey)
+
+	if target.Exists() {
+		compare = target.Float()
 	}
 
 	v := msg.GetValue(insp.conf.Object.SourceKey)

--- a/condition/number_greater_than_test.go
+++ b/condition/number_greater_than_test.go
@@ -107,6 +107,33 @@ var numberGreaterThanTests = []struct {
 		[]byte(`1`),
 		false,
 	},
+	{
+		"pass",
+		config.Config{
+			Settings: map[string]interface{}{
+				"object": map[string]interface{}{
+					"source_key": "foo",
+					"target_key": "bar",
+				},
+			},
+		},
+		[]byte(`{"foo": 100, "bar": 10}`),
+		true,
+	},
+	{
+		"fail",
+		config.Config{
+			Settings: map[string]interface{}{
+				"object": map[string]interface{}{
+					"source_key": "foo",
+					"target_key": "bar",
+				},
+				"value": 10,
+			},
+		},
+		[]byte(`{"foo": 100, "bar": 2000}`),
+		false,
+	},
 }
 
 func TestNumberGreaterThan(t *testing.T) {

--- a/condition/number_less_than.go
+++ b/condition/number_less_than.go
@@ -29,20 +29,29 @@ func (insp *numberLessThan) Inspect(ctx context.Context, msg *message.Message) (
 		return false, nil
 	}
 
+	compare := insp.conf.Value
+
+	target := msg.GetValue(insp.conf.Object.TargetKey)
+
+	if target.Exists() {
+		compare = target.Float()
+	}
+
 	if insp.conf.Object.SourceKey == "" {
 		f, err := strconv.ParseFloat(string(msg.Data()), 64)
 		if err != nil {
 			return false, err
 		}
 
-		return insp.match(f), nil
+		return insp.match(f, compare), nil
 	}
+
 	v := msg.GetValue(insp.conf.Object.SourceKey)
-	return insp.match(v.Float()), nil
+	return insp.match(v.Float(), compare), nil
 }
 
-func (c *numberLessThan) match(f float64) bool {
-	return f < c.conf.Value
+func (c *numberLessThan) match(f float64, t float64) bool {
+	return f < t
 }
 
 func (c *numberLessThan) String() string {

--- a/condition/number_less_than.go
+++ b/condition/number_less_than.go
@@ -31,12 +31,6 @@ func (insp *numberLessThan) Inspect(ctx context.Context, msg *message.Message) (
 
 	compare := insp.conf.Value
 
-	target := msg.GetValue(insp.conf.Object.TargetKey)
-
-	if target.Exists() {
-		compare = target.Float()
-	}
-
 	if insp.conf.Object.SourceKey == "" {
 		f, err := strconv.ParseFloat(string(msg.Data()), 64)
 		if err != nil {
@@ -44,6 +38,12 @@ func (insp *numberLessThan) Inspect(ctx context.Context, msg *message.Message) (
 		}
 
 		return insp.match(f, compare), nil
+	}
+
+	target := msg.GetValue(insp.conf.Object.TargetKey)
+
+	if target.Exists() {
+		compare = target.Float()
 	}
 
 	v := msg.GetValue(insp.conf.Object.SourceKey)

--- a/condition/number_less_than_test.go
+++ b/condition/number_less_than_test.go
@@ -107,6 +107,33 @@ var numberLessThanTests = []struct {
 		[]byte(`1`),
 		true,
 	},
+	{
+		"pass",
+		config.Config{
+			Settings: map[string]interface{}{
+				"object": map[string]interface{}{
+					"source_key": "foo",
+					"target_key": "bar",
+				},
+			},
+		},
+		[]byte(`{"foo": 10, "bar": 100}`),
+		true,
+	},
+	{
+		"fail",
+		config.Config{
+			Settings: map[string]interface{}{
+				"object": map[string]interface{}{
+					"source_key": "foo",
+					"target_key": "bar",
+				},
+				"value": 10,
+			},
+		},
+		[]byte(`{"foo": 2, "bar": 1}`),
+		false,
+	},
 }
 
 func TestNumberLessThan(t *testing.T) {

--- a/condition/string_equal_to.go
+++ b/condition/string_equal_to.go
@@ -34,12 +34,20 @@ func (insp *stringEqualTo) Inspect(ctx context.Context, msg *message.Message) (o
 		return false, nil
 	}
 
+	compare := insp.b
+
+	target := msg.GetValue(insp.conf.Object.TargetKey)
+
+	if target.Exists() {
+		compare = target.Bytes()
+	}
+
 	if insp.conf.Object.SourceKey == "" {
-		return bytes.Equal(msg.Data(), insp.b), nil
+		return bytes.Equal(msg.Data(), compare), nil
 	}
 
 	value := msg.GetValue(insp.conf.Object.SourceKey)
-	return bytes.Equal(value.Bytes(), insp.b), nil
+	return bytes.Equal(value.Bytes(), compare), nil
 }
 
 func (c *stringEqualTo) String() string {

--- a/condition/string_equal_to.go
+++ b/condition/string_equal_to.go
@@ -36,14 +36,14 @@ func (insp *stringEqualTo) Inspect(ctx context.Context, msg *message.Message) (o
 
 	compare := insp.b
 
+	if insp.conf.Object.SourceKey == "" {
+		return bytes.Equal(msg.Data(), compare), nil
+	}
+
 	target := msg.GetValue(insp.conf.Object.TargetKey)
 
 	if target.Exists() {
 		compare = target.Bytes()
-	}
-
-	if insp.conf.Object.SourceKey == "" {
-		return bytes.Equal(msg.Data(), compare), nil
 	}
 
 	value := msg.GetValue(insp.conf.Object.SourceKey)

--- a/condition/string_equal_to_test.go
+++ b/condition/string_equal_to_test.go
@@ -46,6 +46,33 @@ var stringEqualToTests = []struct {
 		[]byte("\"\""),
 		true,
 	},
+	{
+		"pass",
+		config.Config{
+			Settings: map[string]interface{}{
+				"object": map[string]interface{}{
+					"source_key": "foo",
+					"target_key": "bar",
+				},
+			},
+		},
+		[]byte(`{"foo":"abc", "bar":"abc"}`),
+		true,
+	},
+	{
+		"fail",
+		config.Config{
+			Settings: map[string]interface{}{
+				"object": map[string]interface{}{
+					"source_key": "foo",
+					"target_key": "bar",
+				},
+				"value": "abc",
+			},
+		},
+		[]byte(`{"foo":"abc", "bar":"def"}`),
+		false,
+	},
 }
 
 func TestStringEqualTo(t *testing.T) {

--- a/condition/string_greater_than.go
+++ b/condition/string_greater_than.go
@@ -34,12 +34,20 @@ func (insp *stringGreaterThan) Inspect(ctx context.Context, msg *message.Message
 		return false, nil
 	}
 
+	compare := insp.b
+
+	target := msg.GetValue(insp.conf.Object.TargetKey)
+
+	if target.Exists() {
+		compare = target.Bytes()
+	}
+
 	if insp.conf.Object.SourceKey == "" {
-		return bytes.Compare(msg.Data(), insp.b) > 0, nil
+		return bytes.Compare(msg.Data(), compare) > 0, nil
 	}
 
 	value := msg.GetValue(insp.conf.Object.SourceKey)
-	return bytes.Compare(value.Bytes(), insp.b) > 0, nil
+	return bytes.Compare(value.Bytes(), compare) > 0, nil
 }
 
 func (c *stringGreaterThan) String() string {

--- a/condition/string_greater_than.go
+++ b/condition/string_greater_than.go
@@ -36,14 +36,14 @@ func (insp *stringGreaterThan) Inspect(ctx context.Context, msg *message.Message
 
 	compare := insp.b
 
+	if insp.conf.Object.SourceKey == "" {
+		return bytes.Compare(msg.Data(), compare) > 0, nil
+	}
+
 	target := msg.GetValue(insp.conf.Object.TargetKey)
 
 	if target.Exists() {
 		compare = target.Bytes()
-	}
-
-	if insp.conf.Object.SourceKey == "" {
-		return bytes.Compare(msg.Data(), compare) > 0, nil
 	}
 
 	value := msg.GetValue(insp.conf.Object.SourceKey)

--- a/condition/string_greater_than_test.go
+++ b/condition/string_greater_than_test.go
@@ -36,6 +36,33 @@ var stringGreaterThanTests = []struct {
 		[]byte(`2023-01-01T00:00:00Z`),
 		true,
 	},
+	{
+		"pass",
+		config.Config{
+			Settings: map[string]interface{}{
+				"object": map[string]interface{}{
+					"source_key": "foo",
+					"target_key": "bar",
+				},
+			},
+		},
+		[]byte(`{"foo":"2023-01-01T00:00:00Z", "bar":"2022-01-01T00:00:00Z"}`),
+		true,
+	},
+	{
+		"fail",
+		config.Config{
+			Settings: map[string]interface{}{
+				"object": map[string]interface{}{
+					"source_key": "foo",
+					"target_key": "bar",
+				},
+				"value": "greetings",
+			},
+		},
+		[]byte(`{"foo":"hello", "bar":"world"}`),
+		false,
+	},
 }
 
 func TestStringGreaterThan(t *testing.T) {

--- a/condition/string_less_than.go
+++ b/condition/string_less_than.go
@@ -34,12 +34,20 @@ func (insp *stringLessThan) Inspect(ctx context.Context, msg *message.Message) (
 		return false, nil
 	}
 
+	compare := insp.b
+
+	target := msg.GetValue(insp.conf.Object.TargetKey)
+
+	if target.Exists() {
+		compare = target.Bytes()
+	}
+
 	if insp.conf.Object.SourceKey == "" {
-		return bytes.Compare(msg.Data(), insp.b) < 0, nil
+		return bytes.Compare(msg.Data(), compare) < 0, nil
 	}
 
 	value := msg.GetValue(insp.conf.Object.SourceKey)
-	return bytes.Compare(value.Bytes(), insp.b) < 0, nil
+	return bytes.Compare(value.Bytes(), compare) < 0, nil
 }
 
 func (c *stringLessThan) String() string {

--- a/condition/string_less_than.go
+++ b/condition/string_less_than.go
@@ -36,14 +36,13 @@ func (insp *stringLessThan) Inspect(ctx context.Context, msg *message.Message) (
 
 	compare := insp.b
 
+	if insp.conf.Object.SourceKey == "" {
+		return bytes.Compare(msg.Data(), compare) < 0, nil
+	}
 	target := msg.GetValue(insp.conf.Object.TargetKey)
 
 	if target.Exists() {
 		compare = target.Bytes()
-	}
-
-	if insp.conf.Object.SourceKey == "" {
-		return bytes.Compare(msg.Data(), compare) < 0, nil
 	}
 
 	value := msg.GetValue(insp.conf.Object.SourceKey)

--- a/condition/string_less_than_test.go
+++ b/condition/string_less_than_test.go
@@ -36,6 +36,33 @@ var stringLessThanTests = []struct {
 		[]byte(`2023-01-01T00:00:00Z`),
 		true,
 	},
+	{
+		"pass",
+		config.Config{
+			Settings: map[string]interface{}{
+				"object": map[string]interface{}{
+					"source_key": "foo",
+					"target_key": "bar",
+				},
+			},
+		},
+		[]byte(`{"foo":"2022-01-01T00:00:00Z", "bar":"2023-01-01T00:00:00Z"}`),
+		true,
+	},
+	{
+		"fail",
+		config.Config{
+			Settings: map[string]interface{}{
+				"object": map[string]interface{}{
+					"source_key": "foo",
+					"target_key": "bar",
+				},
+				"value": "2025-01-01",
+			},
+		},
+		[]byte(`{"foo":"2024-01-01T00:00:00Z", "bar":"2023-01-01"}`),
+		false,
+	},
 }
 
 func TestStringLessThan(t *testing.T) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updated the following conditions to support comparisons between source_key and target_key.

- number_equal_to
- number_greater_than
- number_less_than
- string_equal_to
- string_greater_than
- string_less_than


### Example:

`sub.condition.number.less_than(
 settings={object: {source_key: 'a', target_key: 'z'}} 
)
`
`sub.condition.string.less_than(
settings={object: {source_key: 'a', target_key: 'z'}} 
)`

## Motivation and Context

This adds flexibility to accept both static values or `target_key` whichever is provided in the config. Static value is ignored if `target_key` is present in the condition. This solves the issue discussed here: https://github.com/brexhq/substation/issues/64. 

## How Has This Been Tested?

Added unit tests in respective files.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [ ] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
