### PR TITLE
fix(internal/bufio): Default Max Token Size

### DIFF
--- a/internal/bufio/bufio.go
+++ b/internal/bufio/bufio.go
@@ -84,7 +84,7 @@ func (s *scanner) ReadFile(file *os.File) error {
 	// (defaults to 128 MB).
 	b := make([]byte, bufio.MaxScanTokenSize)
 	if mem, ok := os.LookupEnv("AWS_LAMBDA_FUNCTION_MEMORY_SIZE"); !ok {
-		s.Scanner.Buffer(b, (1000*1000)*128)
+		s.Scanner.Buffer(b, (1000 * 1000 * 128))
 	} else {
 		m, _ := strconv.ParseFloat(mem, 64)
 		// For AWS Lambda, the max capacity is 80% of the function's memory.

--- a/internal/bufio/bufio.go
+++ b/internal/bufio/bufio.go
@@ -84,7 +84,7 @@ func (s *scanner) ReadFile(file *os.File) error {
 	// (defaults to 128 MB).
 	b := make([]byte, bufio.MaxScanTokenSize)
 	if mem, ok := os.LookupEnv("AWS_LAMBDA_FUNCTION_MEMORY_SIZE"); !ok {
-		s.Scanner.Buffer(b, (1024^2)*128)
+		s.Scanner.Buffer(b, (1000*1000)*128)
 	} else {
 		m, _ := strconv.ParseFloat(mem, 64)
 		// For AWS Lambda, the max capacity is 80% of the function's memory.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Fixes the max token size for bufio scanners

<!--- Describe your changes in detail -->

## Motivation and Context

Noticed that this was wrong when working on another PR. These are not equivalent: https://go.dev/play/p/rGQz8_p5zR3. This doesn't affect deployments in AWS Lambda.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Try to read a file with very large lines using any file reader app -- it should fail using the main branch but succeed with this change.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
