### PR TITLE
fix(transform): specify checksum algorithm when sending to S3

### DIFF
--- a/transform/send_aws_s3.go
+++ b/transform/send_aws_s3.go
@@ -230,6 +230,8 @@ func (tf *sendAWSS3) send(ctx context.Context, key string) error {
 		Body:         f,
 		StorageClass: tf.sclass,
 		ContentType:  &mediaType,
+		// If the bucket has Object Lock enabled, we need to specify a checksum algorithm.
+		ChecksumAlgorithm: types.ChecksumAlgorithmCrc32,
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

Fix for #306.

## Motivation and Context

Sending data to an S3 bucket that has Object Lock enabled requires setting the checksum algorithm. See the linked issue for context. Uses CRC32 because Amazon recommends it for performance.

If there is a different fix to the issue, I'm happy to take that instead!

## How Has This Been Tested?

We run Substation with this change, and it works well for us.

## Types of changes

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
