### PR TITLE
fix(message): Update Flag Iota

### DIFF
--- a/message/message.go
+++ b/message/message.go
@@ -20,7 +20,7 @@ const (
 	metaKey = "meta "
 
 	// IsControl indicates that the message is a control message.
-	IsControl Flag = iota + 1
+	IsControl Flag = iota
 	// SkipNullValues indicates that null values should be ignored when processing the message.
 	SkipNullValues
 	// SkipMissingValues indicates that missing values should be ignored when processing the message.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Changes the message package's `Flag` starting number.

<!--- Describe your changes in detail -->

## Motivation and Context

[This guidance](https://github.com/uber-go/guide/blob/master/style.md#start-enums-at-one) may be outdated because the iota starts at 1 without requiring addition. This small program shows that `IsControl` (`1`) works as expected (does not start at zero):
```go
package main

import (
	"fmt"

	"github.com/brexhq/substation/v2/message"
)

func main() {
	msg := message.New()
	fmt.Println("msg flag 0, ", msg.HasFlag(0))
	fmt.Println("msg flag 1, ", msg.HasFlag(1))

	ctrl := msg.AsControl()
	fmt.Println("ctrl flag 0, ", ctrl.HasFlag(0))
	fmt.Println("ctrl flag 1, ", ctrl.HasFlag(1))
}
```

```sh
msg flag 0,  false
msg flag 1,  false
ctrl flag 0,  false
ctrl flag 1,  true
```

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

See program above.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
