### PR TITLE
fix(internal/secrets): Error on Missing Secrets

### DIFF
--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -17,8 +17,8 @@ var (
 	// interpRe is used for parsing secrets during interpolation. Secrets
 	// must not contain any curly braces.
 	interpRe = regexp.MustCompile(`\${(SECRET:[^}]+)}`)
-	// errNoSecrets is returned when no secrets are found in the cache.
-	errNoSecrets = fmt.Errorf("secrets: no secrets found")
+	// errNoSecret is returned when no secrets are found in the cache.
+	errNoSecret = fmt.Errorf("secrets: no secret found")
 	// KV store is used as a secrets cache
 	cache kv.Storer
 )
@@ -75,7 +75,7 @@ func Interpolate(ctx context.Context, s string) (string, error) {
 		}
 
 		if secret == nil {
-			return "", errNoSecrets
+			return "", errNoSecret
 		}
 
 		// Replaces each substring with a secret. If the secret is

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -17,6 +17,8 @@ var (
 	// interpRe is used for parsing secrets during interpolation. Secrets
 	// must not contain any curly braces.
 	interpRe = regexp.MustCompile(`\${(SECRET:[^}]+)}`)
+	// errNoSecrets is returned when no secrets are found in the cache.
+	errNoSecrets = fmt.Errorf("secrets: no secrets found")
 	// KV store is used as a secrets cache
 	cache kv.Storer
 )
@@ -70,6 +72,10 @@ func Interpolate(ctx context.Context, s string) (string, error) {
 		secret, err := cache.Get(ctx, secretName)
 		if err != nil {
 			return "", err
+		}
+
+		if secret == nil {
+			return "", errNoSecrets
 		}
 
 		// Replaces each substring with a secret. If the secret is


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- Fixes a missing error in case no secret is found

## Motivation and Context

Discovered this after running `substation vet -R examples/`:

```sh
% substation vet examples/transform/enrich/urlscan/config.jsonnet
panic: interface conversion: interface {} is nil, not string
```

This is the new output:
```sh
% substation vet examples/transform/enrich/urlscan/config.jsonnet
examples/transform/enrich/urlscan/config.jsonnet:2 transform bb7942d9-810481d2: secrets: no secret found

    {"type":"enrich_http_post","settings":{"headers":{"API-Key":"${SECRET:URLSCAN}","Content-Type":"application/json"},"id":"bb7942d9-810481d2","object":{"body_key":"@this","target_key":"meta response"},"request":{"timeout":"1s"},"url":"https://urlscan.io/api/v1/scan/"}}
```

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Using `substation vet` (v2.1.0).

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
