### PR TITLE
ci(workflows): Pin More Hashes

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -29,7 +29,7 @@ jobs:
         run: go test -timeout 30s -v ./...
 
       - name: Linting
-        uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.0
+        uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
         with:
           version: v1.61.0
 
@@ -45,11 +45,8 @@ jobs:
         with:
           python-version: "3.x"
 
-      # v24.10.0
       - name: Linting
-        run: |
-          pip install git+https://github.com/psf/black@1b2427a2b785cc4aac97c19bb4b9a0de063f9547 
-          find -name *.py | xargs black --check
+        uses: psf/black@1b2427a2b785cc4aac97c19bb4b9a0de063f9547 # v24.10.0
 
   # Inherits workflow permissions.
   jsonnet:
@@ -61,7 +58,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
           go-version: 1.22
 

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -43,8 +43,8 @@ jobs:
       - name: Linting
         uses: psf/black@1b2427a2b785cc4aac97c19bb4b9a0de063f9547 # v24.10.0
         with:
-          src: "./build"
-          options: "--check"
+          # src: "./build"
+          options: "--check --exclude=''" # "An empty value means no paths are excluded."
 
   # Inherits workflow permissions.
   jsonnet:

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -40,13 +40,11 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - name: Setup Python
-        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
-        with:
-          python-version: "3.x"
-
       - name: Linting
         uses: psf/black@1b2427a2b785cc4aac97c19bb4b9a0de063f9547 # v24.10.0
+        with:
+          src: "./build"
+          options: "--check"
 
   # Inherits workflow permissions.
   jsonnet:

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -43,8 +43,9 @@ jobs:
       - name: Linting
         uses: psf/black@1b2427a2b785cc4aac97c19bb4b9a0de063f9547 # v24.10.0
         with:
-          # src: "./build"
-          options: "--check --exclude=''" # "An empty value means no paths are excluded."
+          # This recursively scans the entire project. Note that `exclude` must be
+          # an empty string: "An empty value means no paths are excluded."
+          options: "--check --exclude=''"
 
   # Inherits workflow permissions.
   jsonnet:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -68,6 +68,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@cf5b0a9041d3c1d336516f1944c96d96598193cc  # v2.19.1
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Closes https://github.com/brexhq/substation/security/code-scanning/38
- Adds missed hash for Go setup
- Updates version comment for golangci

<!--- Describe your changes in detail -->

## Motivation and Context

GitHub's code scanning did not pick up the pinned hash for black, so I've moved this to black's GitHub action.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

N/A (tested on PR).

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
