### PR TITLE
feat(transform): Add MetaRetry Transform

### DIFF
--- a/build/config/substation.libsonnet
+++ b/build/config/substation.libsonnet
@@ -662,6 +662,18 @@
         type: type,
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
       },
+      retry(settings={}): {
+        local type = 'meta_retry',
+        local default = {
+          id: $.helpers.id(type, settings),
+          retry: $.config.retry,
+          condition: null,
+          transforms: null,
+        },
+
+        type: type,
+        settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
+      },
       switch(settings={}): {
         local type = 'meta_switch',
         local default = {
@@ -1312,7 +1324,7 @@
     metric: { name: null, attributes: null, destination: null },
     object: { source_key: null, target_key: null, batch_key: null },
     request: { timeout: '1s' },
-    retry: { count: 3, error_messages: null },
+    retry: { count: 3, duration: '1s', error_messages: null },
   },
   // Mirrors config from the internal/file package.
   file_path: { prefix: null, time_format: '2006/01/02', uuid: true, suffix: null },

--- a/build/config/substation.libsonnet
+++ b/build/config/substation.libsonnet
@@ -126,7 +126,7 @@
       err(settings={}): {
         local default = {
           inspector: null,
-          error_messages: null,
+          error_messages: [".*"],
         },
 
         type: 'meta_err',
@@ -269,7 +269,7 @@
         settings: std.prune(std.mergePatch(default, $.helpers.abbv(settings))),
       },
     },
