### PR TITLE
fix(cmd): CLI Config Relative Imports

### DIFF
--- a/cmd/substation/test.go
+++ b/cmd/substation/test.go
@@ -203,6 +203,8 @@ func testFile(arg string, extVars map[string]string) error {
 	fileName := filepath.Base(arg)
 	_ = os.Chdir(filepath.Dir(arg))
 
+	// The default case is a no-op -- the file is skipped because
+	// it cannot be tested.
 	switch filepath.Ext(fileName) {
 	case ".jsonnet", ".libsonnet":
 		// If the Jsonnet cannot compile, then the file is invalid.

--- a/cmd/substation/vet.go
+++ b/cmd/substation/vet.go
@@ -104,6 +104,8 @@ func vetFile(arg string, extVars map[string]string) error {
 	fileName := filepath.Base(arg)
 	_ = os.Chdir(filepath.Dir(arg))
 
+	// The default case is a no-op -- the file is skipped because
+	// it cannot be vetted.
 	switch filepath.Ext(fileName) {
 	case ".jsonnet", ".libsonnet":
 		mem, err := compileFile(fileName, extVars)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Closes #275 by supporting relative imports. 

<!--- Describe your changes in detail -->

## Motivation and Context

This fixes the relative import problem by switching the directory to each config (jsonnet, libsonnet) file's directory during every test or vet call.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Tested with an internal repo that has 10s to 100s of config files containing relative imports (`substation test -R`, `substation vet -R`).

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
