### PR TITLE
feat(transform): add JSON object support in the obj_to_string transform

### DIFF
--- a/transform/object_to_string.go
+++ b/transform/object_to_string.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/brexhq/substation/v2/config"
 	"github.com/brexhq/substation/v2/message"
@@ -63,7 +64,15 @@ func (tf *objectToString) Transform(ctx context.Context, msg *message.Message) (
 		return []*message.Message{msg}, nil
 	}
 
-	if err := msg.SetValue(tf.conf.Object.TargetKey, value.String()); err != nil {
+	val := value.String()
+
+	// Pad JSON objects with quotes so they fail further isJSON checks
+	// this will be removing during SetValue handling.
+	if strings.HasPrefix(val, "{") && json.Valid([]byte(val)) {
+		val = fmt.Sprintf(`"%s"`, val)
+	}
+
+	if err := msg.SetValue(tf.conf.Object.TargetKey, val); err != nil {
 		return nil, fmt.Errorf("transform %s: %v", tf.conf.ID, err)
 	}
 

--- a/transform/object_to_string_test.go
+++ b/transform/object_to_string_test.go
@@ -62,6 +62,21 @@ var objectToStringTests = []struct {
 			[]byte(`{"a":"1"}`),
 		},
 	},
+	{
+		"obj to_str",
+		config.Config{
+			Settings: map[string]interface{}{
+				"object": map[string]interface{}{
+					"source_key": "a",
+					"target_key": "a",
+				},
+			},
+		},
+		[]byte(`{"a":{"b": "c", "d": true}}`),
+		[][]byte{
+			[]byte(`{"a":"{\"b\": \"c\", \"d\": true}"}`),
+		},
+	},
 }
 
 func TestObjectToString(t *testing.T) {


### PR DESCRIPTION
## Description

In #288 a user reported not being able to convert or copy JSON objects into strings either with the `sub.tf.obj.to.str`. This allows JSON objects to be converted to strings by slightly obfuscating the string-ified JSON object, and then fixing that as it's written. 

## Motivation and Context

More context is in #288. The larger question is if this behavior should be applied for transforms where a string JSON object is copied to a new key. Our current behavior would convert the copied string value into a JSON object value.

## How Has This Been Tested?

This adds a new unit test and was tested with the users string in the playground with the users test message.

## Types of changes

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [ ] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
