### PR TITLE
docs: update v2 migration guide

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -89,7 +89,7 @@ sub.cnd.all([
 
 #### `meta.for_each` Condition
 
-This is replaced by the `meta.all`, `meta.any`, and `meta.none` conditions. If the `object.source_key` value is an array, then the data is treated as a list of elements. 
+This is replaced by the `meta.all`, `meta.any`, and `meta.none` conditions. If the `object.source_key` value is an array, then the data is treated as a list of elements.
 
 v1.x.x:
 
@@ -104,10 +104,10 @@ sub.cnd.meta.for_each({
 v2.x.x:
 
 ```jsonnet
-sub.cnd.meta.any([{
+sub.cnd.meta.any({
   object: { source_key: 'field' },
   conditions: [ sub.cnd.str.eq({ value: 'FOO' }) ],
-}])
+})
 ```
 
 #### `meta.negate` Condition
@@ -184,8 +184,8 @@ v2.x.x:
 sub.tf.meta.switch({ cases: [
   {
     condition: sub.cnd.str.eq({ obj: { source_key: 'field' }, value: 'FOO' }),
-    transforms: [ 
-      sub.tf.obj.insert({ object: { target_key: 'field' }, value: 'BAR' }) 
+    transforms: [
+      sub.tf.obj.insert({ object: { target_key: 'field' }, value: 'BAR' })
     ],
   },
 ]})
@@ -247,7 +247,7 @@ sub.tf.send.aws.dynamodb.put({
 
 The `enrich.aws.dynamodb` transform was renamed to `enrich.aws.dynamodb.query`, and had these additional changes:
 - `PartitionKey` and `SortKey` now reference the column names in the DynamoDB table and are nested under the `Attributes` field.
-- By default, the value retrieved from `Object.SourceKey` is used as the `PartitionKey` value. If the `SortKey` is provided and the value from `Object.SourceKey` is an array, then the first element is used as the `PartitionKey` value and the second element is used as the `SortKey` value. 
+- By default, the value retrieved from `Object.SourceKey` is used as the `PartitionKey` value. If the `SortKey` is provided and the value from `Object.SourceKey` is an array, then the first element is used as the `PartitionKey` value and the second element is used as the `SortKey` value.
 - The `KeyConditionExpression` field was removed because this is now a derived value.
 
 v1.x.x:


### PR DESCRIPTION
## Description

This fixes [examples](https://github.com/brexhq/substation/blob/main/MIGRATION.md#metafor_each-condition) in the v2 migration guide for `sub.cnd.meta.*` conditions that replace for_each conditions by removing the array parameter. Users following this guide would get Jsonnet that failed to build.

## Motivation and Context

Discovered this while migrating an old configuration and following the guide resulted in a broken config. 

## How Has This Been Tested?

Verified that the Jsonnet could be built and passed with `substation vet`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue) * of documentation* 
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [x] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
