### PR TITLE
fix(playground): trim quotes from environment variables

### DIFF
--- a/cmd/substation/playground.go
+++ b/cmd/substation/playground.go
@@ -318,6 +318,8 @@ func handleRun(w http.ResponseWriter, r *http.Request) {
 
 	// Set up environment variables
 	for key, value := range request.Env {
+		// Remove surrounding quotes if present to mimic the behavior of export in bash
+		value = strings.Trim(value, "\"")
 		os.Setenv(key, value)
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This trims the quotes from environment variables set via substation playground to mimic the behaviour of export in bash. 

<!--- Describe your changes in detail -->

## Motivation and Context
Often times environment variables are copied from cloud providers eg AWS identity center. Copied token would have "" wrapped and those will be trimmed by export locally. 
The os.Setenv will treat the "" as literal,  this difference handling cause authentication failure. 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Build and tested locally. 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
