### PR TITLE
test(message): Add Fuzzing

### DIFF
--- a/message/message_test.go
+++ b/message/message_test.go
@@ -341,3 +341,29 @@ func BenchmarkTestMessageSetMetadata(b *testing.B) {
 		)
 	}
 }
+
+func FuzzMessageSetValue(f *testing.F) {
+	f.Add("key", "value")
+	f.Fuzz(func(t *testing.T, key, value string) {
+		msg := New().SetData([]byte(`{}`))
+		if err := msg.SetValue(key, value); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+}
+
+func FuzzMessageGetValue(f *testing.F) {
+	f.Add("key")
+	f.Fuzz(func(t *testing.T, key string) {
+		msg := New().SetData([]byte(`{"key":"value"}`))
+		_ = msg.GetValue(key)
+	})
+}
+
+func FuzzMessageDeleteValue(f *testing.F) {
+	f.Add("key")
+	f.Fuzz(func(t *testing.T, key string) {
+		msg := New().SetData([]byte(`{"key":"value"}`))
+		_ = msg.DeleteValue(key)
+	})
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- Adds fuzz tests for `message`

## Motivation and Context

OpenSSF was recently deployed for CI and it calls out fuzzing as a gap, so this is a test to check the level of effort required to address that. More info available here:
- https://github.com/brexhq/substation/security/code-scanning/31
- https://go.dev/doc/security/fuzz/

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

N/A

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