-    util: $.transform.utility,
+    util: $.condition.utility,
     utility: {
       random(settings={}): {
         type: 'utility_random',
@@ -666,7 +666,7 @@
         local type = 'meta_retry',
         local default = {
           id: $.helpers.id(type, settings),
-          retry: $.config.retry,
+          retry: $.config.retry { error_messages: [".*"] },
           condition: null,
           transforms: null,
         },

--- a/build/config/substation.libsonnet
+++ b/build/config/substation.libsonnet
@@ -1324,7 +1324,7 @@
     metric: { name: null, attributes: null, destination: null },
     object: { source_key: null, target_key: null, batch_key: null },
     request: { timeout: '1s' },
-    retry: { count: 3, duration: '1s', error_messages: null },
+    retry: { count: 3, delay: '1s', error_messages: null },
   },
   // Mirrors config from the internal/file package.
   file_path: { prefix: null, time_format: '2006/01/02', uuid: true, suffix: null },

--- a/examples/config/transform/enrich/urlscan/config.jsonnet
+++ b/examples/config/transform/enrich/urlscan/config.jsonnet
@@ -1,0 +1,49 @@
+// This example shows how to make scan requests and retrieve
+// results using the urlscan API (https://urlscan.io/docs/api/).
+local sub = import '../../../../../build/config/substation.libsonnet';
+
+local headers = { 'API-Key': '${SECRET:URLSCAN}', 'Content-Type': 'application/json' };
+
+{
+  transforms: [
+    // Retrieve the urlscan API key from the secrets store.
+    // (Never put a secret directly into a configuration.)
+    sub.transform.utility.secret({
+      // The API key is stored in an environment variable named 
+      // `URLSCAN_API_KEY`.
+      secret: sub.secrets.environment_variable({ id: 'URLSCAN', name: 'URLSCAN_API_KEY' }),
+    }),
+    // Sends a scan request and waits for the result. This
+    // follows recommended practices from the urlscan API docs,
+    // and will try to fetch the result up to 3 times over 15s. 
+    // If there are no results after retrying, then the unmodified
+    // message is sent to stdout.
+    sub.tf.enrich.http.post({
+      object: { body_key: '@this', target_key: 'meta response' },
+      url: 'https://urlscan.io/api/v1/scan/',
+      headers: headers,
+    }),
+    //
+    sub.tf.util.delay({ duration: '5s' }),
+    sub.tf.meta.err({ transforms: [  // Errors are caught in case the retry limit is reached.
+      sub.tf.meta.retry({
+        // This condition runs on the result of the transforms. If
+        // it returns false, then the transforms are retried until 
+        // it returns true or the retry settings are exhausted.
+        condition: sub.cnd.all([
+          sub.cnd.num.len.gt({ object: { source_key: 'meta result.task.time' }, value: 0 }),
+        ]),
+        transforms: [
+          sub.tf.enrich.http.get({
+            object: { source_key: 'meta response.uuid', target_key: 'meta result' },
+            url: 'https://urlscan.io/api/v1/result/${DATA}',  // DATA is the value of the source_key.
+            headers: headers,
+          }),
+        ],
+        retry: { delay: '5s', count: 3 },  // Retry up to 3 times with a 5 second delay (5s, 5s, 5s).
+      })
+    ]}),
+    sub.tf.obj.cp({ object: { source_key: 'meta result' } }),
+    sub.tf.send.stdout({ batch: { size: 1000 * 1000 * 5 } }),  // 5MB (the results can be large).
+  ],
+}

--- a/examples/config/transform/enrich/urlscan/data.jsonl
+++ b/examples/config/transform/enrich/urlscan/data.jsonl
@@ -1,0 +1,1 @@
+{"url":"https://www.brex.com/"}

--- a/examples/config/transform/meta/retry_with_backoff/config.jsonnet
+++ b/examples/config/transform/meta/retry_with_backoff/config.jsonnet
@@ -6,51 +6,21 @@ local sub = import '../../../../../build/config/substation.libsonnet';
 // `key` is the target of the transform that may not produce an output and is
 // checked to determine if the transform was successful.
 local key = 'c';
-local key_is_empty = sub.cnd.num.len.eq({ object: { source_key: key }, value: 0 });
 
 local cnd = sub.cnd.all([
-  key_is_empty,
-  // Randomness simulates a transform that may fail to produce an output.
-  sub.cnd.utility.random(),
+  sub.cnd.num.len.gt({ object: { source_key: key }, value: 0 }),
+  sub.cnd.utility.random(),  // Simulates a transform that may fail to produce an output.
 ]);
 
-// The number of retries and the backoff duration can be customized. This will
-// retry up to 3 times with a backoff duration of 1 second, 2 seconds, and 4 seconds.
-local retries = ['0s', '1s', '2s', '4s'];
 {
-  transforms:
-    // The retry with backoff behavior is implemented by pipelining a delay transform
-    // with another transform and validating the Message before each retry. The delay
-    // duration is increased with each attempt.
-    [
-      sub.pattern.tf.conditional(
-        condition=cnd,
-        transform=sub.tf.meta.pipe({ transforms: [
-          sub.tf.util.delay({ duration: r }),
-          sub.tf.obj.insert({ object: { target_key: key }, value: true }),
-          // This is added to show the number of retries that were attempted. If
-          // needed in real-world deployments, then it's recommended to put this
-          // info into the Message metadata.
-          sub.tf.obj.insert({ object: { target_key: 'retries' }, value: std.find(r, retries)[0] }),
-        ] }),
-      )
-
-      for r in retries
-    ] + [
-      // If there is no output after all retry attempts, then an error is thrown to crash the program.
-      // This is the same technique from the build/config/transform/meta/crash_program example.
-      sub.tf.meta.switch({ cases: [
-        {
-          condition: sub.cnd.any(key_is_empty),
-          transforms: [
-            sub.tf.util.err({ message: std.format('failed to transform after retrying %d times', std.length(retries) - 1) }),
-          ],
-        },
-        { 
-          transforms: [
-            sub.tf.send.stdout() 
-          ],       
-        },
-      ] }),
-    ],
+  transforms: [
+    sub.tf.meta.retry({
+      transforms: [
+        sub.tf.obj.insert({ object: { target_key: key }, value: true }),
+      ],
+      condition: cnd,  // If this returns false, then the transforms are retried.
+      retry: { delay: '1s', count: 4 },  // Retry up to 4 times with a 1 second backoff (1s, 2s, 3s, 4s).
+    }),
+    sub.tf.send.stdout(),
+  ],
 }

--- a/examples/config/transform/meta/retry_with_backoff/config.jsonnet
+++ b/examples/config/transform/meta/retry_with_backoff/config.jsonnet
@@ -19,7 +19,7 @@ local cnd = sub.cnd.all([
         sub.tf.obj.insert({ object: { target_key: key }, value: true }),
       ],
       condition: cnd,  // If this returns false, then the transforms are retried.
-      retry: { delay: '1s', count: 4 },  // Retry up to 4 times with a 1 second backoff (1s, 2s, 3s, 4s).
+      retry: { delay: '1s', count: 4 },  // Retry up to 4 times with a 1 second backoff (1s, 1s, 1s, 1s).
     }),
     sub.tf.send.stdout(),
   ],

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,7 +1,17 @@
 // package config provides configuration types and functions for Substation.
 //
 // Any non-backwards compatible changes to the configuration types should be
