### PR TITLE
feat: add support for formatting jsonnet with substation cli

### DIFF
--- a/cmd/substation/fmt.go
+++ b/cmd/substation/fmt.go
@@ -17,7 +17,7 @@ func init() {
 
 var fmtCmd = &cobra.Command{
 	Use:   "fmt [path]",
-	Short: "Format Jsonnet files",
+	Short: "format configs",
 	Long: `'substation fmt' formats Jsonnet files.
 It prints the formatted output to stdout by default.
 Use the --write flag to update the files in-place.

--- a/cmd/substation/fmt.go
+++ b/cmd/substation/fmt.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/google/go-jsonnet/formatter"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(fmtCmd)
+	fmtCmd.PersistentFlags().BoolP("write", "w", false, "write result to (source) file instead of stdout")
+	fmtCmd.PersistentFlags().BoolP("recursive", "R", false, "recursively format all files")
+}
+
+var fmtCmd = &cobra.Command{
+	Use:   "fmt [path]",
+	Short: "Format Jsonnet files",
+	Long: `'substation fmt' formats Jsonnet files.
+It prints the formatted output to stdout by default.
+Use the --write flag to update the files in-place.
+
+The command can format a single file or a directory.
+Use the --recursive flag to format all files in a directory and its subdirectories.
+
+Supported file extensions: .jsonnet, .libsonnet`,
+	Example: `  substation fmt config.jsonnet
+  substation fmt -w config.jsonnet
+  substation fmt -R /path/to/configs
+  substation fmt -w -R /path/to/configs`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// Default to current directory if no path is provided
+		path := "."
+		if len(args) > 0 {
+			path = args[0]
+		}
+
+		write, _ := cmd.Flags().GetBool("write")
+		recursive, _ := cmd.Flags().GetBool("recursive")
+
+		return formatPath(path, write, recursive)
+	},
+}
+
+func formatPath(path string, write, recursive bool) error {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+
+	if !fi.IsDir() {
+		return formatFile(path, write)
+	}
+
+	return filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			if !recursive && path != "." {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		ext := filepath.Ext(path)
+		if ext != ".jsonnet" && ext != ".libsonnet" {
+			return nil
+		}
+		return formatFile(path, write)
+	})
+}
+
+func formatFile(path string, write bool) error {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	formatted, err := formatter.Format(path, string(content), formatter.DefaultOptions())
+	if err != nil {
+		return err
+	}
+
+	if write {
+		err = os.WriteFile(path, []byte(formatted), 0o644)
+		if err != nil {
+			return err
+		}
+		fmt.Println(path)
+	} else {
+		fmt.Println(formatted)
+	}
+
+	return nil
+}

--- a/cmd/substation/fmt.go
+++ b/cmd/substation/fmt.go
@@ -38,8 +38,15 @@ Supported file extensions: .jsonnet, .libsonnet`,
 			path = args[0]
 		}
 
-		write, _ := cmd.Flags().GetBool("write")
-		recursive, _ := cmd.Flags().GetBool("recursive")
+		write, err := cmd.Flags().GetBool("write")
+		if err != nil {
+			return err
+		}
+
+		recursive, err := cmd.Flags().GetBool("recursive")
+		if err != nil {
+			return err
+		}
 
 		return formatPath(path, write, recursive)
 	},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This change adds support for running `substation fmt` against jsonnet and libsonnet files, automatically normalizing the format of substation configurations.

## Motivation and Context

This change was added to continue making substation more approachable and easy to work with by enhancing the CLI that is used to manage and develop configurations. Right now the CLI supports building and testing. The addition of `substation fmt` adds a very small piece of that puzzle which is ensuring that all configuration is formatted the same way - this improves quality of life for teams managing many configs that are written by multiple developers.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

The CLI has been locally built and tested on example jsonnet and libsonnet files to verify functionality.

When running `substation fmt`, the output styling mimics that of `go fmt`, for consistency with the stylistic choices in `substation test`.

Write formatted changes to stdout.
```text
> substation fmt examples/transform/aggregate/sample/config.jsonnet
// This example samples data by aggregating events into an array, then
// selecting the first event in the array as a sample. The sampling rate
// is 1/N, where N is the count of events in the buffer.
local sub = import '../../../../substation.libsonnet';

{
  tests: [
    {
      name: 'sample',
      transforms: [
        sub.tf.test.message({ value: { a: 'b' } }),
        sub.tf.test.message({ value: { c: 'd' } }),
        sub.tf.test.message({ value: { e: 'f' } }),
        sub.tf.test.message({ value: { g: 'h' } }),
        sub.tf.test.message({ value: { i: 'j' } }),
        sub.tf.test.message({ value: { k: 'l' } }),
        sub.tf.test.message({ value: { m: 'n' } }),
        sub.tf.test.message({ value: { o: 'p' } }),
        sub.tf.test.message({ value: { q: 'r' } }),
        sub.tf.test.message({ value: { s: 't' } }),
        sub.tf.test.message({ value: { u: 'v' } }),
        sub.tf.test.message({ value: { w: 'x' } }),
        sub.tf.test.message({ value: { y: 'z' } }),
        sub.tf.test.message({ value: ' ' }),
        sub.tf.send.stdout(),
      ],
      // Asserts that the message is '{"c":"d"}'.
      condition: sub.cnd.num.len.greater_than({ value: 0 }),
    },
  ],
  transforms: [
    // Events are aggregated into an array. This example has a sample
    // rate of up to 1/5. By default, the sample rate will be lower if
    // fewer than 5 events are processed by Substation.
    sub.tf.aggregate.to.array({ object: { target_key: 'meta sample' }, batch: { count: 5 } }),
    // A strict sample rate can be enforced by dropping any events that
    // contain the `sample` key, but do not have a length of 5.
    sub.tf.meta.switch(settings={ cases: [
      {
        condition: sub.cnd.num.len.eq({ object: { source_key: 'meta sample' }, value: 5 }),
        transforms: [
          sub.tf.object.copy({ object: { source_key: 'meta sample.0' } }),
        ],
      },
      {
        condition: sub.cnd.num.len.gt({ object: { source_key: 'meta sample' }, value: 0 }),
        transforms: [
          sub.tf.util.drop(),
        ],
      },
    ] }),
    sub.tf.obj.cp({ object: { source_key: 'meta sample.0' } }),
    sub.tf.send.stdout(),
  ],
}
```

Write formatted changes to the file.
```
> substation fmt -w examples/transform/aggregate/sample/config.jsonnet
examples/transform/aggregate/sample/config.jsonnet
```

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
