### PR TITLE
fix(cmd): Out of Bounds int32 Check in AWS Lambda Autoscale

### DIFF
--- a/cmd/aws/lambda/autoscale/main.go
+++ b/cmd/aws/lambda/autoscale/main.go
@@ -63,11 +63,12 @@ func init() {
 			panic(err)
 		}
 
-		if dps > math.MaxInt32 || dps < math.MinInt32 {
-			panic(fmt.Errorf("value %d out of bounds for int32", dps))
+		if dps <= 360 && dps >= 1 {
+			kinesisDownscaleDatapoints = int32(dps)
+		} else {
+			log.Info("init downscale: Provided AUTOSCALE_KINESIS_DOWNSCALE_DATAPOINTS is outside of range 1-360, using default value of 60")
 		}
 
-		kinesisDownscaleDatapoints = int32(dps)
 	}
 
 	if v, found := os.LookupEnv("AUTOSCALE_KINESIS_UPSCALE_DATAPOINTS"); found {
@@ -76,11 +77,11 @@ func init() {
 			panic(err)
 		}
 
-		if dps > math.MaxInt32 || dps < math.MinInt32 {
-			panic(fmt.Errorf("value %d out of bounds for int32", dps))
+		if dps <= 30 && dps >= 1 {
+			kinesisUpscaleDatapoints = int32(dps)
+		} else {
+			log.Info("init upscale: Provided AUTOSCALE_KINESIS_UPSCALE_DATAPOINTS is outside of range 1-30, using default value of 5")
 		}
-
-		kinesisUpscaleDatapoints = int32(dps)
 	}
 
 	if v, found := os.LookupEnv("AUTOSCALE_KINESIS_THRESHOLD"); found {
@@ -91,6 +92,8 @@ func init() {
 
 		if threshold >= 0.4 && threshold <= 0.9 {
 			kinesisThreshold = threshold
+		} else {
+			log.Info("init threshold: Provided AUTOSCALE_KINESIS_THRESHOLD is outside of range 0.4-0.9, using default value of 0.7")
 		}
 	}
 }

--- a/cmd/aws/lambda/autoscale/main.go
+++ b/cmd/aws/lambda/autoscale/main.go
@@ -68,7 +68,6 @@ func init() {
 		} else {
 			log.Info("init downscale: Provided AUTOSCALE_KINESIS_DOWNSCALE_DATAPOINTS is outside of range 1-360, using default value of 60")
 		}
-
 	}
 
 	if v, found := os.LookupEnv("AUTOSCALE_KINESIS_UPSCALE_DATAPOINTS"); found {

--- a/cmd/aws/lambda/autoscale/main.go
+++ b/cmd/aws/lambda/autoscale/main.go
@@ -63,6 +63,10 @@ func init() {
 			panic(err)
 		}
 
+		if dps > math.MaxInt32 || dps < math.MinInt32 {
+			panic(fmt.Errorf("value %d out of bounds for int32", dps))
+		}
+
 		kinesisDownscaleDatapoints = int32(dps)
 	}
 
@@ -70,6 +74,10 @@ func init() {
 		dps, err := strconv.Atoi(v)
 		if err != nil {
 			panic(err)
+		}
+
+		if dps > math.MaxInt32 || dps < math.MinInt32 {
+			panic(fmt.Errorf("value %d out of bounds for int32", dps))
 		}
 
 		kinesisUpscaleDatapoints = int32(dps)

--- a/cmd/aws/lambda/autoscale/main.go
+++ b/cmd/aws/lambda/autoscale/main.go
@@ -63,10 +63,10 @@ func init() {
 			panic(err)
 		}
 
-		if dps <= 360 && dps >= 1 {
+		if dps <= math.MaxInt32 && dps >= 1 {
 			kinesisDownscaleDatapoints = int32(dps)
 		} else {
-			log.Info("init downscale: Provided AUTOSCALE_KINESIS_DOWNSCALE_DATAPOINTS is outside of range 1-360, using default value of 60")
+			log.Info("init downscale: Provided AUTOSCALE_KINESIS_DOWNSCALE_DATAPOINTS is outside of valid range, using default value of 60")
 		}
 	}
 
@@ -76,10 +76,10 @@ func init() {
 			panic(err)
 		}
 
-		if dps <= 30 && dps >= 1 {
+		if dps <= math.MaxInt32 && dps >= 1 {
 			kinesisUpscaleDatapoints = int32(dps)
 		} else {
-			log.Info("init upscale: Provided AUTOSCALE_KINESIS_UPSCALE_DATAPOINTS is outside of range 1-30, using default value of 5")
+			log.Info("init upscale: Provided AUTOSCALE_KINESIS_UPSCALE_DATAPOINTS is outside of valid range, using default value of 5")
 		}
 	}
 


### PR DESCRIPTION
## Description

- Fix security finding for incorrect conversion between integer types (https://github.com/brexhq/substation/security/code-scanning/34 and https://github.com/brexhq/substation/security/code-scanning/35). This adds the upper bound check.

## Motivation and Context

Solves potential overflow issue if the Kinesis downscale and upscale datapoints values are outside the upper bound for int32. This occurs in init - failure should occur pre-runtime if the env var(s) are set incorrectly.

## How Has This Been Tested?

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
