### PR TITLE
fix: only build release artifacts on releases

### DIFF
--- a/.github/workflows/release_please.yml
+++ b/.github/workflows/release_please.yml
@@ -34,7 +34,7 @@ jobs:
           go-version: 1.22
 
       - name: Upload Release Artifact
-        if: ${{ steps.release.outputs.releases_created }}
+        if: github.event_name == 'release' && github.event.prerelease == false
         uses: goreleaser/goreleaser-action@9ed2f89a662bf1735a48bc8557fd212fa902bebf # v6.1.0
         with:
           version: latest


### PR DESCRIPTION
## Description

Attempts to fix the CI build error on merges to main [here](https://github.com/brexhq/substation/actions/runs/12415935705/job/34663406148) by only running this step on releases.

## How Has This Been Tested?

This will be tested during the merge process, the condition is reported as successful [here](https://github.com/orgs/community/discussions/16244#discussioncomment-2717439). 

## Types of changes

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [ ] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
