### PR TITLE
feat(cmd): log test errors

### DIFF
--- a/cmd/substation/playground.go
+++ b/cmd/substation/playground.go
@@ -193,7 +193,7 @@ func handleTest(w http.ResponseWriter, r *http.Request) {
 	for _, test := range cfg.Tests {
 		cnd, err := condition.New(ctx, test.Condition)
 		if err != nil {
-			output.WriteString("?\t[test error]\n")
+			fmt.Fprintf(&output, "test condition error: %v\n", err)
 			sendJSONResponse(w, map[string]string{"output": output.String()})
 			return
 		}
@@ -202,28 +202,28 @@ func handleTest(w http.ResponseWriter, r *http.Request) {
 			Transforms: test.Transforms,
 		})
 		if err != nil {
-			output.WriteString("?\t[test error]\n")
+			fmt.Fprintf(&output, "test config error: %v\n", err)
 			sendJSONResponse(w, map[string]string{"output": output.String()})
 			return
 		}
 
 		tester, err := substation.New(ctx, cfg.Config)
 		if err != nil {
-			output.WriteString("?\t[config error]\n")
+			fmt.Fprintf(&output, "config error: %v\n", err)
 			sendJSONResponse(w, map[string]string{"output": output.String()})
 			return
 		}
 
 		sMsgs, err := setup.Transform(ctx, message.New().AsControl())
 		if err != nil {
-			output.WriteString("?\t[test error]\n")
+			fmt.Fprintf(&output, "test transform error: %v\n", err)
 			sendJSONResponse(w, map[string]string{"output": output.String()})
 			return
 		}
 
 		tMsgs, err := tester.Transform(ctx, sMsgs...)
 		if err != nil {
-			output.WriteString("?\t[config error]\n")
+			fmt.Fprintf(&output, "transform error: %v\n", err)
 			sendJSONResponse(w, map[string]string{"output": output.String()})
 			return
 		}
@@ -236,7 +236,7 @@ func handleTest(w http.ResponseWriter, r *http.Request) {
 
 			ok, err := cnd.Condition(ctx, msg)
 			if err != nil {
-				output.WriteString("?\t[test error]\n")
+				fmt.Fprintf(&output, "test error: %v\n", err)
 				sendJSONResponse(w, map[string]string{"output": output.String()})
 				return
 			}

--- a/cmd/substation/test.go
+++ b/cmd/substation/test.go
@@ -268,17 +268,17 @@ func testFile(arg string, extVars map[string]string) error {
 
 		sMsgs, err := setup.Transform(ctx, message.New().AsControl())
 		if err != nil {
-			fmt.Printf("?\t%s\t[test error]\n", arg)
+			fmt.Printf("?\t%s\t[test.transform error]\n", arg)
+			fmt.Fprintf(os.Stderr, "\t\t%v\n", err)
 
-			//nolint:nilerr  // errors should not disrupt the test.
 			return nil
 		}
 
 		tMsgs, err := tester.Transform(ctx, sMsgs...)
 		if err != nil {
-			fmt.Printf("?\t%s\t[config error]\n", arg)
+			fmt.Printf("?\t%s\t[transform error]\n", arg)
+			fmt.Fprintf(os.Stderr, "\t\t%v\n", err)
 
-			//nolint:nilerr  // errors should not disrupt the test.
 			return nil
 		}
 

--- a/cmd/substation/test.go
+++ b/cmd/substation/test.go
@@ -198,8 +198,8 @@ func testFile(arg string, extVars map[string]string) error {
 		mem, err := compileFile(arg, extVars)
 		if err != nil {
 			fmt.Printf("?\t%s\t[config error]\n", arg)
+			fmt.Fprintf(os.Stderr, "    %v\n", err)
 
-			//nolint:nilerr  // errors should not disrupt the test.
 			return nil
 		}
 
@@ -238,9 +238,9 @@ func testFile(arg string, extVars map[string]string) error {
 		// cnd asserts that the test is successful.
 		cnd, err := condition.New(ctx, test.Condition)
 		if err != nil {
-			fmt.Printf("FAIL\t%s\t[test error]\n", arg)
+			fmt.Printf("FAIL\t%s\t[test condition error]\n", arg)
+			fmt.Fprintf(os.Stderr, "    %v\n", err)
 
-			//nolint:nilerr  // errors should not disrupt the test.
 			return nil
 		}
 
@@ -249,9 +249,9 @@ func testFile(arg string, extVars map[string]string) error {
 			Transforms: test.Transforms,
 		})
 		if err != nil {
-			fmt.Printf("?\t%s\t[test error]\n", arg)
+			fmt.Printf("?\t%s\t[test config error]\n", arg)
+			fmt.Fprintf(os.Stderr, "    %v\n", err)
 
-			//nolint:nilerr  // errors should not disrupt the test.
 			return nil
 		}
 
@@ -261,15 +261,15 @@ func testFile(arg string, extVars map[string]string) error {
 		tester, err := substation.New(ctx, cfg.Config)
 		if err != nil {
 			fmt.Printf("?\t%s\t[config error]\n", arg)
+			fmt.Fprintf(os.Stderr, "    %v\n", err)
 
-			//nolint:nilerr  // errors should not disrupt the test.
 			return nil
 		}
 
 		sMsgs, err := setup.Transform(ctx, message.New().AsControl())
 		if err != nil {
 			fmt.Printf("?\t%s\t[test.transform error]\n", arg)
-			fmt.Fprintf(os.Stderr, "\t\t%v\n", err)
+			fmt.Fprintf(os.Stderr, "    %v\n", err)
 
 			return nil
 		}
@@ -277,7 +277,7 @@ func testFile(arg string, extVars map[string]string) error {
 		tMsgs, err := tester.Transform(ctx, sMsgs...)
 		if err != nil {
 			fmt.Printf("?\t%s\t[transform error]\n", arg)
-			fmt.Fprintf(os.Stderr, "\t\t%v\n", err)
+			fmt.Fprintf(os.Stderr, "    %v\n", err)
 
 			return nil
 		}
@@ -290,9 +290,9 @@ func testFile(arg string, extVars map[string]string) error {
 
 			ok, err := cnd.Condition(ctx, msg)
 			if err != nil {
-				fmt.Printf("?\t%s\t[test error]\n", arg)
+				fmt.Printf("?\t%s\t[test condition error]\n", arg)
+				fmt.Fprintf(os.Stderr, "    %v\n", err)
 
-				//nolint:nilerr  // errors should not disrupt the test.
 				return nil
 			}
 


### PR DESCRIPTION
## Description

This changes the CLIs "test" subcommand (`substation test`) to log runtime transform errors to standard error. This 

## Motivation and Context

When performing test file driven configuration development it's not clear if a specific tests `[config error]` is from misconfigured Jsonnet declarations, invalid Substation options or runtime errors. You can remove the first two options by diagnosing with `substation vet` but then you still don't know what the runtime transform error is if that's the case. 

## How Has This Been Tested?

Verified that multiple tests across files can be run, and are more clear when there was an opaque `[config error]`.

```zsh
$ substation test .
ok	fizz.libsonnet	607µs
?	buzz.libsonnet	[transform error]
error: transform 907268ad-3907ac72: format 2006-01-02T15:04:05.000000Z location UTC: parsing time "2024-10-29T19:15:52.011Z" as "2006-01-02T15:04:05.000000Z": cannot parse ".011Z" as ".000000"
ok	baz.libsonnet	903µs
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
