### PR TITLE
build: upgrade upload action to fix scorecard

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -59,7 +59,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@97a0fba1372883ab732affbe8f94b823f91727db # v3.pre.node20
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: sarif-results
           path: results.sarif


### PR DESCRIPTION
## Description

Follow up to https://github.com/brexhq/substation/pull/295. See https://github.com/ossf/scorecard-action/issues/1498 for details.

## Motivation and Context

The v3 action has been deprecated as of 2024-11 and stopped working for other projects. This is the recommended upgrade from the maintainers (https://github.com/actions/starter-workflows/pull/2786).


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

