### PR TITLE
test: pin test timezone to UTC

### DIFF
--- a/transform/time_to_string_test.go
+++ b/transform/time_to_string_test.go
@@ -64,6 +64,7 @@ var timeToStringTests = []struct {
 }
 
 func TestTimeToString(t *testing.T) {
+	t.Setenv("TZ", "UTC")
 	ctx := context.TODO()
 	for _, test := range timeToStringTests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
## Description

Improves test reliability by pinning the test timezone to UTC. GitHub test runners natively run in UTC timezone but this impacted local test runs for developer workstations. 

## How Has This Been Tested?

The test finally passes on my machine. This slightly drove me nuts over the past few months

## Types of changes

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
