### PR TITLE
fix(message): use correct encodings for JSON Number values

### DIFF
--- a/transform/object_copy_test.go
+++ b/transform/object_copy_test.go
@@ -33,6 +33,36 @@ var objectCopyTests = []struct {
 		},
 	},
 	{
+		"large integer",
+		config.Config{
+			Settings: map[string]interface{}{
+				"object": map[string]interface{}{
+					"source_key": "a",
+					"target_key": "b",
+				},
+			},
+		},
+		[]byte(`{"a":30400402455622563}`),
+		[][]byte{
+			[]byte(`{"a":30400402455622563,"b":30400402455622563}`),
+		},
+	},
+	{
+		"large float",
+		config.Config{
+			Settings: map[string]interface{}{
+				"object": map[string]interface{}{
+					"source_key": "a",
+					"target_key": "b",
+				},
+			},
+		},
+		[]byte(`{"a":3.141592653589793}`),
+		[][]byte{
+			[]byte(`{"a":3.141592653589793,"b":3.141592653589793}`),
+		},
+	},
+	{
 		"unescape object",
 		config.Config{
 			Settings: map[string]interface{}{


### PR DESCRIPTION
## Description

This updates the private setValue helper to conditonally use the correct float or integer encoding per JSON Number type. Relying on the gjson Value method can result in imprecise copies which caused incremented numbers on large integers like the test case added.

## Motivation and Context

As shown in the added test cases bug caused consistent but imprecise copies where a writing a value such as `30400402455622563` would actually set the value of `30400402455622564`.

## How Has This Been Tested?

The new regression tests work, and this has fixed the observed imprecision in our internal deployment. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [x] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