-// accompanied by a version bump.
+// accompanied by a version bump. Use the guidance below for choosing the
+// appropriate fields for configurations:
+//
+// For time-based configurations:
+//
+//   - Use `Delay` for the amount of time to wait before executing.
+//
+//   - Use `Timeout` for the amount of time to wait before interrupting
+//     an execution.
+//
+//   - Use `Duration` for the total amount of time over many executions.
 package config
 
 import (
@@ -42,10 +52,12 @@ type Request struct {
 }
 
 type Retry struct {
-	// Count is the maximum number of times that the action will be retried.
+	// Count is the maximum number of times that the action will be retried. This
+	// can be combined with the Delay field to create a backoff strategy.
 	Count int `json:"count"`
-	// Duration is the maximum amount of time to wait between retries.
-	Duration string `json:"duration"`
+	// Delay is the amount of time to wait before retrying the action. This can be
+	// combined with the Count field to create a backoff strategy.
+	Delay string `json:"delay"`
 	// ErrorMessages are regular expressions that match error messages and determine
 	// if the action should be retried.
 	ErrorMessages []string `json:"error_messages"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -44,6 +44,8 @@ type Request struct {
 type Retry struct {
 	// Count is the maximum number of times that the action will be retried.
 	Count int `json:"count"`
+	// Duration is the maximum amount of time to wait between retries.
+	Duration string `json:"duration"`
 	// ErrorMessages are regular expressions that match error messages and determine
 	// if the action should be retried.
 	ErrorMessages []string `json:"error_messages"`

--- a/transform/meta_err.go
+++ b/transform/meta_err.go
@@ -111,6 +111,7 @@ func (tf *metaErr) Transform(ctx context.Context, msg *message.Message) ([]*mess
 	}
 
 	if err != nil {
+		// Deprecated: Remove this block in a future release.
 		if len(tf.errorMessages) == 0 {
 			return []*message.Message{msg}, nil
 		}

--- a/transform/meta_retry.go
+++ b/transform/meta_retry.go
@@ -132,10 +132,6 @@ LOOP:
 		cMsg := *msg
 		msgs, err := Apply(ctx, tf.transforms, &cMsg)
 		if err != nil {
-			if len(tf.errorMessages) == 0 {
-				continue LOOP
-			}
-
 			for _, r := range tf.errorMessages {
 				if r.MatchString(err.Error()) {
 					continue LOOP

--- a/transform/meta_retry.go
+++ b/transform/meta_retry.go
@@ -104,11 +104,12 @@ func (tf *metaRetry) Transform(ctx context.Context, msg *message.Message) ([]*me
 LOOP:
 	// The first iteration is not a retry, so 1 is added to the
 	// configured count. If this isn't done, then the retries will
-	// be off by one.
+	// be off by one. The first iteration should never sleep.
 	for i := 0; i < tf.conf.Retry.Count+1; i++ {
-		// Implements linear backoff. The first iteration
-		// is a no-op and does not sleep.
-		time.Sleep(tf.delay * time.Duration(i))
+		// Implements constant backoff.
+		if i > 0 {
+			time.Sleep(tf.delay)
+		}
 
 		// This must operate on a copy of the message to avoid
 		// modifying the original message in case the transform

--- a/transform/meta_retry.go
+++ b/transform/meta_retry.go
@@ -1,0 +1,140 @@
+package transform
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/brexhq/substation/condition"
+	"github.com/brexhq/substation/config"
+	iconfig "github.com/brexhq/substation/internal/config"
+	"github.com/brexhq/substation/internal/errors"
+	"github.com/brexhq/substation/message"
+)
+
+type metaRetryConfig struct {
+	// Transforms that are applied in series, then checked for success
+	// based on the condition or errors.
+	Transforms []config.Config `json:"transforms"`
+	// Condition that must be true for the transforms to be considered
+	// a success.
+	Condition condition.Config `json:"condition"`
+
+	Retry iconfig.Retry `json:"retry"`
+	ID    string        `json:"id"`
+}
+
+func (c *metaRetryConfig) Decode(in interface{}) error {
+	return iconfig.Decode(in, c)
+}
+
+func (c *metaRetryConfig) Validate() error {
+	if c.Condition.Operator == "" {
+		return fmt.Errorf("condition: %v", errors.ErrMissingRequiredOption)
+	}
+
+	for _, t := range c.Transforms {
+		if t.Type == "" {
+			return fmt.Errorf("transform: %v", errors.ErrMissingRequiredOption)
+		}
+	}
+
+	return nil
+}
+
+func newMetaRetry(ctx context.Context, cfg config.Config) (*metaRetry, error) {
+	conf := metaRetryConfig{}
+	if err := conf.Decode(cfg.Settings); err != nil {
+		return nil, fmt.Errorf("transform meta_retry: %v", err)
+	}
+
+	if conf.ID == "" {
+		conf.ID = "meta_retry"
+	}
+
+	if err := conf.Validate(); err != nil {
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
+	}
+
+	tforms := make([]Transformer, len(conf.Transforms))
+	for i, t := range conf.Transforms {
+		tfer, err := New(ctx, t)
+		if err != nil {
+			return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
+		}
+
+		tforms[i] = tfer
+	}
+
+	cnd, err := condition.New(ctx, conf.Condition)
+	if err != nil {
+		return nil, fmt.Errorf("transform %s: %v", conf.ID, err)
+	}
+
+	dur, err := time.ParseDuration(conf.Retry.Duration)
+	if err != nil {
+		return nil, fmt.Errorf("transform %s: duration: %v", conf.ID, err)
+	}
+
+	tf := metaRetry{
+		conf:       conf,
+		transforms: tforms,
+		condition:  cnd,
+		duration:   dur,
+	}
+
+	return &tf, nil
+}
+
+type metaRetry struct {
+	conf metaRetryConfig
+
+	condition  condition.Operator
+	transforms []Transformer
+	duration   time.Duration
+}
+
+func (tf *metaRetry) Transform(ctx context.Context, msg *message.Message) ([]*message.Message, error) {
+	// This handles both data and ctrl messages.
+	return tf.retryTransform(ctx, msg, 0)
+}
+
+func (tf *metaRetry) retryTransform(ctx context.Context, msg *message.Message, count int) ([]*message.Message, error) {
+	if count > tf.conf.Retry.Count {
+		return nil, fmt.Errorf("transform %s: limit exceeded", tf.conf.ID)
+	}
+
+	// This implements exponential backoff.
+	for i := 0; i < count; i++ {
+		time.Sleep(tf.duration)
+	}
+
+	msgs, err := Apply(ctx, tf.transforms, msg)
+	if err != nil {
+		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
+	}
+
+	// Every message must pass the condition or else it gets retried.
+	for _, m := range msgs {
+		if m.IsControl() {
+			continue
+		}
+
+		ok, err := tf.condition.Operate(ctx, m)
+		if err != nil {
+			return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
+		}
+
+		if !ok {
+			return tf.retryTransform(ctx, msg, count+1)
+		}
+	}
+
+	return msgs, nil
+}
+
+func (tf *metaRetry) String() string {
+	b, _ := json.Marshal(tf.conf)
+	return string(b)
+}

--- a/transform/transform.go
+++ b/transform/transform.go
@@ -85,6 +85,8 @@ func New(ctx context.Context, cfg config.Config) (Transformer, error) { //nolint
 		return newMetaMetricsDuration(ctx, cfg)
 	case "meta_pipeline":
 		return newMetaPipeline(ctx, cfg)
+	case "meta_retry":
+		return newMetaRetry(ctx, cfg)
 	case "meta_switch":
 		return newMetaSwitch(ctx, cfg)
 	// Number transforms.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- Adds `MetaRetry` transform for retrying transform functions.
- Added urlscan as an example of how the transform works with asynchronous REST APIs.
 
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is a better implementation of what was previously in the `retry_with_backoff` example and can be used to add strict guarantees when enriching data with an external source (such as a REST API or KV store). For example, this can be used to:
- Retry forever until the transform produces an expected result based on a condition
- Retry any number of times until the transform returns without error
- Retry if an error occurs or a condition fails

This transform will eventually return a limit exceeded error, which can be caught with the `MetaErr` transform if needed with the caveat that this can result in data loss for some transforms (only ones that I noticed are `AggregateTo*`; it does work for `Send*` transforms). The default behavior of the packaged applications is to crash on error, so I'm not too concerned about lossy transformation since:
- Errors propagate to the apps, which should trigger retry features in the producer service (e.g. AWS Kinesis, AWS S3)
- Users have to opt into it (by using `MetaErr`)
- This info will be documented on Readme

 In future releases this may supersede retry strategies built into other transforms.

## How Has This Been Tested?

- Integration tested using new and updated examples.

Here are more configs that can be tested with a simple JSON event (like `{"a":"b"}`):

### Retry All Errors

This is retried three times and fails:
```jsonnet
    sub.tf.meta.retry({
      transforms: [
        sub.tf.util.err({ message: 'test err'}),
      ],
      retry: { delay: '1s', count: 3, error_messages: [".*"] },
    }),
```

### Retry Specific Errors

This is not retried and fails:
```jsonnet
    sub.tf.meta.retry({
      transforms: [
        sub.tf.util.err({ message: 'test err'}),
      ],
      retry: { delay: '1s', count: 3, error_messages: ["^err"] },
    }),
```

### Retry Aggregate Transform

This fails if the data is put into the Y aggregate array transform. The failure isn't known until a ctrl message is received, and the data put into the array is lost on retry. 
```jsonnet
    sub.tf.meta.retry({
      transforms: [
        sub.tf.meta.switch({ cases: [
          {
            transforms: [
              sub.tf.agg.to.arr({object: { target_key: 'x'}}),
            ],
            condition: sub.cnd.all([sub.cnd.utility.random()]),
          },
          {
            transforms: [
              sub.tf.agg.to.arr({object: { target_key: 'y'}}),
            ],
          }
        ]}),
      ],
      condition: sub.cnd.all([
        sub.cnd.num.len.gt({ object: { source_key: 'x'}, value: 0 }),
      ]),
      retry: { delay: '1s', count: 3 },
    }),
```

### Retry Send Aux Transform

This retries forever until it succeeds. The failure isn't known until a ctrl message is received, and the data put into the send is not lost on retry.
```jsonnet
    sub.tf.meta.retry({
      transforms: [
        sub.tf.send.stdout({ aux_tforms: [
          sub.tf.meta.switch({ cases: [{
            transforms: [
              sub.tf.util.err({ message: 'test err'}),
            ],
            condition: sub.cnd.all([sub.cnd.utility.random()]),
          }]})
        ]}),
      ],
      retry: { delay: '1s', error_messages: ['test err'] },
    }),
```

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [x] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
