### PR TITLE
fix(condition): handling of missing source and/or target keys

### DIFF
--- a/condition/number_equal_to.go
+++ b/condition/number_equal_to.go
@@ -38,21 +38,23 @@ func (insp *numberEqualTo) Condition(ctx context.Context, msg *message.Message) 
 
 		return insp.match(f, compare), nil
 	}
-	source_value := msg.GetValue(insp.conf.Object.SourceKey)
-	target_value := msg.GetValue(insp.conf.Object.TargetKey)
+
+
+	val := msg.GetValue(insp.conf.Object.SourceKey)
 
 	// for gjson's GetValue, if the path is empty string (indicating source key or target key is not present),
 	// the Result.Exists() will return false
 	// If source or target key is present but value cannot be found, always return false
-	if !source_value.Exists() || insp.conf.Object.TargetKey != "" && !target_value.Exists() {
+	if !val.Exists() {
 		return false, nil
 	}
 
-	if target_value.Exists() {
-		compare = target_value.Float()
+	target := msg.GetValue(insp.conf.Object.TargetKey)
+	if target.Exists() {
+		compare = target.Float()
 	}
 
-	return insp.match(source_value.Float(), compare), nil
+	return insp.match(val.Float(), compare), nil
 }
 
 func (c *numberEqualTo) match(f float64, t float64) bool {

--- a/condition/number_equal_to_test.go
+++ b/condition/number_equal_to_test.go
@@ -135,7 +135,7 @@ var numberEqualToTests = []struct {
 		false,
 	},
 	{
-		"pass",
+		"fail",
 		config.Config{
 			Settings: map[string]interface{}{
 				"object": map[string]interface{}{
@@ -148,7 +148,7 @@ var numberEqualToTests = []struct {
 		false,
 	},
 	{
-		"pass",
+		"fail",
 		config.Config{
 			Settings: map[string]interface{}{
 				"object": map[string]interface{}{
@@ -161,7 +161,7 @@ var numberEqualToTests = []struct {
 		false,
 	},
 	{
-		"pass",
+		"fail",
 		config.Config{
 			Settings: map[string]interface{}{
 				"object": map[string]interface{}{
@@ -173,7 +173,7 @@ var numberEqualToTests = []struct {
 		false,
 	},
 	{
-		"pass",
+		"fail",
 		config.Config{
 			Settings: map[string]interface{}{
 				"object": map[string]interface{}{
@@ -186,7 +186,7 @@ var numberEqualToTests = []struct {
 		false,
 	},
 	{
-		"pass",
+		"fail",
 		config.Config{
 			Settings: map[string]interface{}{
 				"object": map[string]interface{}{

--- a/condition/number_equal_to_test.go
+++ b/condition/number_equal_to_test.go
@@ -134,6 +134,70 @@ var numberEqualToTests = []struct {
 		[]byte(`{"foo": 100, "bar": 200}`),
 		false,
 	},
+	{
+		"pass",
+		config.Config{
+			Settings: map[string]interface{}{
+				"object": map[string]interface{}{
+					"source_key": "baz",
+				},
+				"value": 0,
+			},
+		},
+		[]byte(`{"foo": 100, "bar": 200}`),
+		false,
+	},
+	{
+		"pass",
+		config.Config{
+			Settings: map[string]interface{}{
+				"object": map[string]interface{}{
+					"source_key": "baz",
+					"target_key": "bar",
+				},
+			},
+		},
+		[]byte(`{"foo": 100, "bar": 200}`),
+		false,
+	},
+	{
+		"pass",
+		config.Config{
+			Settings: map[string]interface{}{
+				"object": map[string]interface{}{
+					"target_key": "abc",
+				},
+			},
+		},
+		[]byte(`100`),
+		false,
+	},
+	{
+		"pass",
+		config.Config{
+			Settings: map[string]interface{}{
+				"object": map[string]interface{}{
+					"source_key": "foo",
+					"target_key": "baz",
+				},
+			},
+		},
+		[]byte(`{"foo": 100, "bar": 200}`),
+		false,
+	},
+	{
+		"pass",
+		config.Config{
+			Settings: map[string]interface{}{
+				"object": map[string]interface{}{
+					"source_key": "baz",
+					"target_key": "abc",
+				},
+			},
+		},
+		[]byte(`{"foo": 100, "bar": 200}`),
+		false,
+	},
 }
 
 func TestNumberEqualTo(t *testing.T) {

--- a/condition/string_equal_to.go
+++ b/condition/string_equal_to.go
@@ -40,21 +40,21 @@ func (insp *stringEqualTo) Condition(ctx context.Context, msg *message.Message) 
 		return bytes.Equal(msg.Data(), compare), nil
 	}
 
-	source_value := msg.GetValue(insp.conf.Object.SourceKey)
-	target_value := msg.GetValue(insp.conf.Object.TargetKey)
+	val := msg.GetValue(insp.conf.Object.SourceKey)
 
 	// for gjson's GetValue, if the path is empty string (indicating source key or target key is not present),
 	// the Result.Exists() will return false
 	// If source or target key is present but value cannot be found, always return false
-	if !source_value.Exists() || insp.conf.Object.TargetKey != "" && !target_value.Exists() {
+	if !val.Exists() {
 		return false, nil
 	}
 
-	if target_value.Exists() {
-		compare = target_value.Bytes()
+	target := msg.GetValue(insp.conf.Object.TargetKey)
+	if target.Exists() {
+		compare = target.Bytes()
 	}
 
-	return bytes.Equal(source_value.Bytes(), compare), nil
+	return bytes.Equal(val.Bytes(), compare), nil
 }
 
 func (c *stringEqualTo) String() string {

--- a/condition/string_equal_to.go
+++ b/condition/string_equal_to.go
@@ -40,14 +40,21 @@ func (insp *stringEqualTo) Condition(ctx context.Context, msg *message.Message) 
 		return bytes.Equal(msg.Data(), compare), nil
 	}
 
-	target := msg.GetValue(insp.conf.Object.TargetKey)
+	source_value := msg.GetValue(insp.conf.Object.SourceKey)
+	target_value := msg.GetValue(insp.conf.Object.TargetKey)
 
-	if target.Exists() {
-		compare = target.Bytes()
+	// for gjson's GetValue, if the path is empty string (indicating source key or target key is not present),
+	// the Result.Exists() will return false
+	// If source or target key is present but value cannot be found, always return false
+	if !source_value.Exists() || insp.conf.Object.TargetKey != "" && !target_value.Exists() {
+		return false, nil
 	}
 
-	value := msg.GetValue(insp.conf.Object.SourceKey)
-	return bytes.Equal(value.Bytes(), compare), nil
+	if target_value.Exists() {
+		compare = target_value.Bytes()
+	}
+
+	return bytes.Equal(source_value.Bytes(), compare), nil
 }
 
 func (c *stringEqualTo) String() string {

--- a/condition/string_equal_to_test.go
+++ b/condition/string_equal_to_test.go
@@ -73,6 +73,70 @@ var stringEqualToTests = []struct {
 		[]byte(`{"foo":"abc", "bar":"def"}`),
 		false,
 	},
+	{
+		"pass",
+		config.Config{
+			Settings: map[string]interface{}{
+				"object": map[string]interface{}{
+					"source_key": "foo",
+				},
+				"value": "abc",
+			},
+		},
+		[]byte(`{"bar": "abc", "baz": "0"}`),
+		false,
+	},
+	{
+		"pass",
+		config.Config{
+			Settings: map[string]interface{}{
+				"object": map[string]interface{}{
+					"source_key": "foo",
+				},
+				"value": "",
+			},
+		},
+		[]byte(`{"bar": "abc", "baz": "0"}`),
+		false,
+	},
+	{
+		"pass",
+		config.Config{
+			Settings: map[string]interface{}{
+				"object": map[string]interface{}{
+					"source_key": "foo",
+					"target_key": "baz",
+				},
+			},
+		},
+		[]byte(`{"bar": "abc", "baz": "0"}`),
+		false,
+	},
+	{
+		"pass",
+		config.Config{
+			Settings: map[string]interface{}{
+				"object": map[string]interface{}{
+					"target_key": "foo",
+				},
+			},
+		},
+		[]byte(`{"bar": "abc", "baz": "0"}`),
+		false,
+	},
+	{
+		"pass",
+		config.Config{
+			Settings: map[string]interface{}{
+				"object": map[string]interface{}{
+					"source_key": "bar",
+					"target_key": "foo",
+				},
+			},
+		},
+		[]byte(`{"bar": "abc", "baz": "0"}`),
+		false,
+	},
 }
 
 func TestStringEqualTo(t *testing.T) {

--- a/condition/string_equal_to_test.go
+++ b/condition/string_equal_to_test.go
@@ -74,7 +74,7 @@ var stringEqualToTests = []struct {
 		false,
 	},
 	{
-		"pass",
+		"fail",
 		config.Config{
 			Settings: map[string]interface{}{
 				"object": map[string]interface{}{
@@ -87,7 +87,7 @@ var stringEqualToTests = []struct {
 		false,
 	},
 	{
-		"pass",
+		"fail",
 		config.Config{
 			Settings: map[string]interface{}{
 				"object": map[string]interface{}{
@@ -100,7 +100,7 @@ var stringEqualToTests = []struct {
 		false,
 	},
 	{
-		"pass",
+		"fail",
 		config.Config{
 			Settings: map[string]interface{}{
 				"object": map[string]interface{}{
@@ -113,7 +113,7 @@ var stringEqualToTests = []struct {
 		false,
 	},
 	{
-		"pass",
+		"fail",
 		config.Config{
 			Settings: map[string]interface{}{
 				"object": map[string]interface{}{
@@ -125,7 +125,7 @@ var stringEqualToTests = []struct {
 		false,
 	},
 	{
-		"pass",
+		"fail",
 		config.Config{
 			Settings: map[string]interface{}{
 				"object": map[string]interface{}{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds additional handling of missing source and/or target keys in condition package number equal to and string equal to.

<!--- Describe your changes in detail -->

## Motivation and Context
Fix for issue:Condition Package Zero Value Matches Can Be Inaccurate #263. 

Current behaviour of condition package does not contain source key or target key's  object path existence check. This caused unexpected behaviour:

- When only src key is present but the path doesn't exist, condition package inaccurately matches on zero value and empty string. 

- When both source key and target key are present but both paths do not exist, the number equal to and string equal to return true.

This adds checks thus

-  when source key or target key is present in condition package number equal to and string equal to, but either of path does not exist in the object, then condition equal to check return false. 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
